### PR TITLE
[#32] Remove all uses of `MonadError Text` and `Either Text`

### DIFF
--- a/src/Cardano/Chain/Block/Body.hs
+++ b/src/Cardano/Chain/Block/Body.hs
@@ -19,7 +19,8 @@ import qualified Cardano.Chain.Delegation.Payload as Delegation (Payload,
                      checkPayload)
 import           Cardano.Chain.Ssc (SscPayload (..))
 import           Cardano.Chain.Txp.Tx (Tx)
-import           Cardano.Chain.Txp.TxPayload (TxPayload (..), checkTxPayload)
+import           Cardano.Chain.Txp.TxPayload (TxPayload (..), txpTxs,
+                     txpWitnesses)
 import           Cardano.Chain.Txp.TxWitness (TxWitness)
 import qualified Cardano.Chain.Update.Payload as Update
 import           Cardano.Crypto (ProtocolMagic)
@@ -51,12 +52,11 @@ instance Bi Body where
 
 verifyBody :: MonadError Text m => ProtocolMagic -> Body -> m ()
 verifyBody pm mb = do
-  checkTxPayload (bodyTxPayload mb)
   Delegation.checkPayload pm (bodyDlgPayload mb)
   Update.checkPayload pm (bodyUpdatePayload mb)
 
 bodyTxs :: Body -> [Tx]
-bodyTxs = _txpTxs . bodyTxPayload
+bodyTxs = txpTxs . bodyTxPayload
 
 bodyWitnesses :: Body -> [TxWitness]
-bodyWitnesses = _txpWitnesses . bodyTxPayload
+bodyWitnesses = txpWitnesses . bodyTxPayload

--- a/src/Cardano/Chain/Txp/TxAux.hs
+++ b/src/Cardano/Chain/Txp/TxAux.hs
@@ -6,18 +6,16 @@
 module Cardano.Chain.Txp.TxAux
        ( TxAux (..)
        , txaF
-       , checkTxAux
        ) where
 
 import           Cardano.Prelude
 
-import           Control.Monad.Except (MonadError)
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Formatting (Format, bprint, build, later, (%))
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
-import           Cardano.Chain.Txp.Tx (Tx, checkTx)
+import           Cardano.Chain.Txp.Tx (Tx)
 import           Cardano.Chain.Txp.TxWitness (TxWitness)
 
 
@@ -36,11 +34,6 @@ txaF = later $ \(TxAux tx w) ->
 
 instance B.Buildable TxAux where
   build = bprint txaF
-
--- | Check that a 'TxAux' is internally valid (checks that its 'Tx' is valid via
---   'checkTx'). Does not check the witness.
-checkTxAux :: MonadError Text m => TxAux -> m ()
-checkTxAux ta = checkTx (taTx ta)
 
 instance Bi TxAux where
   encode ta = encodeListLen 2 <> encode (taTx ta) <> encode (taWitness ta)

--- a/src/Cardano/Chain/Txp/TxPayload.hs
+++ b/src/Cardano/Chain/Txp/TxPayload.hs
@@ -1,54 +1,32 @@
-{-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Cardano.Chain.Txp.TxPayload
        ( TxPayload (..)
-       , mkTxPayload
-       , checkTxPayload
        , txpTxs
        , txpWitnesses
        ) where
 
 import           Cardano.Prelude
 
-import           Control.Lens (makeLenses)
-import           Control.Monad.Except (MonadError)
-
 import           Cardano.Binary.Class (Bi (..))
-import           Cardano.Chain.Txp.Tx (Tx, checkTx)
+import           Cardano.Chain.Txp.Tx (Tx)
 import           Cardano.Chain.Txp.TxAux (TxAux (..))
 import           Cardano.Chain.Txp.TxWitness (TxWitness)
 
 
--- | Payload of Txp component which is part of main block. Constructor is
---   unsafe, because it lets one create invalid payload, for example with
---   different number of transactions and witnesses.
-data TxPayload = UnsafeTxPayload
-  { _txpTxs       :: ![Tx]
-  -- ^ Transactions are the main payload
-  , _txpWitnesses :: ![TxWitness]
-  -- ^ Witnesses for each transaction
-  --
-  --   The payload is invalid if this list is not of the same length
-  --   as '_txpTxs'. See 'mkTxPayload'.
+-- | Payload of Txp component which is part of the block body
+newtype TxPayload = TxPayload
+  { unTxPayload :: [TxAux]
   } deriving (Show, Eq, Generic)
+    deriving newtype Bi
+    deriving anyclass NFData
 
-instance NFData TxPayload
+txpTxs :: TxPayload -> [Tx]
+txpTxs = fmap taTx . unTxPayload
 
-makeLenses ''TxPayload
-
--- | Smart constructor of 'TxPayload' which ensures that invariants of
---   'TxPayload' hold. Currently there is only one invariant: number of txs must
---   be same as number of witnesses.
-mkTxPayload :: [TxAux] -> TxPayload
-mkTxPayload txws = UnsafeTxPayload {_txpTxs = txs, _txpWitnesses = witnesses}
-  where (txs, witnesses) = unzip $ map (liftA2 (,) taTx taWitness) txws
-
-instance Bi TxPayload where
-  encode payload = encode $ zip (_txpTxs payload) (_txpWitnesses payload)
-  decode = mkTxPayload <$> decode
-
--- | Check a TxPayload by checking all of the Txs it contains
-checkTxPayload :: MonadError Text m => TxPayload -> m ()
-checkTxPayload payload = forM_ (_txpTxs payload) checkTx
+txpWitnesses :: TxPayload -> [TxWitness]
+txpWitnesses = fmap taWitness . unTxPayload

--- a/src/Cardano/Chain/Txp/TxProof.hs
+++ b/src/Cardano/Chain/Txp/TxProof.hs
@@ -14,7 +14,7 @@ import qualified Formatting.Buildable as B
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
 import           Cardano.Chain.Common.Merkle (MerkleRoot, mkMerkleTree, mtRoot)
 import           Cardano.Chain.Txp.Tx (Tx)
-import           Cardano.Chain.Txp.TxPayload (TxPayload (..))
+import           Cardano.Chain.Txp.TxPayload (TxPayload, txpTxs, txpWitnesses)
 import           Cardano.Chain.Txp.TxWitness (TxWitness)
 import           Cardano.Crypto (Hash, hash)
 
@@ -51,7 +51,7 @@ instance NFData TxProof
 --   care. Bi constraints arise because we need to hash these things.
 mkTxProof :: TxPayload -> TxProof
 mkTxProof payload = TxProof
-  { txpNumber        = fromIntegral (length $ _txpTxs payload)
-  , txpRoot          = mtRoot (mkMerkleTree $ _txpTxs payload)
-  , txpWitnessesHash = hash $ _txpWitnesses payload
+  { txpNumber        = fromIntegral (length $ txpTxs payload)
+  , txpRoot          = mtRoot (mkMerkleTree $ txpTxs payload)
+  , txpWitnessesHash = hash $ txpWitnesses payload
   }

--- a/src/Cardano/Chain/Update/BlockVersionModifier.hs
+++ b/src/Cardano/Chain/Update/BlockVersionModifier.hs
@@ -7,13 +7,11 @@
 
 module Cardano.Chain.Update.BlockVersionModifier
        ( BlockVersionModifier (..)
-       , checkBlockVersionModifier
        , applyBVM
        ) where
 
 import           Cardano.Prelude
 
-import           Control.Monad.Except (MonadError)
 import           Data.Text.Lazy.Builder (Builder)
 import           Data.Time (NominalDiffTime)
 import           Formatting (Format, bprint, build, bytes, int, later, shortest,
@@ -21,12 +19,10 @@ import           Formatting (Format, bprint, build, bytes, int, later, shortest,
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
-import           Cardano.Chain.Common (CoinPortion, ScriptVersion, TxFeePolicy,
-                     checkCoinPortion)
+import           Cardano.Chain.Common (CoinPortion, ScriptVersion, TxFeePolicy)
 import           Cardano.Chain.Slotting (EpochIndex, FlatSlotId)
 import           Cardano.Chain.Update.BlockVersionData (BlockVersionData (..))
-import           Cardano.Chain.Update.SoftforkRule (SoftforkRule,
-                     checkSoftforkRule)
+import           Cardano.Chain.Update.SoftforkRule (SoftforkRule)
 
 
 -- | Data which represents modifications of block (aka protocol) version
@@ -121,14 +117,6 @@ instance Bi BlockVersionModifier where
       <*> decode
       <*> decode
       <*> decode
-
-checkBlockVersionModifier :: MonadError Text m => BlockVersionModifier -> m ()
-checkBlockVersionModifier bvm = do
-  whenJust (bvmMpcThd bvm)            checkCoinPortion
-  whenJust (bvmHeavyDelThd bvm)       checkCoinPortion
-  whenJust (bvmUpdateVoteThd bvm)     checkCoinPortion
-  whenJust (bvmUpdateProposalThd bvm) checkCoinPortion
-  whenJust (bvmSoftforkRule bvm)      checkSoftforkRule
 
 -- | Apply 'BlockVersionModifier' to 'BlockVersionData'
 applyBVM :: BlockVersionModifier -> BlockVersionData -> BlockVersionData

--- a/src/Cardano/Chain/Update/SoftforkRule.hs
+++ b/src/Cardano/Chain/Update/SoftforkRule.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Chain.Update.SoftforkRule
        ( SoftforkRule (..)
-       , checkSoftforkRule
        ) where
 
 import           Cardano.Prelude
@@ -24,7 +23,7 @@ import           Text.JSON.Canonical (FromJSON (..), ToJSON (..), fromJSField,
                      mkObject)
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
-import           Cardano.Chain.Common (CoinPortion, checkCoinPortion)
+import           Cardano.Chain.Common (CoinPortion)
 
 
 -- | Values defining softfork resolution rule
@@ -75,11 +74,5 @@ instance MonadError SchemaError m => FromJSON m SoftforkRule where
       <$> fromJSField obj "initThd"
       <*> fromJSField obj "minThd"
       <*> fromJSField obj "thdDecrement"
-
-checkSoftforkRule :: (MonadError Text m) => SoftforkRule -> m ()
-checkSoftforkRule sr = do
-  checkCoinPortion (srInitThd sr)
-  checkCoinPortion (srMinThd sr)
-  checkCoinPortion (srThdDecrement sr)
 
 deriveJSON S.defaultOptions ''SoftforkRule

--- a/src/Cardano/Chain/Update/SystemTag.hs
+++ b/src/Cardano/Chain/Update/SystemTag.hs
@@ -2,11 +2,13 @@
 {-# LANGUAGE DeriveLift                 #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TemplateHaskell            #-}
 
 module Cardano.Chain.Update.SystemTag
        ( SystemTag (..)
+       , SystemTagError (..)
        , checkSystemTag
        , systemTagMaxLength
 
@@ -24,7 +26,8 @@ import           Data.Char (isAscii)
 import qualified Data.Text as T
 import           Distribution.System (Arch (..), OS (..))
 import           Distribution.Text (display)
-import           Formatting.Buildable (Buildable)
+import           Formatting (bprint, int, stext, (%))
+import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..))
 
@@ -32,7 +35,7 @@ import           Cardano.Binary.Class (Bi (..))
 -- | Tag of system for which update data is purposed, e.g. win64, mac32
 newtype SystemTag = SystemTag
   { getSystemTag :: Text
-  } deriving (Eq, Ord, Show, Generic, Buildable, Typeable)
+  } deriving (Eq, Ord, Show, Generic, B.Buildable)
 
 instance NFData SystemTag
 
@@ -48,12 +51,24 @@ instance Bi SystemTag where
 systemTagMaxLength :: Integral i => i
 systemTagMaxLength = 10
 
-checkSystemTag :: MonadError Text m => SystemTag -> m ()
+data SystemTagError
+  = SystemTagNotAscii Text
+  | SystemTagTooLong Text
+
+instance B.Buildable SystemTagError where
+  build = \case
+    SystemTagNotAscii tag ->
+      bprint ("SystemTag, " % stext % ", contains non-ascii characters") tag
+    SystemTagTooLong tag -> bprint
+      ("SystemTag, " % stext % ", exceeds limit of " % int)
+      tag
+      (systemTagMaxLength :: Int)
+
+checkSystemTag :: MonadError SystemTagError m => SystemTag -> m ()
 checkSystemTag (SystemTag tag)
-  | T.length tag > systemTagMaxLength = throwError
-    "SystemTag: too long string passed"
-  | T.any (not . isAscii) tag = throwError "SystemTag: not ascii string passed"
-  | otherwise = pure ()
+  | T.length tag > systemTagMaxLength = throwError $ SystemTagTooLong tag
+  | T.any (not . isAscii) tag         = throwError $ SystemTagNotAscii tag
+  | otherwise                         = pure ()
 
 -- | Helper to turn an @OS@ into a @String@ compatible with the @systemTag@
 --   previously used in 'configuration.yaml'

--- a/src/Cardano/Chain/Update/Undo.hs
+++ b/src/Cardano/Chain/Update/Undo.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TypeApplications   #-}
 
 module Cardano.Chain.Update.Undo
        ( -- * Proposal state
@@ -59,7 +61,7 @@ import           Cardano.Binary.Class (Bi (..), DecoderError (..),
                      decodeListLenCanonical, encodeListLen, enforceSize)
 import           Cardano.Chain.Block.Header (HeaderHash)
 import           Cardano.Chain.Common (ChainDifficulty, Coin, ScriptVersion,
-                     StakeholderId, mkCoin)
+                     StakeholderId, mkKnownCoin)
 import           Cardano.Chain.Slotting (EpochIndex, SlotId, SlottingData)
 import           Cardano.Chain.Update.ApplicationName (ApplicationName)
 import           Cardano.Chain.Update.BlockVersion (BlockVersion)
@@ -327,8 +329,8 @@ mkUProposalState slot proposal = UndecidedProposalState
   { upsVotes         = mempty
   , upsProposal      = proposal
   , upsSlot          = slot
-  , upsPositiveStake = mkCoin 0
-  , upsNegativeStake = mkCoin 0
+  , upsPositiveStake = mkKnownCoin @0
+  , upsNegativeStake = mkKnownCoin @0
   , upsExtra         = Nothing
   }
 

--- a/src/Cardano/Chain/Update/Vote.hs
+++ b/src/Cardano/Chain/Update/Vote.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.Chain.Update.Vote
        (
        -- Software update proposal
          Proposal (..)
+       , ProposalError (..)
        , Proposals
        , UpId
        , ProposalBody (..)
@@ -17,6 +19,7 @@ module Cardano.Chain.Update.Vote
        -- Software update vote
        , VoteId
        , Vote (..)
+       , VoteError (..)
        , mkVote
        , mkVoteSafe
        , formatVoteShort
@@ -42,8 +45,9 @@ import           Cardano.Chain.Update.BlockVersionModifier
                      (BlockVersionModifier)
 import           Cardano.Chain.Update.Data (UpdateData)
 import           Cardano.Chain.Update.SoftwareVersion (SoftwareVersion,
-                     checkSoftwareVersion)
-import           Cardano.Chain.Update.SystemTag (SystemTag, checkSystemTag)
+                     SoftwareVersionError, checkSoftwareVersion)
+import           Cardano.Chain.Update.SystemTag (SystemTag, SystemTagError,
+                     checkSystemTag)
 import           Cardano.Crypto (Hash, ProtocolMagic, PublicKey, SafeSigner,
                      SecretKey, SignTag (SignUSProposal, SignUSVote),
                      Signature, checkSig, hash, safeSign, safeToPublic,
@@ -155,11 +159,30 @@ signProposal pm body ss = Proposal
   issuer    = safeToPublic ss
   signature = safeSign pm SignUSProposal ss body
 
-checkProposal :: MonadError Text m => ProtocolMagic -> Proposal -> m ()
+data ProposalError
+  = ProposalInvalidSignature (Signature ProposalBody)
+  | ProposalSoftwareVersionError SoftwareVersionError
+  | ProposalSystemTagError SystemTagError
+
+instance B.Buildable ProposalError where
+  build = \case
+    ProposalInvalidSignature sig ->
+      bprint ("Invalid signature, " % build % ", in Proposal") sig
+    ProposalSoftwareVersionError err -> bprint
+      ("SoftwareVersion was invalid while checking Proposal.\n Error: " % build)
+      err
+    ProposalSystemTagError err -> bprint
+      ("SystemTag was invalid while checking Proposal.\n Error: " % build)
+      err
+
+checkProposal :: MonadError ProposalError m => ProtocolMagic -> Proposal -> m ()
 checkProposal pm proposal = do
   let body = proposalBody proposal
-  checkSoftwareVersion (pbSoftwareVersion body)
-  forM_ (Map.keys (pbData body)) checkSystemTag
+  either (throwError . ProposalSoftwareVersionError) pure
+    $ checkSoftwareVersion (pbSoftwareVersion body)
+  forM_
+    (Map.keys (pbData body))
+    (either (throwError . ProposalSystemTagError) pure . checkSystemTag)
   let
     sigIsValid = checkSig
       pm
@@ -167,7 +190,8 @@ checkProposal pm proposal = do
       (proposalIssuer proposal)
       body
       (proposalSignature proposal)
-  unless sigIsValid $ throwError "Proposal: invalid signature"
+  unless sigIsValid $ throwError $ ProposalInvalidSignature
+    (proposalSignature proposal)
 
 
 --------------------------------------------------------------------------------
@@ -284,15 +308,25 @@ formatVoteShort uv = bprint
 shortVoteF :: Format r (Vote -> r)
 shortVoteF = later formatVoteShort
 
-checkVote :: (MonadError Text m) => ProtocolMagic -> Vote -> m ()
-checkVote pm it = unless sigValid (throwError "Vote: invalid signature")
+data VoteError =
+  VoteInvalidSignature (Signature (UpId, Bool))
+
+instance B.Buildable VoteError where
+  build = \case
+    VoteInvalidSignature sig ->
+      bprint ("Invalid signature, " % build % ", in Vote") sig
+
+checkVote :: MonadError VoteError m => ProtocolMagic -> Vote -> m ()
+checkVote pm uv = unless
+  sigValid
+  (throwError $ VoteInvalidSignature (uvSignature uv))
  where
   sigValid = checkSig
     pm
     SignUSVote
-    (uvKey it)
-    (uvProposalId it, uvDecision it)
-    (uvSignature it)
+    (uvKey uv)
+    (uvProposalId uv, uvDecision uv)
+    (uvSignature uv)
 
 mkVoteId :: Vote -> VoteId
 mkVoteId vote = (uvProposalId vote, uvKey vote, uvDecision vote)

--- a/src/Cardano/Chain/Update/Vote.hs
+++ b/src/Cardano/Chain/Update/Vote.hs
@@ -39,7 +39,7 @@ import           Cardano.Chain.Common.Attributes (Attributes,
                      areAttributesKnown)
 import           Cardano.Chain.Update.BlockVersion (BlockVersion)
 import           Cardano.Chain.Update.BlockVersionModifier
-                     (BlockVersionModifier, checkBlockVersionModifier)
+                     (BlockVersionModifier)
 import           Cardano.Chain.Update.Data (UpdateData)
 import           Cardano.Chain.Update.SoftwareVersion (SoftwareVersion,
                      checkSoftwareVersion)
@@ -158,7 +158,6 @@ signProposal pm body ss = Proposal
 checkProposal :: MonadError Text m => ProtocolMagic -> Proposal -> m ()
 checkProposal pm proposal = do
   let body = proposalBody proposal
-  checkBlockVersionModifier (pbBlockVersionModifier body)
   checkSoftwareVersion (pbSoftwareVersion body)
   forM_ (Map.keys (pbData body)) checkSystemTag
   let

--- a/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/test/Test/Cardano/Chain/Common/Gen.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module Test.Cardano.Chain.Common.Gen
        ( genAddrAttributes
        , genAddress
@@ -23,6 +26,7 @@ import           Test.Cardano.Prelude
 
 import           Data.Fixed (Fixed (..))
 import qualified Data.Map.Strict as Map
+import           Formatting (build, sformat, (%))
 
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -32,11 +36,10 @@ import           Cardano.Binary.Class (Bi)
 import           Cardano.Chain.Common (AddrAttributes (..),
                      AddrSpendingData (..), AddrStakeDistribution (..),
                      AddrType (..), Address (..), BlockCount (..),
-                     ChainDifficulty (..), Coeff (..), Coin (..),
-                     CoinPortion (..), MerkleRoot (..), MerkleTree,
-                     Script (..), ScriptVersion, StakeholderId,
-                     TxFeePolicy (..), TxSizeLinear (..),
-                     coinPortionDenominator, makeAddress, maxCoinVal,
+                     ChainDifficulty (..), Coeff (..), Coin, CoinPortion (..),
+                     MerkleRoot (..), MerkleTree, Script (..), ScriptVersion,
+                     StakeholderId, TxFeePolicy (..), TxSizeLinear (..),
+                     coinPortionDenominator, makeAddress, maxCoinVal, mkCoin,
                      mkMerkleTree, mkStakeholderId, mtRoot)
 
 import           Test.Cardano.Crypto.Gen (genHDAddressPayload, genPublicKey,
@@ -130,7 +133,10 @@ genCoeff = do
     pure $ Coeff (MkFixed integer)
 
 genCoin :: Gen Coin
-genCoin = Coin <$> Gen.word64 (Range.constant 0 maxCoinVal)
+genCoin = mkCoin <$> Gen.word64 (Range.constant 0 maxCoinVal) >>= \case
+  Right coin -> pure coin
+  Left err ->
+    error $ sformat ("The impossible happened in genCoin: " % build) err
 
 genCoinPortion :: Gen CoinPortion
 genCoinPortion =

--- a/test/Test/Cardano/Chain/Txp/Gen.hs
+++ b/test/Test/Cardano/Chain/Txp/Gen.hs
@@ -39,8 +39,8 @@ import qualified Hedgehog.Range as Range
 import           Cardano.Chain.Common (mkAttributes)
 import           Cardano.Chain.Txp (Tx (..), TxAttributes, TxAux (..), TxId,
                      TxIn (..), TxInWitness (..), TxOut (..), TxOutAux (..),
-                     TxPayload, TxProof (..), TxSig, TxSigData (..), TxUndo,
-                     TxWitness, TxpUndo, mkTxPayload)
+                     TxPayload (..), TxProof (..), TxSig, TxSigData (..),
+                     TxUndo, TxWitness, TxpUndo)
 import           Cardano.Crypto (Hash, ProtocolMagic, decodeHash, sign)
 
 import           Test.Cardano.Chain.Common.Gen (genAddress, genCoin,
@@ -105,7 +105,7 @@ genTxpUndo :: Gen TxpUndo
 genTxpUndo = Gen.list (Range.linear 1 50) genTxUndo
 
 genTxPayload :: ProtocolMagic -> Gen TxPayload
-genTxPayload pm = mkTxPayload <$> Gen.list (Range.linear 0 10) (genTxAux pm)
+genTxPayload pm = TxPayload <$> Gen.list (Range.linear 0 10) (genTxAux pm)
 
 genTxProof :: ProtocolMagic -> Gen TxProof
 genTxProof pm =


### PR DESCRIPTION
This replaces uses of `MonadError Text` with error ADTs. This PR is an example of how those errors can compose to give more informative error output.