### PR TITLE
[#17] Replace Universum with protolude

### DIFF
--- a/binary/src/Cardano/Binary/Class/Primitive.hs
+++ b/binary/src/Cardano/Binary/Class/Primitive.hs
@@ -63,7 +63,7 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Internal as BSL
 import           Data.Digest.CRC32 (CRC32 (..))
 import           Data.Typeable (typeOf)
-import           Formatting (Format, sformat, shown, (%))
+import           Formatting (Format, sformat, shown)
 
 import           Cardano.Binary.Class.Core (Bi (..), DecoderError (..), Size,
                      apMono, enforceSize, withWordSize)
@@ -256,7 +256,7 @@ encodedCrcProtectedSizeExpr
   :: forall a . Bi a => (forall t . Bi t => Proxy t -> Size) -> Proxy a -> Size
 encodedCrcProtectedSizeExpr size pxy =
   2 + unknownCborDataItemSizeExpr (size pxy) + size
-    (pure $ crc32 (serialize (error "unused" :: a)))
+    (pure $ crc32 (serialize (panic "unused" :: a)))
 
 -- | Decodes a CBOR blob into a type `a`, checking the serialised CRC corresponds to the computed one.
 decodeCrcProtected :: forall s a . Bi a => D.Decoder s a
@@ -271,9 +271,9 @@ decodeCrcProtected = do
     crcErrorFmt :: Format r (Word32 -> Word32 -> r)
     crcErrorFmt =
       "decodeCrcProtected, expected CRC "
-        % shown
-        % " was not the computed one, which was "
-        % shown
+        . shown
+        . " was not the computed one, which was "
+        . shown
   when (actualCrc /= expectedCrc)
     $ cborError (sformat crcErrorFmt expectedCrc actualCrc)
   toCborError $ decodeFull' body

--- a/binary/test/Test/Cardano/Binary/BiSizeBounds.hs
+++ b/binary/test/Test/Cardano/Binary/BiSizeBounds.hs
@@ -5,19 +5,23 @@ module Test.Cardano.Binary.BiSizeBounds
     ( tests
     ) where
 
-import           Cardano.Binary.Class
 import           Cardano.Prelude
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map as M
+import           Data.String (String)
 import           Data.Tagged (Tagged (..))
+import qualified Data.Text as T
+
 import           Data.Typeable (typeRep)
 import           Hedgehog (Gen, Group (..), checkParallel, withTests)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import           Test.Cardano.Binary.Helpers
 
+import           Cardano.Binary.Class
+
+import           Test.Cardano.Binary.Helpers
 
 tests :: IO Bool
 tests
@@ -158,7 +162,7 @@ tests
           { gen         = Gen.text (Range.linear 0 1000) Gen.latin1
           , computedCtx = \bs -> M.fromList
             [ ( typeRep (Proxy @(LengthOf String))
-              , SizeConstant $ fromIntegral $ length bs
+              , SizeConstant $ fromIntegral $ T.length bs
               )
             ]
           }
@@ -168,7 +172,7 @@ tests
           { gen         = Gen.text (Range.linear 0 1000) Gen.unicode
           , computedCtx = \bs -> M.fromList
             [ ( typeRep (Proxy @(LengthOf String))
-              , SizeConstant $ fromIntegral $ length bs
+              , SizeConstant $ fromIntegral $ T.length bs
               )
             ]
           }

--- a/binary/test/Test/Cardano/Binary/Cbor/CborSpec.hs
+++ b/binary/test/Test/Cardano/Binary/Cbor/CborSpec.hs
@@ -22,11 +22,14 @@ import           Cardano.Prelude
 import           Data.Bits (shiftL)
 import qualified Data.ByteString as BS
 import           Data.Fixed (Nano)
+import           Data.String (String)
+
 import           Test.Hspec (Spec, describe)
 import           Test.Hspec.QuickCheck (modifyMaxSize, modifyMaxSuccess, prop)
 import           Test.QuickCheck (Arbitrary (..), choose, sized, (===))
 
 import           Cardano.Binary.Class
+
 import           Test.Cardano.Binary.Helpers (U, binaryTest, extensionProperty)
 import qualified Test.Cardano.Cbor.RefImpl as R
 

--- a/binary/test/Test/Cardano/Binary/Helpers.hs
+++ b/binary/test/Test/Cardano/Binary/Helpers.hs
@@ -43,10 +43,11 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Map (Map)
 import qualified Data.Map as M
+import           Data.String (String)
 import           Data.Text.Lazy (unpack)
 import           Data.Text.Lazy.Builder (toLazyText)
 import           Data.Typeable (TypeRep, typeRep)
-import           Formatting (Buildable, bprint, build, formatToString, int, (%))
+import           Formatting (Buildable, bprint, build, formatToString, int)
 import           Hedgehog (annotate, failure, forAllWith, success)
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as HH.Gen
@@ -226,7 +227,7 @@ msgLenLimitedCheck :: Bi a => Limit a -> a -> Property
 msgLenLimitedCheck limit msg = if sz <= fromIntegral limit
   then property True
   else flip counterexample False $ formatToString
-    ("Message size (max found " % int % ") exceeds limit (" % int % ")")
+    ("Message size (max found " . int . ") exceeds limit (" . int . ")")
     sz
     limit
   where sz = BS.length . serialize' $ msg
@@ -291,7 +292,7 @@ bshow = unpack . toLazyText . bprint build
 
 -- | Configuration for a single test case.
 data SizeTestConfig a = SizeTestConfig
-    { debug       :: a -> String      -- ^ Pretty-print values
+    { debug       :: a -> String     -- ^ Pretty-print values
     , gen         :: HH.Gen a        -- ^ Generator
     , precise     :: Bool            -- ^ Must estimates be exact?
     , addlCtx     :: Map TypeRep SizeOverride -- ^ Additional size overrides

--- a/binary/test/Test/Cardano/Cbor/Canonicity.hs
+++ b/binary/test/Test/Cardano/Cbor/Canonicity.hs
@@ -63,7 +63,7 @@ traverseCanonicalBits tuint tnint tzeroes tlength ttag tmapset tnan16 = go
           <*> (tlength . toUInt . fromIntegral $ length bs)
           <*> pure n
       k ->
-        error
+        panic
           $  "Unexpected TBigInt with "
           <> show k
           <> " leading zeroes: "
@@ -84,20 +84,20 @@ traverseCanonicalBits tuint tnint tzeroes tlength ttag tmapset tnan16 = go
     TFloat16 f
       | not $ isNaN f -> pure $ TFloat16 f
       | getHalf f == getHalf canonicalNaN -> TFloat16 <$> tnan16 f
-      | otherwise -> error "Unexpected 16bit representation of NaN"
+      | otherwise -> panic "Unexpected 16bit representation of NaN"
     -- Tag representation can be widened.
     TTagged tag t -> if tag == UInt8 24 -- cbor-in-cbor
       then TTagged <$> ttag tag <*> pure t
-      else error "Unexpected TTagged"
+      else panic "Unexpected TTagged"
 
     -- Terms that are unexpected.
     TFloat32 f -> if not $ isNaN f
       then pure $ TFloat32 f
-      else error "Unexpected 32bit representation of NaN"
+      else panic "Unexpected 32bit representation of NaN"
     TFloat64 f -> if not $ isNaN f
       then pure $ TFloat64 f
-      else error "Unexpected 64bit representation of NaN"
-    TMapI _          -> error "Unexpected TMapI"
+      else panic "Unexpected 64bit representation of NaN"
+    TMapI _          -> panic "Unexpected TMapI"
 
     -- Representation of length can be widened.
     TArray len terms -> TArray <$> tlength len <*> mapM go terms
@@ -236,7 +236,7 @@ perturbCanonicity term = sized $ \sz -> do
           -- We use traverseCanonicalBits for both counting canonical bits and
           -- changing them, hence the list will have just the right amount of
           -- elements.
-        error "shouldBeChanged: impossible - not enough elements"
+        panic "shouldBeChanged: impossible - not enough elements"
     S.put xs
     return x
 

--- a/cardano-chain.cabal
+++ b/cardano-chain.cabal
@@ -118,6 +118,7 @@ library
                      , streaming-bytestring
                      , text
                      , time
+                     , vector
 
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude

--- a/crypto/src/Cardano/Crypto/HD.hs
+++ b/crypto/src/Cardano/Crypto/HD.hs
@@ -103,9 +103,9 @@ isHardened = (>= firstHardened)
 deriveHDPublicKey :: PublicKey -> Word32 -> PublicKey
 deriveHDPublicKey (PublicKey xpub) childIndex
   | isHardened childIndex
-  = error "Wrong index for non-hardened derivation"
+  = panic "Wrong index for non-hardened derivation"
   | otherwise
-  = maybe (error "deriveHDPublicKey: deriveXPub failed") PublicKey
+  = maybe (panic "deriveHDPublicKey: deriveXPub failed") PublicKey
     $ deriveXPub DerivationScheme1 xpub childIndex
 
 -- | Whether to call 'checkPassMatches'
@@ -134,7 +134,7 @@ packHDAddressAttr (HDPassphrase passphrase) path = do
   let !pathSer = serialize' path
   let !packCF = encryptChaChaPoly addrAttrNonce passphrase "" pathSer
   case packCF of
-    CryptoFailed er -> error $ "Error in packHDAddressAttr: " <> show er
+    CryptoFailed er -> panic $ "Error in packHDAddressAttr: " <> show er
     CryptoPassed p  -> HDAddressPayload p
 
 -- | Try to decrypt 'HDAddressPayload' using 'HDPassphrase'

--- a/crypto/src/Cardano/Crypto/Limits.hs
+++ b/crypto/src/Cardano/Crypto/Limits.hs
@@ -20,7 +20,7 @@ import           Cardano.Crypto (AbstractHash, PublicKey, Signature (..))
 mlAbstractHash
   :: forall algo a . HashAlgorithm algo => Limit (AbstractHash algo a)
 mlAbstractHash =
-  fromIntegral (hashDigestSize (error "AbstractHash limit" :: algo) + 4)
+  fromIntegral (hashDigestSize (panic "AbstractHash limit" :: algo) + 4)
 
 mlPublicKey :: Limit PublicKey
 mlPublicKey = 66

--- a/crypto/src/Cardano/Crypto/Random.hs
+++ b/crypto/src/Cardano/Crypto/Random.hs
@@ -15,6 +15,7 @@ module Cardano.Crypto.Random
        ) where
 
 import           Cardano.Prelude
+
 import           Crypto.Number.Basic (numBytes)
 import           Crypto.Number.Serialize (os2ip)
 import           Crypto.OpenSSL.Random (randBytes)
@@ -53,7 +54,7 @@ deterministic seed gen = fst $ withDRG chachaSeed gen
 --   be divisible by n, and thus applying 'mod' to it will be safe.
 randomNumber :: forall m . MonadRandom m => Integer -> m Integer
 randomNumber n
-  | n <= 0    = error "randomNumber: n <= 0"
+  | n <= 0    = panic "randomNumber: n <= 0"
   | otherwise = gen
  where
   size     = max 4 (numBytes n)             -- size of integers, in bytes
@@ -67,5 +68,5 @@ randomNumber n
 -- | Generate a random number in range [a, b]
 randomNumberInRange :: MonadRandom m => Integer -> Integer -> m Integer
 randomNumberInRange a b
-  | a > b     = error "randomNumberInRange: a > b"
+  | a > b     = panic "randomNumberInRange: a > b"
   | otherwise = (a +) <$> randomNumber (b - a + 1)

--- a/crypto/src/Cardano/Crypto/Signing/Redeem.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Redeem.hs
@@ -8,17 +8,19 @@ module Cardano.Crypto.Signing.Redeem
 
 import           Cardano.Prelude
 
-import           Cardano.Binary.Class (Bi, Raw)
-import qualified Cardano.Binary.Class as Bi
-import           Cardano.Crypto.ProtocolMagic (ProtocolMagic)
-import           Cardano.Crypto.Signing.Tag (SignTag, signTag)
-import           Cardano.Crypto.Signing.Types.Redeem
+import           Control.Monad (fail)
 import           Crypto.Error (maybeCryptoError)
 import qualified Crypto.PubKey.Ed25519 as Ed25519
 import           Crypto.Random (MonadRandom)
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import           Data.Coerce (coerce)
+
+import           Cardano.Binary.Class (Bi, Raw)
+import qualified Cardano.Binary.Class as Bi
+import           Cardano.Crypto.ProtocolMagic (ProtocolMagic)
+import           Cardano.Crypto.Signing.Tag (SignTag, signTag)
+import           Cardano.Crypto.Signing.Types.Redeem
 
 
 --------------------------------------------------------------------------------

--- a/crypto/src/Cardano/Crypto/Signing/Signing.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Signing.hs
@@ -35,7 +35,7 @@ import           Crypto.Random (MonadRandom, getRandomBytes)
 import           Data.ByteArray (ScrubbedBytes)
 import qualified Data.ByteString as BS
 import           Data.Coerce (coerce)
-import           Formatting (build, sformat, (%))
+import           Formatting (build, sformat)
 
 import           Cardano.Binary.Class (Bi, Raw)
 import qualified Cardano.Binary.Class as Bi
@@ -128,13 +128,13 @@ proxySign
   -> a
   -> ProxySignature w a
 proxySign pm t sk@(SecretKey delegateSk) psk m
-  | toPublic sk /= pskDelegatePk psk = error $ sformat
+  | toPublic sk /= pskDelegatePk psk = panic $ sformat
     ( "proxySign called with irrelevant certificate "
-    % "(psk delegatePk: "
-    % build
-    % ", real delegate pk: "
-    % build
-    % ")"
+    . "(psk delegatePk: "
+    . build
+    . ", real delegate pk: "
+    . build
+    . ")"
     )
     (pskDelegatePk psk)
     (toPublic sk)

--- a/crypto/src/Cardano/Crypto/Signing/Types/Safe.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Types/Safe.hs
@@ -29,7 +29,7 @@ import qualified Data.ByteArray as ByteArray
 import qualified Data.ByteString as BS
 import           Data.Default (Default (..))
 import           Data.Semigroup (Semigroup)
-import           Formatting (int, sformat, (%))
+import           Formatting (int, sformat)
 import           Formatting.Buildable (Buildable (..))
 import qualified Prelude
 
@@ -99,7 +99,7 @@ instance Bi PassPhrase where
     toCborError $ if bl == 0 || bl == passphraseLength
       then Right $ ByteArray.convert bs
       else Left $ sformat
-        ("put@PassPhrase: expected length 0 or " % int % ", not " % int)
+        ("put@PassPhrase: expected length 0 or " . int . ", not " . int)
         passphraseLength
         bl
 
@@ -115,7 +115,7 @@ data SafeSigner
 
 -- | Parameters used to evaluate hash of passphrase.
 passScryptParam :: S.ScryptParams
-passScryptParam = fromMaybe (error "Bad passphrase scrypt parameters")
+passScryptParam = fromMaybe (panic "Bad passphrase scrypt parameters")
   $ S.mkScryptParams def { S.spHashLen = 32 }  -- maximal passphrase length
 
 -- | Wrap raw secret key, attaching hash to it

--- a/crypto/test/Test/Cardano/Crypto/Arbitrary.hs
+++ b/crypto/test/Test/Cardano/Crypto/Arbitrary.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -14,7 +15,7 @@ module Test.Cardano.Crypto.Arbitrary
        , genRedeemSignature
        ) where
 
-import           Cardano.Prelude hiding (keys)
+import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import qualified Data.ByteArray as ByteArray
@@ -166,7 +167,7 @@ instance Arbitrary PassPhrase where
 --------------------------------------------------------------------------------
 
 instance Arbitrary HDPassphrase where
-    arbitrary = HDPassphrase . fromString <$> vector 32
+    arbitrary = HDPassphrase . toS @[Char] <$> vector 32
 
 instance Arbitrary HDAddressPayload where
     arbitrary = genericArbitrary

--- a/crypto/test/Test/Cardano/Crypto/Bi.hs
+++ b/crypto/test/Test/Cardano/Crypto/Bi.hs
@@ -377,34 +377,34 @@ constantByteString
 sizeEstimates :: H.Group
 sizeEstimates
   = let
-      check :: forall a . (Show a, Bi a) => Gen a -> Property
-      check g = sizeTest $ scfg { gen = g, precise = True }
+      testPrecise :: forall a . (Show a, Bi a) => Gen a -> Property
+      testPrecise g = sizeTest $ scfg { gen = g, precise = True }
     in H.Group
       "Encoded size bounds for crypto types."
-      [ ("PublicKey", check genPublicKey)
+      [ ("PublicKey", testPrecise genPublicKey)
       , ( "AbstractHash Blake2b_224 PublicKey"
-        , check @(AbstractHash Blake2b_224 PublicKey)
+        , testPrecise @(AbstractHash Blake2b_224 PublicKey)
           $ genAbstractHash genPublicKey
         )
       , ( "AbstractHash Blake2b_256 PublicKey"
-        , check @(AbstractHash Blake2b_256 PublicKey)
+        , testPrecise @(AbstractHash Blake2b_256 PublicKey)
           $ genAbstractHash genPublicKey
         )
       , ( "AbstractHash Blake2b_384 PublicKey"
-        , check @(AbstractHash Blake2b_384 PublicKey)
+        , testPrecise @(AbstractHash Blake2b_384 PublicKey)
           $ genAbstractHash genPublicKey
         )
       , ( "AbstractHash Blake2b_512 PublicKey"
-        , check @(AbstractHash Blake2b_512 PublicKey)
+        , testPrecise @(AbstractHash Blake2b_512 PublicKey)
           $ genAbstractHash genPublicKey
         )
       , ( "AbstractHash SHA1 PublicKey"
-        , check @(AbstractHash SHA1 PublicKey) $ genAbstractHash genPublicKey
+        , testPrecise @(AbstractHash SHA1 PublicKey) $ genAbstractHash genPublicKey
         )
-      , ("RedeemPublicKey", check genRedeemPublicKey)
-      , ("RedeemSecretKey", check genRedeemSecretKey)
+      , ("RedeemPublicKey", testPrecise genRedeemPublicKey)
+      , ("RedeemSecretKey", testPrecise genRedeemSecretKey)
       , ( "RedeemSignature PublicKey"
-        , check (genRedeemSignature (ProtocolMagic 0) genPublicKey)
+        , testPrecise (genRedeemSignature (ProtocolMagic 0) genPublicKey)
         )
       ]
 

--- a/crypto/test/Test/Cardano/Crypto/CryptoSpec2.hs
+++ b/crypto/test/Test/Cardano/Crypto/CryptoSpec2.hs
@@ -387,6 +387,6 @@ passphraseChangeLeavesAddressUnmodified
 passphraseChangeLeavesAddressUnmodified oldPass newPass = ioProperty $ do
   (_, oldKey) <- Crypto.safeKeyGen oldPass
   newKey      <-
-    fromMaybe (error "Passphrase didn't match")
+    fromMaybe (panic "Passphrase didn't match")
       <$> Crypto.changeEncPassphrase oldPass newPass oldKey
   return $ Crypto.encToPublic oldKey === Crypto.encToPublic newKey

--- a/crypto/test/Test/Cardano/Crypto/Gen.hs
+++ b/crypto/test/Test/Cardano/Crypto/Gen.hs
@@ -129,14 +129,14 @@ genRedeemPublicKey :: Gen RedeemPublicKey
 genRedeemPublicKey = do
     rkp <- genRedeemKeypair
     case rkp of
-        Nothing      -> error "Error generating a RedeemPublicKey."
+        Nothing      -> panic "Error generating a RedeemPublicKey."
         Just (pk, _) -> return pk
 
 genRedeemSecretKey :: Gen RedeemSecretKey
 genRedeemSecretKey = do
     rkp <- genRedeemKeypair
     case rkp of
-        Nothing      -> error "Error generating a RedeemSecretKey."
+        Nothing      -> panic "Error generating a RedeemSecretKey."
         Just (_, sk) -> return sk
 
 

--- a/prelude/cardano-prelude.cabal
+++ b/prelude/cardano-prelude.cabal
@@ -42,10 +42,10 @@ library
                      , formatting
                      , hashable
                      , mtl
+                     , protolude
                      , tagged
                      , text
                      , time
-                     , universum
 
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude

--- a/prelude/src/Cardano/Prelude/Base.hs
+++ b/prelude/src/Cardano/Prelude/Base.hs
@@ -1,5 +1,9 @@
 module Cardano.Prelude.Base
-       ( module Universum
+       ( module X
        ) where
 
-import           Universum
+import           Protolude as X hiding (Hashable, hash, hashUsing, hashWithSalt,
+                     (.))
+
+import           Control.Category as X
+import           Numeric.Natural as X

--- a/prelude/src/Cardano/Prelude/Base16.hs
+++ b/prelude/src/Cardano/Prelude/Base16.hs
@@ -10,7 +10,7 @@ import           Cardano.Prelude.Base
 
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BS
-import           Formatting (bprint, shown, (%))
+import           Formatting (bprint, shown)
 import           Formatting.Buildable (Buildable (build))
 
 
@@ -20,10 +20,10 @@ newtype Base16ParseError =
 
 instance Buildable Base16ParseError where
   build (Base16IncorrectSuffix suffix) =
-    bprint ("Base16 parsing failed with incorrect suffix " % shown) suffix
+    bprint ("Base16 parsing failed with incorrect suffix " . shown) suffix
 
 parseBase16 :: Text -> Either Base16ParseError ByteString
 parseBase16 s = do
-  let (bs, suffix) = B16.decode . fromString $ toString s
+  let (bs, suffix) = B16.decode $ toS s
   unless (BS.null suffix) . Left $ Base16IncorrectSuffix suffix
   pure bs

--- a/prelude/src/Cardano/Prelude/Error.hs
+++ b/prelude/src/Cardano/Prelude/Error.hs
@@ -10,6 +10,7 @@ module Cardano.Prelude.Error
 import           Cardano.Prelude.Base
 
 import qualified Codec.CBOR.Decoding as CBOR
+import           Control.Monad (fail)
 import qualified Data.Aeson.Types as A
 import           Formatting (build, formatToString)
 import           Formatting.Buildable (Buildable)

--- a/prelude/src/Cardano/Prelude/Json/Canonical.hs
+++ b/prelude/src/Cardano/Prelude/Json/Canonical.hs
@@ -18,7 +18,6 @@ import           Cardano.Prelude.Base
 
 import           Control.Monad.Except (MonadError (throwError))
 import           Data.Fixed (E12, resolution)
-import qualified Data.Ratio as R
 import qualified Data.Text.Lazy.Builder as Builder (fromText)
 import           Data.Time (NominalDiffTime)
 import           Formatting.Buildable (Buildable (build))
@@ -47,8 +46,8 @@ instance
     => ReportSchemaErrors m
   where
   expected expec actual = throwError SchemaError
-    { seExpected = fromString expec
-    , seActual   = fmap fromString actual
+    { seExpected = toS expec
+    , seActual   = fmap toS actual
     }
 
 instance Monad m => ToJSON m Int32 where
@@ -90,13 +89,13 @@ instance ReportSchemaErrors m => FromJSON m Word32 where
   fromJSON val       = expectedButGotValue "Word32" val
 
 instance ReportSchemaErrors m => FromJSON m Word64 where
-  fromJSON = parseJSString readEither
+  fromJSON = parseJSString (readEither . toS)
 
 instance ReportSchemaErrors m => FromJSON m Integer where
-  fromJSON = parseJSString readEither
+  fromJSON = parseJSString (readEither . toS)
 
 instance MonadError SchemaError m => FromJSON m Natural where
-  fromJSON = parseJSString readEither
+  fromJSON = parseJSString (readEither . toS)
 
 instance MonadError SchemaError m => FromJSON m NominalDiffTime where
-  fromJSON = fmap (fromRational . (R.% 1e6)) . fromJSON
+  fromJSON = fmap (fromRational . (% 1e6)) . fromJSON

--- a/prelude/src/Cardano/Prelude/Json/Parse.hs
+++ b/prelude/src/Cardano/Prelude/Json/Parse.hs
@@ -12,7 +12,7 @@ module Cardano.Prelude.Json.Parse
 import           Cardano.Prelude.Base
 
 import           Data.Typeable (typeRep)
-import           Formatting (Format, build, formatToString, shown, (%))
+import           Formatting (Format, build, formatToString, shown)
 import           Formatting.Buildable (Buildable)
 import           Text.JSON.Canonical (JSValue (JSString),
                      ReportSchemaErrors (expected), expectedButGotValue)
@@ -27,17 +27,17 @@ parseJSString
     -> JSValue
     -> m a
 parseJSString parser = \case
-  JSString str -> either (report str) pure . parser $ toText str
+  JSString str -> either (report $ toS str) pure . parser $ toS str
   val          -> expectedButGotValue typeName val
  where
-  typeName :: String
+  typeName :: [Char]
   typeName = show $ typeRep (Proxy @a)
 
-  report :: String -> e -> m a
+  report :: Text -> e -> m a
   report str err =
     expected typeName (Just $ formatToString errFormat str err)
 
-  errFormat :: Format r (String -> e -> r)
+  errFormat :: Format r (Text -> e -> r)
   errFormat =
-    "Failed to parse value from JSString " % shown % "\n"
-      % "Parser failed with error: " % build
+    "Failed to parse value from JSString " . shown . "\n"
+      . "Parser failed with error: " . build

--- a/prelude/test/Test/Cardano/Prelude/Golden.hs
+++ b/prelude/test/Test/Cardano/Prelude/Golden.hs
@@ -43,7 +43,7 @@ goldenTestJSON
   => a
   -> FilePath
   -> Property
-goldenTestJSON x path = withFrozenCallStack . withTests 1 . property $ do
+goldenTestJSON x path = withFrozenCallStack $ withTests 1 . property $ do
   bs <- liftIO (LB.readFile path)
   encode x === bs
   case eitherDecode bs of

--- a/prelude/test/Test/Cardano/Prelude/QuickCheck/Arbitrary.hs
+++ b/prelude/test/Test/Cardano/Prelude/QuickCheck/Arbitrary.hs
@@ -24,7 +24,7 @@ import           Cardano.Prelude
 import           Data.ByteString (pack)
 import qualified Data.ByteString.Lazy as BL (ByteString, pack)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
-import           Formatting (build, sformat, (%))
+import           Formatting (build, sformat)
 import           Test.QuickCheck (Arbitrary (..), Gen, listOf, scale, shuffle,
                      vector)
 import           Test.QuickCheck.Gen (unGen)
@@ -63,8 +63,8 @@ sublistN :: Int -> [a] -> Gen [a]
 sublistN n xs = do
     let len = length xs
     if len < n then
-        error $ sformat ("sublistN: requested "%build%" elements, "%
-            "but list only contains "%build) n len
+        panic $ sformat ("sublistN: requested ".build." elements, ".
+            "but list only contains ".build) n len
     else
         take n <$> shuffle xs
 

--- a/prelude/test/Test/Cardano/Prelude/Tripping.hs
+++ b/prelude/test/Test/Cardano/Prelude/Tripping.hs
@@ -75,28 +75,22 @@ trippingBuildable x enc dec =
     else case valueDiff <$> buildValue mx <*> buildValue my of
       Nothing -> withFrozenCallStack $ failWith Nothing $ Prelude.unlines
         [ "━━━ Original ━━━"
-        , buildPretty mx
+        , show $ buildValue mx
         , "━━━ Intermediate ━━━"
         , show i
         , "━━━ Roundtrip ━━━"
-        , buildPretty my
+        , show $ buildValue my
         ]
 
-      Just diff ->
+      Just dif ->
         withFrozenCallStack
           $ failWith
-              (Just $ Diff "━━━ " "- Original" "/" "+ Roundtrip" " ━━━" diff)
+              (Just $ Diff "━━━ " "- Original" "/" "+ Roundtrip" " ━━━" dif)
           $ Prelude.unlines ["━━━ Intermediate ━━━", show i]
 
 instance (Buildable e, Buildable a) => Buildable (Either e a) where
     build (Left e)  = build e
     build (Right a) = build a
 
-buildPretty :: Buildable a => a -> String
-buildPretty = show . buildValue
-
 buildValue :: Buildable a => a -> Maybe Value
-buildValue = parseValue . stringBuild
-
-stringBuild :: Buildable a => a -> String
-stringBuild = toString . toLazyText . build
+buildValue = parseValue . toS . toLazyText . build

--- a/src/Cardano/Chain/Block/Block.hs
+++ b/src/Cardano/Chain/Block/Block.hs
@@ -39,7 +39,7 @@ module Cardano.Chain.Block.Block
 import           Cardano.Prelude
 
 import           Control.Monad.Except (MonadError (..))
-import           Formatting (bprint, build, int, shown, (%))
+import           Formatting (bprint, build, int, shown)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), Decoder, DecoderError (..),
@@ -85,11 +85,11 @@ data Block = Block
 instance B.Buildable Block where
   build block = bprint
     ( "Block:\n"
-    % "  " % build % "  transactions (" % int % " items): " % listJson % "\n"
-    % "  " % build % "\n"
-    % "  " % shown % "\n"
-    % "  update payload: " % build % "\n"
-    % "  " % build
+    . "  " . build . "  transactions (" . int . " items): " . listJson . "\n"
+    . "  " . build . "\n"
+    . "  " . shown . "\n"
+    . "  update payload: " . build . "\n"
+    . "  " . build
     )
     (blockHeader block)
     (length txs)
@@ -206,20 +206,20 @@ data BlockError
 instance B.Buildable BlockError where
   build = \case
     BlockBodyError err ->
-      bprint ("Body was invalid while checking Block.\n Error: " % build) err
+      bprint ("Body was invalid while checking Block.\n Error: " . build) err
     BlockHeaderError err ->
-      bprint ("Header was invalid while checking Block.\n Error: " % build) err
+      bprint ("Header was invalid while checking Block.\n Error: " . build) err
     BlockInvalidExtraDataProof p p' -> bprint
       ( "Incorrect proof of ExtraBodyData.\n"
-      % "Proof in Block:\n"
-      % build % "\n"
-      % "Calculated proof:\n"
-      % build % "\n"
+      . "Proof in Block:\n"
+      . build . "\n"
+      . "Calculated proof:\n"
+      . build . "\n"
       )
       p
       p'
     BlockProofError err ->
-      bprint ("Proof was invalid while checking Block.\n Error: " % build) err
+      bprint ("Proof was invalid while checking Block.\n Error: " . build) err
 
 verifyBlock :: MonadError BlockError m => ProtocolMagic -> Block -> m ()
 verifyBlock pm block = do

--- a/src/Cardano/Chain/Block/Body.hs
+++ b/src/Cardano/Chain/Block/Body.hs
@@ -15,7 +15,7 @@ module Cardano.Chain.Block.Body
 import           Cardano.Prelude
 
 import           Control.Monad.Except (MonadError (..))
-import           Formatting (bprint, build, (%))
+import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -61,10 +61,10 @@ data BodyError
 instance B.Buildable BodyError where
   build = \case
     BodyDelegationPayloadError err -> bprint
-      ("Delegation.Payload was invalid while checking Body.\n Error: " % build)
+      ("Delegation.Payload was invalid while checking Body.\n Error: " . build)
       err
     BodyUpdatePayloadError err -> bprint
-      ("Update.Payload was invalid while checking Body.\n Error: " % build)
+      ("Update.Payload was invalid while checking Body.\n Error: " . build)
       err
 
 verifyBody :: MonadError BodyError m => ProtocolMagic -> Body -> m ()

--- a/src/Cardano/Chain/Block/ExtraBodyData.hs
+++ b/src/Cardano/Chain/Block/ExtraBodyData.hs
@@ -9,7 +9,7 @@ module Cardano.Chain.Block.ExtraBodyData
 
 import           Cardano.Prelude
 
-import           Formatting (bprint, build, (%))
+import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -25,7 +25,7 @@ newtype ExtraBodyData = ExtraBodyData
 instance B.Buildable ExtraBodyData where
   build (ExtraBodyData attrs)
     | areAttributesKnown attrs = "no extra data"
-    | otherwise = bprint ("extra data has attributes: " % build) attrs
+    | otherwise = bprint ("extra data has attributes: " . build) attrs
 
 instance Bi ExtraBodyData where
   encode ebd = encodeListLen 1 <> encode (ebdAttributes ebd)

--- a/src/Cardano/Chain/Block/ExtraHeaderData.hs
+++ b/src/Cardano/Chain/Block/ExtraHeaderData.hs
@@ -14,7 +14,7 @@ module Cardano.Chain.Block.ExtraHeaderData
 import           Cardano.Prelude
 
 import           Control.Monad.Except (MonadError (..))
-import           Formatting (bprint, build, builder, (%))
+import           Formatting (bprint, build, builder)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -41,7 +41,7 @@ data ExtraHeaderData = ExtraHeaderData
 
 instance B.Buildable ExtraHeaderData where
   build mehd = bprint
-    ("    block: v" % build % "\n" % "    software: " % build % "\n" % builder)
+    ("    block: v" . build . "\n" . "    software: " . build . "\n" . builder)
     (ehdBlockVersion mehd)
     (ehdSoftwareVersion mehd)
     formattedExtra
@@ -49,7 +49,7 @@ instance B.Buildable ExtraHeaderData where
     formattedExtra
       | areAttributesKnown (ehdAttributes mehd) = mempty
       | otherwise = bprint
-        ("    attributes: " % build % "\n")
+        ("    attributes: " . build . "\n")
         (ehdAttributes mehd)
 
 instance Bi ExtraHeaderData where
@@ -71,7 +71,7 @@ instance B.Buildable ExtraHeaderDataError where
   build = \case
     ExtraHeaderDataSoftwareVersionError err -> bprint
       ( "SoftwareVersion was invalid while checking ExtraHeaderData.\n Error: "
-      % build
+      . build
       )
       err
 

--- a/src/Cardano/Chain/Block/Header.hs
+++ b/src/Cardano/Chain/Block/Header.hs
@@ -43,7 +43,7 @@ module Cardano.Chain.Block.Header
 import           Cardano.Prelude
 
 import           Control.Monad.Except (MonadError (..))
-import           Formatting (Format, bprint, build, int, (%))
+import           Formatting (Format, bprint, build, int)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), Decoder, DecoderError (..),
@@ -90,13 +90,13 @@ data Header = Header
 instance B.Buildable Header where
   build header = bprint
     ( "Header:\n"
-    % "    hash: " % hashHexF % "\n"
-    % "    previous block: " % hashHexF % "\n"
-    % "    slot: " % slotIdF % "\n"
-    % "    difficulty: " % int % "\n"
-    % "    leader: " % build % "\n"
-    % "    signature: " % build % "\n"
-    % build
+    . "    hash: " . hashHexF . "\n"
+    . "    previous block: " . hashHexF . "\n"
+    . "    slot: " . slotIdF . "\n"
+    . "    difficulty: " . int . "\n"
+    . "    leader: " . build . "\n"
+    . "    signature: " . build . "\n"
+    . build
     )
     headerHash
     (headerPrevHash header)
@@ -212,13 +212,13 @@ data HeaderError
 instance B.Buildable HeaderError where
   build = \case
     HeaderConsensusError err -> bprint
-      ("ConsensusData was invalid while checking Header.\n Error: " % build)
+      ("ConsensusData was invalid while checking Header.\n Error: " . build)
       err
     HeaderExtraDataError err -> bprint
-      ("ExtraHeaderData was invalid while checking Header.\n Error: " % build)
+      ("ExtraHeaderData was invalid while checking Header.\n Error: " . build)
       err
     HeaderInvalidSignature sig ->
-      bprint ("Invalid signature while checking Header.\n" % build) sig
+      bprint ("Invalid signature while checking Header.\n" . build) sig
 
 -- | Verify a main block header in isolation
 verifyHeader :: MonadError HeaderError m => ProtocolMagic -> Header -> m ()
@@ -325,9 +325,9 @@ data BlockSignature
 instance NFData BlockSignature
 
 instance B.Buildable BlockSignature where
-  build (BlockSignature s)       = bprint ("BlockSignature: "%build) s
-  build (BlockPSignatureLight s) = bprint ("BlockPSignatureLight: "%build) s
-  build (BlockPSignatureHeavy s) = bprint ("BlockPSignatureHeavy: "%build) s
+  build (BlockSignature s)       = bprint ("BlockSignature: ".build) s
+  build (BlockPSignatureLight s) = bprint ("BlockPSignatureLight: ".build) s
+  build (BlockPSignatureHeavy s) = bprint ("BlockPSignatureHeavy: ".build) s
 
 instance Bi BlockSignature where
   encode input = case input of

--- a/src/Cardano/Chain/Block/Proof.hs
+++ b/src/Cardano/Chain/Block/Proof.hs
@@ -15,7 +15,7 @@ module Cardano.Chain.Block.Proof
 import           Cardano.Prelude
 
 import           Control.Monad.Except (MonadError (..))
-import           Formatting (bprint, build, shown, (%))
+import           Formatting (bprint, build, shown)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -37,7 +37,7 @@ data Proof = Proof
 
 instance B.Buildable Proof where
   build proof = bprint
-    ("<Proof: " % build % ", " % shown % ", " % build % ", " % build % ">")
+    ("<Proof: " . build . ", " . shown . ", " . build . ", " . build . ">")
     (proofTxp proof)
     (proofSsc proof)
     (proofDelegation proof)
@@ -69,10 +69,10 @@ instance B.Buildable ProofError where
   build = \case
     ProofIncorrect p p' -> bprint
       ( "Incorrect proof of Body.\n"
-      % "Proof in header:\n"
-      % build % "\n"
-      % "Calculated proof:\n"
-      % build % "\n"
+      . "Proof in header:\n"
+      . build . "\n"
+      . "Calculated proof:\n"
+      . build . "\n"
       )
       p
       p'

--- a/src/Cardano/Chain/Block/Undo.hs
+++ b/src/Cardano/Chain/Block/Undo.hs
@@ -11,7 +11,7 @@ module Cardano.Chain.Block.Undo
 
 import           Cardano.Prelude
 
-import           Formatting (Format, bprint, build, later, (%))
+import           Formatting (Format, bprint, build, later)
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
 import           Cardano.Chain.Block.Block (Block)
@@ -37,10 +37,10 @@ type Blund = (Block, Undo)
 buildUndo :: SlotCount -> Format r (Undo -> r)
 buildUndo epochSlots = later $ \undo -> bprint
   ( "Undo:\n"
-  % "  undoTx: " % listJson % "\n"
-  % "  undoDlg: " % build % "\n"
-  % "  undoUS: " % build % "\n"
-  % "  undoSlog: " % buildSlogUndo epochSlots
+  . "  undoTx: " . listJson . "\n"
+  . "  undoDlg: " . build . "\n"
+  . "  undoUS: " . build . "\n"
+  . "  undoSlog: " . buildSlogUndo epochSlots
   )
   (map (bprint listJson) (undoTx undo))
   (undoDlg undo)

--- a/src/Cardano/Chain/Common/AddrAttributes.hs
+++ b/src/Cardano/Chain/Common/AddrAttributes.hs
@@ -9,7 +9,7 @@ module Cardano.Chain.Common.AddrAttributes
 import           Cardano.Prelude
 
 import qualified Data.ByteString.Lazy as LBS
-import           Formatting (bprint, build, builder, (%))
+import           Formatting (bprint, build, builder)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi, decode, encode)
@@ -30,8 +30,8 @@ data AddrAttributes = AddrAttributes
 
 instance B.Buildable AddrAttributes where
     build aa = bprint
-        ("AddrAttributes { stake distribution: "%build%
-         ", derivation path: "%builder%
+        ("AddrAttributes { stake distribution: ".build.
+         ", derivation path: ".builder.
          " }")
         (aaStakeDistribution aa)
         derivationPathBuilder
@@ -79,7 +79,7 @@ instance Bi (Attributes AddrAttributes) where
                     [(1, Bi.serialize . unsafeFromJust . aaPkDerivationPath)]
         unsafeFromJust =
             fromMaybe
-                (error "Maybe was Nothing in Bi (Attributes AddrAttributes)")
+                (panic "Maybe was Nothing in Bi (Attributes AddrAttributes)")
 
     decode = decodeAttributes initValue go
       where

--- a/src/Cardano/Chain/Common/AddrSpendingData.hs
+++ b/src/Cardano/Chain/Common/AddrSpendingData.hs
@@ -12,7 +12,7 @@ module Cardano.Chain.Common.AddrSpendingData
 import           Cardano.Prelude
 
 import qualified Data.ByteString.Lazy as LBS
-import           Formatting (bprint, build, int, (%))
+import           Formatting (bprint, build, int)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), Case (..), szCases)
@@ -40,10 +40,10 @@ data AddrSpendingData
 
 instance B.Buildable AddrSpendingData where
     build = \case
-        PubKeyASD pk     -> bprint ("PubKeyASD " % build) pk
-        ScriptASD script -> bprint ("ScriptASD " % build) script
-        RedeemASD rpk    -> bprint ("RedeemASD " % build) rpk
-        UnknownASD tag _ -> bprint ("UnknownASD with tag " % int) tag
+        PubKeyASD pk     -> bprint ("PubKeyASD " . build) pk
+        ScriptASD script -> bprint ("ScriptASD " . build) script
+        RedeemASD rpk    -> bprint ("RedeemASD " . build) rpk
+        UnknownASD tag _ -> bprint ("UnknownASD with tag " . int) tag
 
 instance NFData AddrSpendingData
 
@@ -93,11 +93,11 @@ instance Bi AddrSpendingData where
             tag -> UnknownASD tag <$> Bi.decodeUnknownCborDataItem
 
     encodedSizeExpr size _ = szCases
-        [ let PubKeyASD pk = error "unused"
+        [ let PubKeyASD pk = panic "unused"
           in  Case "PubKeyASD" $ size ((,) <$> pure (w8 0) <*> pure pk)
-        , let ScriptASD script = error "unused"
+        , let ScriptASD script = panic "unused"
           in  Case "ScriptASD" $ size ((,) <$> pure (w8 1) <*> pure script)
-        , let RedeemASD redeemPK = error "unused"
+        , let RedeemASD redeemPK = panic "unused"
           in  Case "RedeemASD" $ size ((,) <$> pure (w8 2) <*> pure redeemPK)
         ]
 

--- a/src/Cardano/Chain/Common/Address.hs
+++ b/src/Cardano/Chain/Common/Address.hs
@@ -77,7 +77,7 @@ import qualified Data.ByteString as BS
 import           Data.ByteString.Base58 (Alphabet (..), bitcoinAlphabet,
                      decodeBase58, encodeBase58)
 import           Formatting (Format, bprint, build, builder, formatToString,
-                     later, sformat, (%))
+                     later, sformat)
 import qualified Formatting.Buildable as B
 import           Text.JSON.Canonical (FromJSON (..), FromObjectKey (..),
                      JSValue (..), ToJSON (..), ToObjectKey (..))
@@ -180,7 +180,7 @@ instance Aeson.ToJSON Address where
 -- | A formatter showing guts of an 'Address'.
 addressDetailedF :: Format r (Address -> r)
 addressDetailedF = later $ \addr -> bprint
-    (builder % " address with root " % hashHexF % ", attributes: " % build)
+    (builder . " address with root " . hashHexF . ", attributes: " . build)
     (formattedType $ addrType addr)
     (addrRoot addr)
     (addrAttributes addr)
@@ -200,7 +200,7 @@ addrToBase58 :: Address -> ByteString
 addrToBase58 = encodeBase58 addrAlphabet . Bi.serialize'
 
 instance B.Buildable Address where
-    build = B.build . decodeUtf8 @Text . addrToBase58
+    build = B.build . decodeUtf8 . addrToBase58
 
 -- | Specialized formatter for 'Address'.
 addressF :: Format r (Address -> r)
@@ -462,7 +462,7 @@ maxPubKeyAddressSizeSingleKey = biSize largestPubKeyAddressSingleKey
 -- is serialized using var-length encoding.
 largestHDAddressBoot :: Address
 largestHDAddressBoot = case lvl2KeyPair of
-    Nothing        -> error "largestHDAddressBoot failed"
+    Nothing        -> panic "largestHDAddressBoot failed"
     Just (addr, _) -> addr
   where
     lvl2KeyPair = deriveLvl2KeyPair

--- a/src/Cardano/Chain/Common/Attributes.hs
+++ b/src/Cardano/Chain/Common/Attributes.hs
@@ -30,7 +30,7 @@ import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Data.ByteString.Base64.Type (getByteString64, makeByteString64)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map as M
-import           Formatting (bprint, build, int, (%))
+import           Formatting (bprint, build, int)
 import           Formatting.Buildable (Buildable)
 import qualified Formatting.Buildable as Buildable
 
@@ -84,7 +84,7 @@ instance {-# OVERLAPPABLE #-} Buildable h => Buildable (Attributes h) where
   build attr = if areAttributesKnown attr
     then Buildable.build (attrData attr)
     else bprint
-      ("Attributes { data: " % build % ", remain: <" % int % " bytes> }")
+      ("Attributes { data: " . build . ", remain: <" . int . " bytes> }")
       (attrData attr)
       (unknownAttributesLength attr)
 
@@ -92,7 +92,7 @@ instance Buildable (Attributes ()) where
   build attr
     | areAttributesKnown attr = "<no attributes>"
     | otherwise = bprint
-      ("Attributes { data: (), remain: <" % int % " bytes> }")
+      ("Attributes { data: (), remain: <" . int . " bytes> }")
       (unknownAttributesLength attr)
 
 instance Bi (Attributes ()) where
@@ -171,7 +171,7 @@ encodeAttributes encs attr = encode
    where
     insertCheck v Nothing = Just v
     insertCheck _ (Just v') =
-      error
+      panic
         $  "encodeAttributes: impossible: field no. "
         <> show k
         <> " is already encoded as unparsed field: "

--- a/src/Cardano/Chain/Common/Coeff.hs
+++ b/src/Cardano/Chain/Common/Coeff.hs
@@ -16,6 +16,7 @@ import           Cardano.Prelude
 import           Control.Monad.Except (MonadError)
 import qualified Data.Aeson as Aeson
 import           Data.Fixed (Fixed (..), Nano, resolution, showFixed)
+import qualified Data.Text.Lazy.Builder as Builder
 import           Formatting.Buildable (Buildable (..))
 import           Text.JSON.Canonical (FromJSON (..), ToJSON (..))
 
@@ -27,7 +28,7 @@ newtype Coeff = Coeff Nano
     deriving (Eq, Ord, Show, Generic, NFData, Num)
 
 instance Buildable Coeff where
-    build (Coeff x) = fromString (showFixed True x)
+    build (Coeff x) = Builder.fromString (showFixed True x)
 
 instance Bi Coeff where
     encode (Coeff n) = encode n

--- a/src/Cardano/Chain/Common/CoinPortion.hs
+++ b/src/Cardano/Chain/Common/CoinPortion.hs
@@ -23,7 +23,7 @@ import           Cardano.Prelude
 
 import           Control.Monad.Except (MonadError (..))
 import qualified Data.Aeson as Aeson (FromJSON (..), ToJSON (..))
-import           Formatting (bprint, build, float, int, sformat, (%))
+import           Formatting (bprint, build, float, int, sformat)
 import qualified Formatting.Buildable as B
 import           Text.JSON.Canonical (FromJSON (..), ToJSON (..))
 
@@ -47,7 +47,7 @@ newtype CoinPortion = CoinPortion
 
 instance B.Buildable CoinPortion where
   build cp@(getCoinPortion -> x) = bprint
-    (int % "/" % int % " (approx. " % float % ")")
+    (int . "/" . int . " (approx. " . float . ")")
     x
     coinPortionDenominator
     (coinPortionToDouble cp)
@@ -88,12 +88,12 @@ instance B.Buildable CoinPortionError where
   build = \case
     CoinPortionDoubleOutOfRange d -> bprint
       ( "Double, "
-      % build
-      % " , out of range [0, 1] when constructing CoinPortion"
+      . build
+      . " , out of range [0, 1] when constructing CoinPortion"
       )
       d
     CoinPortionTooLarge c -> bprint
-      ("CoinPortion, " % build % ", exceeds maximum, " % build)
+      ("CoinPortion, " . build . ", exceeds maximum, " . build)
       c
       coinPortionDenominator
 
@@ -126,8 +126,8 @@ coinPortionToDouble (getCoinPortion -> x) =
 applyCoinPortionDown :: CoinPortion -> Coin -> Coin
 applyCoinPortionDown (getCoinPortion -> p) (unsafeGetCoin -> c) = case c' of
   Right coin -> coin
-  Left  err  -> error $ sformat
-    ("The impossible happened in applyCoinPortionDown: " % build)
+  Left  err  -> panic $ sformat
+    ("The impossible happened in applyCoinPortionDown: " . build)
     err
  where
   c' =
@@ -144,8 +144,8 @@ applyCoinPortionUp :: CoinPortion -> Coin -> Coin
 applyCoinPortionUp (getCoinPortion -> p) (unsafeGetCoin -> c) =
   case mkCoin c' of
     Right coin -> coin
-    Left  err  -> error $ sformat
-      ("The impossible happened in applyCoinPortionUp: " % build)
+    Left  err  -> panic $ sformat
+      ("The impossible happened in applyCoinPortionUp: " . build)
       err
  where
   (d, m) =

--- a/src/Cardano/Chain/Common/Merkle.hs
+++ b/src/Cardano/Chain/Common/Merkle.hs
@@ -29,7 +29,7 @@ import           Cardano.Prelude
 
 import           Data.Bits (Bits (..))
 import           Data.ByteArray (ByteArrayAccess, convert)
-import           Data.ByteString.Builder (Builder, byteString)
+import           Data.ByteString.Builder (Builder, byteString, word8)
 import qualified Data.ByteString.Builder.Extra as Builder
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Coerce (coerce)
@@ -99,7 +99,7 @@ mkLeaf :: Bi a => a -> MerkleNode a
 mkLeaf a = MerkleLeaf mRoot a
     where
       mRoot = MerkleRoot $ coerce $
-          hashRaw (toLazyByteString ((byteString (one 0)) <> serializeBuilder a))
+          hashRaw (toLazyByteString (word8 0 <> serializeBuilder a))
 
 mkBranch :: MerkleNode a -> MerkleNode a -> MerkleNode a
 mkBranch nodeA nodeB =
@@ -120,9 +120,9 @@ merkleRootToBuilder (MerkleRoot (AbstractHash d)) = byteString (convert d)
 
 mkRoot :: MerkleRoot a -> MerkleRoot a -> MerkleRoot a
 mkRoot a b = MerkleRoot $ coerce $ hashRaw $ toLazyByteString $ mconcat
-    [ byteString (one 1)
-    , merkleRootToBuilder (a)
-    , merkleRootToBuilder (b) ]
+    [ word8 1
+    , merkleRootToBuilder a
+    , merkleRootToBuilder b ]
 
 -- | Smart constructor for 'MerkleTree'.
 mkMerkleTree :: Bi a => [a] -> MerkleTree a

--- a/src/Cardano/Chain/Common/Script.hs
+++ b/src/Cardano/Chain/Common/Script.hs
@@ -14,7 +14,7 @@ import           Cardano.Prelude
 import           Data.Aeson (FromJSON (..), ToJSON (toJSON), object, withObject,
                      (.:), (.=))
 import           Data.ByteString.Base64.Type (getByteString64, makeByteString64)
-import           Formatting (bprint, int, (%))
+import           Formatting (bprint, int)
 import qualified Formatting.Buildable as B
 import qualified PlutusCore.Program as PLCore
 
@@ -31,7 +31,7 @@ data Script = Script
       deriving anyclass NFData
 
 instance B.Buildable Script where
-    build script = bprint ("<script v"%int%">") (scrVersion script)
+    build script = bprint ("<script v".int.">") (scrVersion script)
 
 instance ToJSON Script where
     toJSON script = object

--- a/src/Cardano/Chain/Common/TxSizeLinear.hs
+++ b/src/Cardano/Chain/Common/TxSizeLinear.hs
@@ -14,7 +14,7 @@ import           Cardano.Prelude
 import           Data.Aeson (object, (.=))
 import qualified Data.Aeson as Aeson
 import           Data.Fixed (Nano)
-import           Formatting (bprint, build, (%))
+import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -29,7 +29,7 @@ data TxSizeLinear = TxSizeLinear !Coeff !Coeff
 instance NFData TxSizeLinear
 
 instance B.Buildable TxSizeLinear where
-    build (TxSizeLinear a b) = bprint (build%" + "%build%"*s") a b
+  build (TxSizeLinear a b) = bprint (build . " + " . build . "*s") a b
 
 instance Bi TxSizeLinear where
     encode (TxSizeLinear a b) = encodeListLen 2 <> encode a <> encode b

--- a/src/Cardano/Chain/Delegation/LightDlgIndices.hs
+++ b/src/Cardano/Chain/Delegation/LightDlgIndices.hs
@@ -11,7 +11,7 @@ module Cardano.Chain.Delegation.LightDlgIndices
 
 import           Cardano.Prelude
 
-import           Formatting (bprint, build, (%))
+import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B (Buildable (..))
 
 import           Cardano.Binary.Class (Bi (..))
@@ -30,7 +30,7 @@ newtype LightDlgIndices = LightDlgIndices
     deriving anyclass NFData
 
 instance B.Buildable LightDlgIndices where
-  build (LightDlgIndices (a, b)) = bprint ("(" % build % ", " % build % ")") a b
+  build (LightDlgIndices (a, b)) = bprint ("(" . build . ", " . build . ")") a b
 
 instance Bi LightDlgIndices where
   encode = encode . getLightDlgIndices

--- a/src/Cardano/Chain/Delegation/Payload.hs
+++ b/src/Cardano/Chain/Delegation/Payload.hs
@@ -13,7 +13,7 @@ module Cardano.Chain.Delegation.Payload
 import           Cardano.Prelude
 
 import           Control.Monad.Except (MonadError (throwError))
-import           Formatting (bprint, int, stext, (%))
+import           Formatting (bprint, int, stext)
 import           Formatting.Buildable (Buildable (..))
 
 import           Cardano.Binary.Class (Bi (..))
@@ -29,7 +29,7 @@ newtype Payload = UnsafePayload
 
 instance Buildable Payload where
   build (UnsafePayload psks) = bprint
-    ("proxy signing keys (" % int % " items): " % listJson % "\n")
+    ("proxy signing keys (" . int . " items): " . listJson . "\n")
     (length psks)
     psks
 
@@ -43,7 +43,7 @@ instance Buildable PayloadError where
   build = \case
     PayloadPSKError err -> bprint
       ( "ProxySecretKey invalid when checing Delegation.Payload.\n Error: "
-      % stext
+      . stext
       )
       err
 

--- a/src/Cardano/Chain/Delegation/Undo.hs
+++ b/src/Cardano/Chain/Delegation/Undo.hs
@@ -12,7 +12,7 @@ module Cardano.Chain.Delegation.Undo
 
 import           Cardano.Prelude
 
-import           Formatting (bprint, (%))
+import           Formatting (bprint)
 import           Formatting.Buildable (Buildable (..))
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -36,8 +36,8 @@ data Undo = Undo
 instance Buildable Undo where
   build undo = bprint
     ( "DlgUndo:\n"
-    % "  duPsks: " % listJson % "\n"
-    % "  duPrevEpochPosted: " % listJson
+    . "  duPsks: " . listJson . "\n"
+    . "  duPrevEpochPosted: " . listJson
     )
     (duPsks undo)
     (duPrevEpochPosted undo)

--- a/src/Cardano/Chain/Epoch/File.hs
+++ b/src/Cardano/Chain/Epoch/File.hs
@@ -43,7 +43,7 @@ epochHeader = "Epoch data v1\n"
 data ParseError
   = ParseErrorDecoder !DecoderError
   -- ^ The CBOR is invalid
-  | ParseErrorBinary !FilePath !B.ByteOffset !String
+  | ParseErrorBinary !FilePath !B.ByteOffset !Text
   | ParseErrorMissingHeader !FilePath
   deriving (Eq, Show)
 
@@ -77,7 +77,7 @@ parseEpochFile file = do
   liftBinaryError = \case
     (_, _, Right ()) -> pure ()
     (_, offset, Left message) ->
-      throwError (ParseErrorBinary file offset message)
+      throwError (ParseErrorBinary file offset (toS message))
 
 parseEpochFiles :: [FilePath] -> Stream (Of (Block, Undo)) (ExceptT ParseError ResIO) ()
 parseEpochFiles fs = foldr (<>) mempty (parseEpochFile <$> fs)

--- a/src/Cardano/Chain/Slotting/Data.hs
+++ b/src/Cardano/Chain/Slotting/Data.hs
@@ -24,7 +24,7 @@ module Cardano.Chain.Slotting.Data
        , computeSlotStart
        ) where
 
-import           Cardano.Prelude hiding (keys)
+import           Cardano.Prelude
 
 import           Data.Map.Strict as M
 import           Data.Semigroup (Semigroup)
@@ -101,7 +101,7 @@ createSlottingDataUnsafe epochSlottingDataMap =
     else criticalError
  where
   criticalError =
-    error
+    panic
       "It's impossible to create slotting data without at least\
     \ two epochs. Epochs need to be sequential."
 

--- a/src/Cardano/Chain/Slotting/EpochIndex.hs
+++ b/src/Cardano/Chain/Slotting/EpochIndex.hs
@@ -17,7 +17,7 @@ import           Cardano.Prelude
 import           Control.Monad.Except (MonadError)
 import qualified Data.Aeson as Aeson (FromJSON (..), ToJSON (..))
 import           Data.Ix (Ix)
-import           Formatting (bprint, int, (%))
+import           Formatting (bprint, int)
 import           Formatting.Buildable (Buildable (..))
 import           Servant.API (FromHttpApiData)
 import           Text.JSON.Canonical (FromJSON (..), ToJSON (..))
@@ -43,7 +43,7 @@ newtype EpochIndex = EpochIndex
              )
 
 instance Buildable EpochIndex where
-  build = bprint ("#"%int)
+  build = bprint ("#" . int)
 
 instance Bi EpochIndex where
   encode (EpochIndex epoch) = encode epoch

--- a/src/Cardano/Chain/Slotting/LocalSlotIndex.hs
+++ b/src/Cardano/Chain/Slotting/LocalSlotIndex.hs
@@ -28,7 +28,7 @@ import           Cardano.Prelude
 import           Control.Monad.Except (MonadError (throwError))
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Data.Ix (Ix)
-import           Formatting (bprint, build, int, (%))
+import           Formatting (bprint, build, int)
 import qualified Formatting.Buildable as B (Buildable (..))
 
 import           Cardano.Binary.Class (Bi (..))
@@ -67,20 +67,20 @@ instance B.Buildable LocalSlotIndexError where
   build = \case
     LocalSlotIndexEnumOverflow epochSlots i -> bprint
       ( "localSlotIndexToEnum: "
-      % int
-      % " is greater than the maxBound, "
-      % build
+      . int
+      . " is greater than the maxBound, "
+      . build
       )
       i
       (epochSlots - 1)
     LocalSlotIndexEnumUnderflow i -> bprint
-      ("localSlotIndexToEnum: " % build % " is less than the minBound, 0")
+      ("localSlotIndexToEnum: " . build . " is less than the minBound, 0")
       i
     LocalSlotIndexOverflow epochSlots i -> bprint
       ( "Cannot construct LocalSlotIndex: "
-      % build
-      % "is greater than or equal to epochSlots, "
-      % build
+      . build
+      . "is greater than or equal to epochSlots, "
+      . build
       )
       i
       epochSlots

--- a/src/Cardano/Chain/Slotting/SlotId.hs
+++ b/src/Cardano/Chain/Slotting/SlotId.hs
@@ -28,7 +28,7 @@ import           Cardano.Prelude
 
 import           Control.Lens (Iso', iso, makeLensesFor)
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
-import           Formatting (Format, bprint, build, ords, sformat, (%))
+import           Formatting (Format, bprint, build, ords, sformat)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -51,7 +51,7 @@ data SlotId = SlotId
 
 instance B.Buildable SlotId where
   build si = bprint
-    (ords % " slot of " % ords % " epoch")
+    (ords . " slot of " . ords . " epoch")
     (getSlotIndex $ siSlot si)
     (getEpochIndex $ siEpoch si)
 
@@ -111,8 +111,8 @@ unflattenSlotId es n = SlotId {siEpoch = fromIntegral epoch, siSlot = lsi}
  where
   (epoch, slot) = n `divMod` fromIntegral es
   lsi           = case mkLocalSlotIndex es (fromIntegral slot) of
-    Left err -> error
-      $ sformat ("The impossible happened in unflattenSlotId: " % build) err
+    Left err -> panic
+      $ sformat ("The impossible happened in unflattenSlotId: " . build) err
     Right lsi' -> lsi'
 
 flatSlotId :: SlotCount -> Iso' SlotId FlatSlotId
@@ -129,5 +129,5 @@ crucialSlot k epochIdx = SlotId {siEpoch = epochIdx - 1, siSlot = slot}
   idx = fromIntegral $ fromIntegral epochSlots - kSlotSecurityParam k - 1
   slot = case mkLocalSlotIndex epochSlots idx of
     Left err ->
-      error $ sformat ("The impossible happened in crucialSlot: " % build) err
+      panic $ sformat ("The impossible happened in crucialSlot: " . build) err
     Right lsi -> lsi

--- a/src/Cardano/Chain/Txp/TxAux.hs
+++ b/src/Cardano/Chain/Txp/TxAux.hs
@@ -11,7 +11,7 @@ module Cardano.Chain.Txp.TxAux
 import           Cardano.Prelude
 
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
-import           Formatting (Format, bprint, build, later, (%))
+import           Formatting (Format, bprint, build, later)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -30,7 +30,7 @@ instance NFData TxAux
 -- | Specialized formatter for 'TxAux'
 txaF :: Format r (TxAux -> r)
 txaF = later $ \(TxAux tx w) ->
-  bprint (build % "\n" % "witnesses: " % listJsonIndent 4) tx w
+  bprint (build . "\n" . "witnesses: " . listJsonIndent 4) tx w
 
 instance B.Buildable TxAux where
   build = bprint txaF

--- a/src/Cardano/Chain/Txp/TxOutAux.hs
+++ b/src/Cardano/Chain/Txp/TxOutAux.hs
@@ -9,7 +9,7 @@ module Cardano.Chain.Txp.TxOutAux
 import           Cardano.Prelude
 
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
-import           Formatting (bprint, build, (%))
+import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -23,7 +23,7 @@ data TxOutAux = TxOutAux
   } deriving (Generic, Show, Eq, Ord)
 
 instance B.Buildable TxOutAux where
-  build (TxOutAux out) = bprint ("{txout = "%build%"}") out
+  build (TxOutAux out) = bprint ("{txout = " . build . "}") out
 
 instance NFData TxOutAux
 

--- a/src/Cardano/Chain/Txp/TxProof.hs
+++ b/src/Cardano/Chain/Txp/TxProof.hs
@@ -8,7 +8,7 @@ module Cardano.Chain.Txp.TxProof
 
 import           Cardano.Prelude
 
-import           Formatting (bprint, build, (%))
+import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -27,7 +27,7 @@ data TxProof = TxProof
 
 instance B.Buildable TxProof where
   build proof = bprint
-    ("<TxProof: " % build % ", " % build % ", " % build % ">")
+    ("<TxProof: " . build . ", " . build . ", " . build . ">")
     (txpNumber proof)
     (txpRoot proof)
     (txpWitnessesHash proof)

--- a/src/Cardano/Chain/Txp/TxWitness.hs
+++ b/src/Cardano/Chain/Txp/TxWitness.hs
@@ -19,7 +19,8 @@ import           Data.Aeson (FromJSON (..), ToJSON (toJSON), object, withObject,
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Data.ByteString.Base64.Type (getByteString64, makeByteString64)
 import qualified Data.ByteString.Lazy as LBS
-import           Formatting (bprint, build, (%))
+import           Data.Vector (Vector)
+import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), Case (..),
@@ -86,29 +87,29 @@ instance FromJSON TxInWitness where
 instance B.Buildable TxInWitness where
   build (PkWitness key sig) = bprint
     ( "PkWitness: key = "
-    % build
-    % ", key hash = "
-    % shortHashF
-    % ", sig = "
-    % build
+    . build
+    . ", key hash = "
+    . shortHashF
+    . ", sig = "
+    . build
     )
     key
     (addressHash key)
     sig
   build (ScriptWitness val red) = bprint
     ( "ScriptWitness: "
-    % "validator hash = "
-    % shortHashF
-    % ", "
-    % "redeemer hash = "
-    % shortHashF
+    . "validator hash = "
+    . shortHashF
+    . ", "
+    . "redeemer hash = "
+    . shortHashF
     )
     (hash val)
     (hash red)
   build (RedeemWitness key sig) =
-    bprint ("PkWitness: key = " % build % ", sig = " % build) key sig
+    bprint ("PkWitness: key = " . build . ", sig = " . build) key sig
   build (UnknownWitnessType t bs) =
-    bprint ("UnknownWitnessType " % build % " " % base16F) t bs
+    bprint ("UnknownWitnessType " . build . " " . base16F) t bs
 
 instance Bi TxInWitness where
   encode input = case input of
@@ -148,11 +149,11 @@ instance Bi TxInWitness where
   encodedSizeExpr size _ = 2 + szCases
     (map
       (fmap knownCborDataItemSizeExpr)
-      [ let PkWitness key sig = error "unused"
+      [ let PkWitness key sig = panic "unused"
         in Case "PkWitness" $ size ((,) <$> pure key <*> pure sig)
-      , let ScriptWitness key sig = error "unused"
+      , let ScriptWitness key sig = panic "unused"
         in Case "ScriptWitness" $ size ((,) <$> pure key <*> pure sig)
-      , let RedeemWitness key sig = error "unused"
+      , let RedeemWitness key sig = panic "unused"
         in Case "RedeemWitness" $ size ((,) <$> pure key <*> pure sig)
       ]
     )

--- a/src/Cardano/Chain/Update/ApplicationName.hs
+++ b/src/Cardano/Chain/Update/ApplicationName.hs
@@ -19,7 +19,7 @@ import           Data.Aeson (FromJSON (..))
 import           Data.Aeson.TH (defaultOptions, deriveToJSON)
 import           Data.Char (isAscii)
 import qualified Data.Text as T
-import           Formatting (bprint, int, stext, (%))
+import           Formatting (bprint, int, stext)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..))
@@ -27,7 +27,7 @@ import           Cardano.Binary.Class (Bi (..))
 
 newtype ApplicationName = ApplicationName
   { getApplicationName :: Text
-  } deriving (Eq, Ord, Show, Generic, ToString, B.Buildable, NFData)
+  } deriving (Eq, Ord, Show, Generic, B.Buildable, NFData)
 
 instance Bi ApplicationName where
   encode appName = encode (getApplicationName appName)
@@ -45,18 +45,18 @@ data ApplicationNameError
 instance B.Buildable ApplicationNameError where
   build = \case
     ApplicationNameTooLong name -> bprint
-      ("ApplicationName, " % stext % ", exceeds limit of " % int)
+      ("ApplicationName, " . stext . ", exceeds limit of " . int)
       name
       (applicationNameMaxLength :: Int)
     ApplicationNameNotAscii name -> bprint
-      ("ApplicationName, " % stext % ", contains non-ascii characters")
+      ("ApplicationName, " . stext . ", contains non-ascii characters")
       name
 
 -- | Smart constructor of 'ApplicationName'
 checkApplicationName
   :: MonadError ApplicationNameError m => ApplicationName -> m ()
 checkApplicationName (ApplicationName appName)
-  | length appName > applicationNameMaxLength = throwError
+  | T.length appName > applicationNameMaxLength = throwError
   $ ApplicationNameTooLong appName
   | T.any (not . isAscii) appName = throwError $ ApplicationNameNotAscii appName
   | otherwise = pure ()

--- a/src/Cardano/Chain/Update/BlockVersionData.hs
+++ b/src/Cardano/Chain/Update/BlockVersionData.hs
@@ -18,7 +18,7 @@ import           Control.Monad.Except (MonadError)
 import qualified Data.Aeson.Options as S (defaultOptions)
 import           Data.Aeson.TH (deriveJSON)
 import           Data.Time (NominalDiffTime)
-import           Formatting (bprint, build, bytes, int, shortest, (%))
+import           Formatting (bprint, build, bytes, int, shortest)
 import qualified Formatting.Buildable as B
 import           Text.JSON.Canonical (FromJSON (..), ToJSON (..), fromJSField,
                      mkObject)
@@ -51,21 +51,21 @@ instance NFData BlockVersionData where
 
 instance B.Buildable BlockVersionData where
   build bvd = bprint
-    ( "{ script version: " % build
-    % ", slot duration: " % build
-    % ", block size limit: " % bytes'
-    % ", header size limit: " % bytes'
-    % ", tx size limit: " % bytes'
-    % ", proposal size limit: " % bytes'
-    % ", mpc threshold: " % build
-    % ", heavyweight delegation threshold: " % build
-    % ", update vote threshold: " % build
-    % ", update proposal threshold: " % build
-    % ", update implicit period: " % int % " slots"
-    % ", softfork rule: " % build
-    % ", tx fee policy: " % build
-    % ", unlock stake epoch: " % build
-    % " }"
+    ( "{ script version: " . build
+    . ", slot duration: " . build
+    . ", block size limit: " . bytes'
+    . ", header size limit: " . bytes'
+    . ", tx size limit: " . bytes'
+    . ", proposal size limit: " . bytes'
+    . ", mpc threshold: " . build
+    . ", heavyweight delegation threshold: " . build
+    . ", update vote threshold: " . build
+    . ", update proposal threshold: " . build
+    . ", update implicit period: " . int . " slots"
+    . ", softfork rule: " . build
+    . ", tx fee policy: " . build
+    . ", unlock stake epoch: " . build
+    . " }"
     )
     (bvdScriptVersion bvd)
     (bvdSlotDuration bvd)

--- a/src/Cardano/Chain/Update/BlockVersionModifier.hs
+++ b/src/Cardano/Chain/Update/BlockVersionModifier.hs
@@ -14,8 +14,7 @@ import           Cardano.Prelude
 
 import           Data.Text.Lazy.Builder (Builder)
 import           Data.Time (NominalDiffTime)
-import           Formatting (Format, bprint, build, bytes, int, later, shortest,
-                     (%))
+import           Formatting (Format, bprint, build, bytes, int, later, shortest)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -46,21 +45,21 @@ data BlockVersionModifier = BlockVersionModifier
 
 instance B.Buildable BlockVersionModifier where
   build bvm = bprint
-    ( "{ script version: " % bmodifier build
-    % ", slot duration: " % bmodifier build
-    % ", block size limit: " % bmodifier bytes'
-    % ", header size limit: " % bmodifier bytes'
-    % ", tx size limit: " % bmodifier bytes'
-    % ", proposal size limit: " % bmodifier bytes'
-    % ", mpc threshold: " % bmodifier build
-    % ", heavyweight delegation threshold: " % bmodifier build
-    % ", update vote threshold: " % bmodifier build
-    % ", update proposal threshold: " % bmodifier build
-    % ", update implicit period (slots): " % bmodifier int
-    % ", softfork rule: " % bmodifier build
-    % ", tx fee policy: " % bmodifier build
-    % ", unlock stake epoch: " % bmodifier build
-    % " }"
+    ( "{ script version: " . bmodifier build
+    . ", slot duration: " . bmodifier build
+    . ", block size limit: " . bmodifier bytes'
+    . ", header size limit: " . bmodifier bytes'
+    . ", tx size limit: " . bmodifier bytes'
+    . ", proposal size limit: " . bmodifier bytes'
+    . ", mpc threshold: " . bmodifier build
+    . ", heavyweight delegation threshold: " . bmodifier build
+    . ", update vote threshold: " . bmodifier build
+    . ", update proposal threshold: " . bmodifier build
+    . ", update implicit period (slots): " . bmodifier int
+    . ", softfork rule: " . bmodifier build
+    . ", tx fee policy: " . bmodifier build
+    . ", unlock stake epoch: " . bmodifier build
+    . " }"
     )
     (bvmScriptVersion bvm)
     (bvmSlotDuration bvm)

--- a/src/Cardano/Chain/Update/Data.hs
+++ b/src/Cardano/Chain/Update/Data.hs
@@ -9,7 +9,7 @@ module Cardano.Chain.Update.Data
 
 import           Cardano.Prelude
 
-import           Formatting (bprint, build, (%))
+import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), Raw, encodeListLen, enforceSize)
@@ -38,14 +38,14 @@ data UpdateData = UpdateData
 instance B.Buildable UpdateData where
   build ud = bprint
     ( "{ appDiff: "
-    % build
-    % ", pkg: "
-    % build
-    % ", updater: "
-    % build
-    % ", metadata: "
-    % build
-    % " }"
+    . build
+    . ", pkg: "
+    . build
+    . ", updater: "
+    . build
+    . ", metadata: "
+    . build
+    . " }"
     )
     (udAppDiffHash ud)
     (udPkgHash ud)

--- a/src/Cardano/Chain/Update/SoftforkRule.hs
+++ b/src/Cardano/Chain/Update/SoftforkRule.hs
@@ -17,7 +17,7 @@ import           Cardano.Prelude
 import           Control.Monad.Except (MonadError)
 import qualified Data.Aeson.Options as S (defaultOptions)
 import           Data.Aeson.TH (deriveJSON)
-import           Formatting (bprint, build, (%))
+import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 import           Text.JSON.Canonical (FromJSON (..), ToJSON (..), fromJSField,
                      mkObject)
@@ -47,7 +47,7 @@ data SoftforkRule = SoftforkRule
 
 instance B.Buildable SoftforkRule where
   build sr = bprint
-    ("(init = " % build % ", min = " % build % ", decrement = " % build % ")")
+    ("(init = " . build . ", min = " . build . ", decrement = " . build . ")")
     (srInitThd sr)
     (srMinThd sr)
     (srThdDecrement sr)

--- a/src/Cardano/Chain/Update/SoftwareVersion.hs
+++ b/src/Cardano/Chain/Update/SoftwareVersion.hs
@@ -18,7 +18,7 @@ import qualified Prelude
 
 import           Control.Monad.Except (MonadError (..))
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
-import           Formatting (bprint, build, formatToString, int, stext, (%))
+import           Formatting (bprint, build, formatToString, int, stext)
 import qualified Formatting.Buildable as B (Buildable (..))
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -37,7 +37,7 @@ data SoftwareVersion = SoftwareVersion
 
 instance B.Buildable SoftwareVersion where
   build sv =
-    bprint (stext % ":" % int) (getApplicationName $ svAppName sv) (svNumber sv)
+    bprint (stext . ":" . int) (getApplicationName $ svAppName sv) (svNumber sv)
 
 instance Show SoftwareVersion where
   show = formatToString build
@@ -56,7 +56,7 @@ instance B.Buildable SoftwareVersionError where
   build = \case
     SoftwareVersionApplicationNameError err -> bprint
       ( "ApplicationName was invalid when checking SoftwareVersion\n Error:"
-      % build
+      . build
       )
       err
 

--- a/src/Cardano/Chain/Update/SystemTag.hs
+++ b/src/Cardano/Chain/Update/SystemTag.hs
@@ -26,7 +26,7 @@ import           Data.Char (isAscii)
 import qualified Data.Text as T
 import           Distribution.System (Arch (..), OS (..))
 import           Distribution.Text (display)
-import           Formatting (bprint, int, stext, (%))
+import           Formatting (bprint, int, stext)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..))
@@ -58,9 +58,9 @@ data SystemTagError
 instance B.Buildable SystemTagError where
   build = \case
     SystemTagNotAscii tag ->
-      bprint ("SystemTag, " % stext % ", contains non-ascii characters") tag
+      bprint ("SystemTag, " . stext . ", contains non-ascii characters") tag
     SystemTagTooLong tag -> bprint
-      ("SystemTag, " % stext % ", exceeds limit of " % int)
+      ("SystemTag, " . stext . ", exceeds limit of " . int)
       tag
       (systemTagMaxLength :: Int)
 
@@ -70,19 +70,19 @@ checkSystemTag (SystemTag tag)
   | T.any (not . isAscii) tag         = throwError $ SystemTagNotAscii tag
   | otherwise                         = pure ()
 
--- | Helper to turn an @OS@ into a @String@ compatible with the @systemTag@
+-- | Helper to turn an @OS@ into a @Text@ compatible with the @systemTag@
 --   previously used in 'configuration.yaml'
-osHelper :: OS -> String
+osHelper :: OS -> Text
 osHelper sys = case sys of
   Windows -> "win"
   OSX     -> "macos"
   Linux   -> "linux"
-  _       -> display sys
+  _       -> toS $ display sys
 
--- | Helper to turn an @Arch@ into a @String@ compatible with the @systemTag@
+-- | Helper to turn an @Arch@ into a @Text@ compatible with the @systemTag@
 --   previously used in 'configuration.yaml'
-archHelper :: Arch -> String
+archHelper :: Arch -> Text
 archHelper archt = case archt of
   I386   -> "32"
   X86_64 -> "64"
-  _      -> display archt
+  _      -> toS $ display archt

--- a/src/Cardano/Chain/Update/Vote.hs
+++ b/src/Cardano/Chain/Update/Vote.hs
@@ -33,7 +33,7 @@ import           Cardano.Prelude
 import           Control.Monad.Except (MonadError (throwError))
 import qualified Data.Map.Strict as Map
 import           Data.Text.Lazy.Builder (Builder)
-import           Formatting (Format, bprint, build, builder, later, (%))
+import           Formatting (Format, bprint, build, builder, later)
 import qualified Formatting.Buildable as B
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
@@ -100,17 +100,17 @@ type Proposals = Map UpId Proposal
 instance B.Buildable Proposal where
   build proposal = bprint
     ( build
-    % " { block v"
-    % build
-    % ", UpId: "
-    % build
-    % ", "
-    % build
-    % ", tags: "
-    % listJson
-    % ", "
-    % builder
-    % " }"
+    . " { block v"
+    . build
+    . ", UpId: "
+    . build
+    . ", "
+    . build
+    . ", tags: "
+    . listJson
+    . ", "
+    . builder
+    . " }"
     )
     (pbSoftwareVersion body)
     (pbBlockVersion body)
@@ -123,7 +123,7 @@ instance B.Buildable Proposal where
     attrs = pbAttributes body
     attrsBuilder
       | areAttributesKnown attrs = "no attributes"
-      | otherwise                = bprint ("attributes: " % build) attrs
+      | otherwise                = bprint ("attributes: " . build) attrs
 
 instance NFData Proposal
 
@@ -167,12 +167,12 @@ data ProposalError
 instance B.Buildable ProposalError where
   build = \case
     ProposalInvalidSignature sig ->
-      bprint ("Invalid signature, " % build % ", in Proposal") sig
+      bprint ("Invalid signature, " . build . ", in Proposal") sig
     ProposalSoftwareVersionError err -> bprint
-      ("SoftwareVersion was invalid while checking Proposal.\n Error: " % build)
+      ("SoftwareVersion was invalid while checking Proposal.\n Error: " . build)
       err
     ProposalSystemTagError err -> bprint
-      ("SystemTag was invalid while checking Proposal.\n Error: " % build)
+      ("SystemTag was invalid while checking Proposal.\n Error: " . build)
       err
 
 checkProposal :: MonadError ProposalError m => ProtocolMagic -> Proposal -> m ()
@@ -205,12 +205,12 @@ type VoteId = (UpId, PublicKey, Bool)
 instance B.Buildable VoteId where
   build (upId, pk, dec) = bprint
     ( "Vote Id { voter: "
-    % build
-    % ", proposal id: "
-    % build
-    % ", voter's decision: "
-    % build
-    % " }"
+    . build
+    . ", proposal id: "
+    . build
+    . ", voter's decision: "
+    . build
+    . " }"
     )
     pk
     upId
@@ -235,12 +235,12 @@ instance NFData Vote
 instance B.Buildable Vote where
   build uv = bprint
     ( "Update Vote { voter: "
-    % build
-    % ", proposal id: "
-    % build
-    % ", voter's decision: "
-    % build
-    % " }"
+    . build
+    . ", proposal id: "
+    . build
+    . ", voter's decision: "
+    . build
+    . " }"
     )
     (addressHash $ uvKey uv)
     (uvProposalId uv)
@@ -248,7 +248,7 @@ instance B.Buildable Vote where
 
 instance B.Buildable (Proposal, [Vote]) where
   build (up, votes) =
-    bprint (build % " with votes: " % listJson) up (map formatVoteShort votes)
+    bprint (build . " with votes: " . listJson) up (map formatVoteShort votes)
 
 instance Bi Vote where
   encode uv =
@@ -299,7 +299,7 @@ mkVoteSafe pm sk proposalId decision = UnsafeVote
 -- | Format 'Vote' compactly
 formatVoteShort :: Vote -> Builder
 formatVoteShort uv = bprint
-  ("(" % shortHashF % " " % builder % " " % shortHashF % ")")
+  ("(" . shortHashF . " " . builder . " " . shortHashF . ")")
   (addressHash $ uvKey uv)
   (bool "against" "for" $ uvDecision uv)
   (uvProposalId uv)
@@ -314,7 +314,7 @@ data VoteError =
 instance B.Buildable VoteError where
   build = \case
     VoteInvalidSignature sig ->
-      bprint ("Invalid signature, " % build % ", in Vote") sig
+      bprint ("Invalid signature, " . build . ", in Vote") sig
 
 checkVote :: MonadError VoteError m => ProtocolMagic -> Vote -> m ()
 checkVote pm uv = unless

--- a/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/test/Test/Cardano/Chain/Common/Gen.hs
@@ -26,7 +26,7 @@ import           Test.Cardano.Prelude
 
 import           Data.Fixed (Fixed (..))
 import qualified Data.Map.Strict as Map
-import           Formatting (build, sformat, (%))
+import           Formatting (build, sformat)
 
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -128,15 +128,15 @@ genCoeff = do
     -- A `Coeff` wraps a Nano-precision integral value, which corresponds to a
     -- number of "Lovelace" (10^6 Lovelace == 1 ADA). The `Coeff` values used
     -- in Cardano correspond to less than 1 ADA.
-    let exponent = 9 + 6 :: Integer
-    integer <- Gen.integral (Range.constant 0 (10^exponent))
+    let e = 9 + 6 :: Integer
+    integer <- Gen.integral (Range.constant 0 (10^e))
     pure $ Coeff (MkFixed integer)
 
 genCoin :: Gen Coin
 genCoin = mkCoin <$> Gen.word64 (Range.constant 0 maxCoinVal) >>= \case
   Right coin -> pure coin
   Left err ->
-    error $ sformat ("The impossible happened in genCoin: " % build) err
+    panic $ sformat ("The impossible happened in genCoin: " . build) err
 
 genCoinPortion :: Gen CoinPortion
 genCoinPortion =

--- a/test/Test/Cardano/Chain/Slotting/Gen.hs
+++ b/test/Test/Cardano/Chain/Slotting/Gen.hs
@@ -15,7 +15,7 @@ import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import qualified Data.Map.Strict as Map
-import           Formatting (build, sformat, (%))
+import           Formatting (build, sformat)
 
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -48,8 +48,8 @@ genLocalSlotIndex epochSlots = mkLocalSlotIndex'
   lb = getSlotIndex localSlotIndexMinBound
   ub = getSlotIndex (localSlotIndexMaxBound epochSlots)
   mkLocalSlotIndex' slot = case mkLocalSlotIndex epochSlots slot of
-    Left err -> error $ sformat
-      ("The impossible happened in genLocalSlotIndex: " % build)
+    Left err -> panic $ sformat
+      ("The impossible happened in genLocalSlotIndex: " . build)
       err
     Right lsi -> lsi
 

--- a/test/Test/Cardano/Chain/Txp/Gen.hs
+++ b/test/Test/Cardano/Chain/Txp/Gen.hs
@@ -73,9 +73,9 @@ genTxHash :: Gen (Hash Tx)
 genTxHash = coerce <$> genTextHash
 
 genTxId :: Gen TxId
-genTxId = genBase16Text >>= pure . decodeHash >>= either error pure
+genTxId = genBase16Text >>= pure . decodeHash >>= either panic pure
     where
-        genBase16Text = decodeUtf8 @Text @ByteString <$> genBase16Bs
+        genBase16Text = decodeUtf8 <$> genBase16Bs
 
 genBase16Bs :: Gen ByteString
 genBase16Bs = B16.encode <$> genBytes 32


### PR DESCRIPTION
Remove `Universum`, replacing it with `protolude`. `Universum` was originally based on `protolude`, but grew a lot bigger. We'd prefer to have something smaller and more localised to the project.