### PR TITLE
Buildkite fixes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,12 +4,13 @@ steps:
       AWS_REGION: us-west-1
       S3_BUCKET: appveyor-ci-cache
       CACHE_S3_MAX_SIZE: 2500MB
+      STACK_ROOT: "/build/cardano-chain.stack"
     command:
       # cache-s3 needs a build directory that is the same across all buildkite agents.
-      # so copy the source into /build/cardano-sl
-      - "rm -rf /build/cardano-sl"
-      - "cp -R . /build/cardano-sl"
-      - "cd /build/cardano-sl"
+      # so copy the source into /build/cardano-chain
+      - "rm -rf /build/cardano-chain"
+      - "cp -R . /build/cardano-chain"
+      - "cd /build/cardano-chain"
       - "nix-build scripts/buildkite -o stack-rebuild"
       - "./stack-rebuild"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ steps:
       # cache-s3 needs a build directory that is the same across all buildkite agents.
       # so copy the source into /build/cardano-sl
       - "rm -rf /build/cardano-sl"
-      - "git clone . /build/cardano-sl"
+      - "cp -R . /build/cardano-sl"
       - "cd /build/cardano-sl"
       - "nix-build scripts/buildkite -o stack-rebuild"
       - "./stack-rebuild"

--- a/scripts/buildkite/rebuild.hs
+++ b/scripts/buildkite/rebuild.hs
@@ -95,12 +95,12 @@ cacheUploadStep cacheConfig = do
 
 restoreCICache :: CICacheConfig -> IO ()
 restoreCICache cfg = do
-  cacheS3 cfg (Just "develop") "restore stack"
+  -- cacheS3 cfg (Just "develop") "restore stack"
   cacheS3 cfg (Just "develop") "restore stack work"
 
 saveCICache :: CICacheConfig -> IO ()
 saveCICache cfg = do
-  cacheS3 cfg Nothing "save stack"
+  -- cacheS3 cfg Nothing "save stack"
   cacheS3 cfg Nothing "save stack work"
 
 cacheS3 :: CICacheConfig -> Maybe Text -> Text -> IO ()

--- a/scripts/nix/stack-shell.nix
+++ b/scripts/nix/stack-shell.nix
@@ -7,5 +7,5 @@ with pkgs;
 
 haskell.lib.buildStackProject {
   name = "cardano-chain-env";
-  buildInputs = [ zlib openssl ];
+  buildInputs = [ zlib openssl git ];
 }


### PR DESCRIPTION
These changes let it build on Buildkite (apart from compile warnings received when running `stack build`).
It also required adding git-lfs to the buildkite-agent's build environment.
