### PR TITLE
[#56] Use base-noprelude with cardano-prelude

### DIFF
--- a/binary/cardano-binary.cabal
+++ b/binary/cardano-binary.cabal
@@ -29,7 +29,7 @@ library
                        Cardano.Binary.Class.Drop
                        Cardano.Binary.Class.Primitive
 
-  build-depends:       base
+  build-depends:       base-noprelude
                      , bytestring
                      , cardano-prelude
                      , cborg
@@ -46,9 +46,9 @@ library
                      , vector
 
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
 
   ghc-options:         -Weverything
+                       -fno-warn-implicit-prelude
                        -fno-warn-missing-import-lists
                        -fno-warn-unsafe
                        -fno-warn-safe
@@ -70,7 +70,7 @@ test-suite test
                        Test.Cardano.Cbor.RefImpl
                        Test.Cardano.Cbor.Canonicity
 
-  build-depends:       base
+  build-depends:       base-noprelude
                      , bytestring
                      , cardano-binary
                      , cardano-prelude
@@ -90,9 +90,9 @@ test-suite test
                      , text
 
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
 
   ghc-options:         -Weverything
+                       -fno-warn-implicit-prelude
                        -fno-warn-missing-import-lists
                        -fno-warn-unsafe
                        -fno-warn-safe

--- a/binary/src/Cardano/Binary/Class/Core.hs
+++ b/binary/src/Cardano/Binary/Class/Core.hs
@@ -63,8 +63,6 @@ module Cardano.Binary.Class.Core
     , szBounds
     ) where
 
-import           Cardano.Prelude
-
 import qualified Codec.CBOR.Decoding as D
 import qualified Codec.CBOR.Encoding as E
 import qualified Codec.CBOR.Read as CBOR.Read

--- a/binary/src/Cardano/Binary/Class/Drop.hs
+++ b/binary/src/Cardano/Binary/Class/Drop.hs
@@ -17,8 +17,6 @@ module Cardano.Binary.Class.Drop
        , dropWord64
        ) where
 
-import           Cardano.Prelude
-
 import qualified Codec.CBOR.Decoding as D
 
 
@@ -34,7 +32,7 @@ dropInt32 = void D.decodeInt32Canonical
 dropList :: Dropper s -> Dropper s
 dropList dropElems = do
   D.decodeListLenIndef
-  D.decodeSequenceLenIndef const () id dropElems
+  D.decodeSequenceLenIndef const () identity dropElems
 
 dropMap :: Dropper s -> Dropper s -> Dropper s
 dropMap dropKey dropValue = do

--- a/binary/src/Cardano/Binary/Class/Primitive.hs
+++ b/binary/src/Cardano/Binary/Class/Primitive.hs
@@ -48,8 +48,6 @@ module Cardano.Binary.Class.Primitive
        , decodeCrcProtected
        ) where
 
-import           Cardano.Prelude
-
 import qualified Codec.CBOR.Decoding as D
 import qualified Codec.CBOR.Encoding as E
 import qualified Codec.CBOR.Read as Read

--- a/binary/src/Cardano/Binary/Limit.hs
+++ b/binary/src/Cardano/Binary/Limit.hs
@@ -12,8 +12,6 @@ module Cardano.Binary.Limit
        , vectorOfNE
        ) where
 
-import           Cardano.Prelude
-
 
 -- | A limit on the length of something (in bytes).
 --   TODO should check for overflow in the Num instance.

--- a/binary/stack.yaml
+++ b/binary/stack.yaml
@@ -6,7 +6,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: d3a3dfc451725cc3e17f47677739ba3dc7d9bbee
+    commit: 339d7384c263a234ff553fe731bed2d7091c9e10
     subdirs:
       - .
       - test

--- a/binary/test/Test/Cardano/Binary/BiSizeBounds.hs
+++ b/binary/test/Test/Cardano/Binary/BiSizeBounds.hs
@@ -5,8 +5,6 @@ module Test.Cardano.Binary.BiSizeBounds
     ( tests
     ) where
 
-import           Cardano.Prelude
-
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map as M

--- a/binary/test/Test/Cardano/Binary/Cbor/CborSpec.hs
+++ b/binary/test/Test/Cardano/Binary/Cbor/CborSpec.hs
@@ -17,8 +17,6 @@ module Test.Cardano.Binary.Cbor.CborSpec
        , extensionProperty
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Bits (shiftL)
 import qualified Data.ByteString as BS
 import           Data.Fixed (Nano)

--- a/binary/test/Test/Cardano/Binary/Helpers.hs
+++ b/binary/test/Test/Cardano/Binary/Helpers.hs
@@ -35,7 +35,6 @@ module Test.Cardano.Binary.Helpers
        , sizeTest
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Codec.CBOR.FlatTerm (toFlatTerm, validFlatTerm)
@@ -51,13 +50,13 @@ import           Formatting (Buildable, bprint, build, formatToString, int)
 import           Hedgehog (annotate, failure, forAllWith, success)
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as HH.Gen
-import           Prelude (read)
 import           Test.Hspec (Spec, describe)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
 import           Test.QuickCheck (Arbitrary (arbitrary), Gen, Property, choose,
                      conjoin, counterexample, forAll, property, resize,
                      suchThat, vectorOf, (.&&.), (===))
 import           Test.QuickCheck.Instances ()
+import           Text.Read (read)
 
 import           Cardano.Binary.Class (Bi (..), DecoderError (..), Range (..),
                      Size, SizeOverride (..), decodeFull,

--- a/binary/test/Test/Cardano/Binary/Helpers/GoldenRoundTrip.hs
+++ b/binary/test/Test/Cardano/Binary/Helpers/GoldenRoundTrip.hs
@@ -10,12 +10,12 @@ module Test.Cardano.Binary.Helpers.GoldenRoundTrip
        , legacyGoldenDecode
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import qualified Codec.CBOR.Decoding as D
 import           Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Lazy.Char8 as BS
+import           Data.String (unlines)
 import           Formatting.Buildable (Buildable (..))
 import           Hedgehog (MonadTest, Property, eval, property, success,
                      tripping, withTests, (===))
@@ -25,7 +25,6 @@ import           Hedgehog.Internal.Show (LineDiff, lineDiff, mkValue,
 
 import           Cardano.Binary.Class (Bi (..), decodeFull, decodeFullDecoder,
                      serialize)
-import qualified Prelude
 import           Text.Show.Pretty (Value (..))
 
 
@@ -34,7 +33,7 @@ type HexDump = LByteString
 type HexDumpDiff = [LineDiff]
 
 renderHexDumpDiff :: HexDumpDiff -> [Char]
-renderHexDumpDiff = Prelude.unlines . fmap renderLineDiff
+renderHexDumpDiff = unlines . fmap renderLineDiff
 
 -- | Diff two 'HexDump's by comparing lines pairwise
 hexDumpDiff :: HexDump -> HexDump -> Maybe HexDumpDiff
@@ -61,7 +60,7 @@ compareHexDump x y = do
 -- | Fail with a nice line diff of the two HexDumps
 failHexDumpDiff :: (MonadTest m, HasCallStack) => HexDump -> HexDump -> m ()
 failHexDumpDiff x y = case hexDumpDiff x y of
-  Nothing -> withFrozenCallStack $ failWith Nothing $ Prelude.unlines
+  Nothing -> withFrozenCallStack $ failWith Nothing $ unlines
     ["━━━ Not Equal ━━━", showPretty x, showPretty y]
   Just dif -> withFrozenCallStack $ failWith Nothing $ renderHexDumpDiff dif
 

--- a/binary/test/Test/Cardano/Cbor/Canonicity.hs
+++ b/binary/test/Test/Cardano/Cbor/Canonicity.hs
@@ -7,8 +7,6 @@ module Test.Cardano.Cbor.Canonicity
     ( perturbCanonicity
     ) where
 
-import           Cardano.Prelude
-
 import qualified Control.Monad.State as S
 import           GHC.Float (RealFloat (..))
 import           Numeric.Half (Half (..))

--- a/binary/test/Test/Cardano/Cbor/RefImpl.hs
+++ b/binary/test/Test/Cardano/Cbor/RefImpl.hs
@@ -33,8 +33,6 @@ module Test.Cardano.Cbor.RefImpl
     , prop_halfToFromFloat
     ) where
 
-import           Cardano.Prelude
-
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import           Data.List (span)

--- a/binary/test/cardano-binary-test.cabal
+++ b/binary/test/cardano-binary-test.cabal
@@ -23,7 +23,7 @@ library
                        Test.Cardano.Cbor.Canonicity
                        Test.Cardano.Cbor.RefImpl
 
-  build-depends:       base
+  build-depends:       base-noprelude
                      , bytestring
                      , cardano-binary
                      , cardano-prelude
@@ -43,9 +43,9 @@ library
                      , text
 
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
 
   ghc-options:         -Weverything
+                       -fno-warn-implicit-prelude
                        -fno-warn-missing-import-lists
                        -fno-warn-unsafe
                        -fno-warn-safe

--- a/binary/test/test.hs
+++ b/binary/test/test.hs
@@ -1,4 +1,3 @@
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Test.Hspec (hspec)

--- a/cardano-chain.cabal
+++ b/cardano-chain.cabal
@@ -89,7 +89,7 @@ library
                        Cardano.Chain.Update.Undo
                        Cardano.Chain.Update.Vote
 
-  build-depends:       base >=4.11 && <4.12
+  build-depends:       base-noprelude
                      , aeson
                      , aeson-options
                      , base16-bytestring
@@ -121,7 +121,6 @@ library
                      , vector
 
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
 
   ghc-options:         -Wall
                        -Werror
@@ -151,7 +150,7 @@ test-suite test
                        Test.Cardano.Chain.Update.Gen
                        Test.Cardano.Chain.Update.Json
 
-  build-depends:       base
+  build-depends:       base-noprelude
                      , base16-bytestring
                      , bytestring
                      , cardano-binary
@@ -172,7 +171,6 @@ test-suite test
                      , vector
 
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
 
   ghc-options:         -Wall
                        -Werror

--- a/crypto/cardano-crypto-wrapper.cabal
+++ b/crypto/cardano-crypto-wrapper.cabal
@@ -43,7 +43,7 @@ library
                        Cardano.Crypto.Signing.Types.Signing
                        Cardano.Crypto.Signing.Types.Tag
 
-  build-depends:       base
+  build-depends:       base-noprelude
                      , aeson
                      , base64-bytestring
                      , base64-bytestring-type
@@ -66,9 +66,9 @@ library
                      , text
 
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
 
   ghc-options:         -Weverything
+                       -fno-warn-implicit-prelude
                        -fno-warn-missing-import-lists
                        -fno-warn-unsafe
                        -fno-warn-safe
@@ -92,7 +92,7 @@ test-suite test
                        Test.Cardano.Crypto.Dummy
                        Test.Cardano.Crypto.Gen
 
-  build-depends:       base
+  build-depends:       base-noprelude
                      , bytestring
                      , cardano-binary
                      , cardano-binary-test
@@ -112,9 +112,9 @@ test-suite test
                      , text
 
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
 
   ghc-options:         -Weverything
+                       -fno-warn-implicit-prelude
                        -fno-warn-missing-import-lists
                        -fno-warn-unsafe
                        -fno-warn-safe

--- a/crypto/src/Cardano/Crypto/HD.hs
+++ b/crypto/src/Cardano/Crypto/HD.hs
@@ -26,8 +26,6 @@ module Cardano.Crypto.HD
        , isHardened
        ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Crypto.Wallet (DerivationScheme (..), deriveXPrv,
                      deriveXPub, unXPub)
 import qualified Crypto.Cipher.ChaChaPoly1305 as C

--- a/crypto/src/Cardano/Crypto/Hashing.hs
+++ b/crypto/src/Cardano/Crypto/Hashing.hs
@@ -33,9 +33,6 @@ module Cardano.Crypto.Hashing
        , hashDigestSize'
        ) where
 
-import           Cardano.Prelude
-import qualified Prelude
-
 import           Crypto.Hash (Blake2b_256, Digest, HashAlgorithm,
                      hashDigestSize)
 import qualified Crypto.Hash as Hash
@@ -48,6 +45,7 @@ import qualified Data.ByteString.Lazy as LBS
 import           Formatting (Format, bprint, build, fitLeft, later, sformat,
                      (%.))
 import qualified Formatting.Buildable as B (Buildable (..))
+import           Text.Read (Read (readsPrec))
 
 import           Cardano.Binary.Class (Bi (..), DecoderError (..), Raw,
                      withWordSize)

--- a/crypto/src/Cardano/Crypto/Limits.hs
+++ b/crypto/src/Cardano/Crypto/Limits.hs
@@ -8,8 +8,6 @@ module Cardano.Crypto.Limits
        , mlSignature
        ) where
 
-import           Cardano.Prelude
-
 import qualified Cardano.Crypto.Wallet as CC
 import           Crypto.Hash.IO (HashAlgorithm, hashDigestSize)
 

--- a/crypto/src/Cardano/Crypto/Orphans.hs
+++ b/crypto/src/Cardano/Crypto/Orphans.hs
@@ -6,8 +6,6 @@ module Cardano.Crypto.Orphans
        (
        ) where
 
-import           Cardano.Prelude
-
 import qualified Codec.CBOR.Encoding as E
 import           Crypto.Error (CryptoFailable (..))
 import qualified Crypto.PubKey.Ed25519 as Ed25519

--- a/crypto/src/Cardano/Crypto/ProtocolMagic.hs
+++ b/crypto/src/Cardano/Crypto/ProtocolMagic.hs
@@ -5,8 +5,6 @@ module Cardano.Crypto.ProtocolMagic
        ( ProtocolMagic (..)
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson (FromJSON (..), ToJSON (..))
 
 -- | Magic number which should differ for different clusters. It's

--- a/crypto/src/Cardano/Crypto/Random.hs
+++ b/crypto/src/Cardano/Crypto/Random.hs
@@ -14,8 +14,6 @@ module Cardano.Crypto.Random
        , randomNumberInRange
        ) where
 
-import           Cardano.Prelude
-
 import           Crypto.Number.Basic (numBytes)
 import           Crypto.Number.Serialize (os2ip)
 import           Crypto.OpenSSL.Random (randBytes)

--- a/crypto/src/Cardano/Crypto/Scrypt.hs
+++ b/crypto/src/Cardano/Crypto/Scrypt.hs
@@ -25,8 +25,6 @@ module Cardano.Crypto.Scrypt
        , verifyPass
        ) where
 
-import           Cardano.Prelude
-
 import           Crypto.Random (MonadRandom, getRandomBytes)
 import qualified Crypto.Scrypt as S
 import           Data.Default (Default (..))

--- a/crypto/src/Cardano/Crypto/Signing/Check.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Check.hs
@@ -16,8 +16,6 @@ module Cardano.Crypto.Signing.Check
        , validateProxySignature
        ) where
 
-import           Cardano.Prelude
-
 import qualified Cardano.Crypto.Wallet as CC
 import           Control.Monad.Except (MonadError, throwError)
 import           Data.Coerce (coerce)

--- a/crypto/src/Cardano/Crypto/Signing/Redeem.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Redeem.hs
@@ -6,8 +6,6 @@ module Cardano.Crypto.Signing.Redeem
        , module Cardano.Crypto.Signing.Types.Redeem
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad (fail)
 import           Crypto.Error (maybeCryptoError)
 import qualified Crypto.PubKey.Ed25519 as Ed25519

--- a/crypto/src/Cardano/Crypto/Signing/Safe.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Safe.hs
@@ -19,8 +19,6 @@ module Cardano.Crypto.Signing.Safe
        , module Cardano.Crypto.Signing.Types.Safe
        ) where
 
-import           Cardano.Prelude
-
 import qualified Cardano.Crypto.Wallet as CC
 import           Crypto.Random (MonadRandom, getRandomBytes)
 import qualified Data.ByteString as BS

--- a/crypto/src/Cardano/Crypto/Signing/Signing.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Signing.hs
@@ -28,8 +28,6 @@ module Cardano.Crypto.Signing.Signing
        , module Cardano.Crypto.Signing.Types.Signing
        ) where
 
-import           Cardano.Prelude
-
 import qualified Cardano.Crypto.Wallet as CC
 import           Crypto.Random (MonadRandom, getRandomBytes)
 import           Data.ByteArray (ScrubbedBytes)

--- a/crypto/src/Cardano/Crypto/Signing/Tag.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Tag.hs
@@ -6,8 +6,6 @@ module Cardano.Crypto.Signing.Tag
        , module Cardano.Crypto.Signing.Types.Tag
        ) where
 
-import           Cardano.Prelude
-
 import qualified Cardano.Binary.Class as Bi
 import           Cardano.Crypto.ProtocolMagic (ProtocolMagic (..))
 import           Cardano.Crypto.Signing.Types.Tag

--- a/crypto/src/Cardano/Crypto/Signing/Types/Redeem.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Types/Redeem.hs
@@ -21,8 +21,6 @@ module Cardano.Crypto.Signing.Types.Redeem
        , redeemToPublic
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError)
 import           Crypto.Error (CryptoFailable (..))
 import qualified Crypto.PubKey.Ed25519 as Ed25519

--- a/crypto/src/Cardano/Crypto/Signing/Types/Safe.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Types/Safe.hs
@@ -22,7 +22,6 @@ module Cardano.Crypto.Signing.Types.Safe
        ) where
 
 import qualified Cardano.Crypto.Wallet as CC
-import           Cardano.Prelude
 import           Crypto.Random (MonadRandom)
 import           Data.ByteArray (ByteArray, ByteArrayAccess, ScrubbedBytes)
 import qualified Data.ByteArray as ByteArray
@@ -31,7 +30,7 @@ import           Data.Default (Default (..))
 import           Data.Semigroup (Semigroup)
 import           Formatting (int, sformat)
 import           Formatting.Buildable (Buildable (..))
-import qualified Prelude
+import qualified Text.Show
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
 import qualified Cardano.Crypto.Scrypt as S

--- a/crypto/src/Cardano/Crypto/Signing/Types/Signing.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Types/Signing.hs
@@ -44,8 +44,6 @@ module Cardano.Crypto.Signing.Types.Signing
        , isSelfSignedPsk
        ) where
 
-import           Cardano.Prelude hiding (show)
-
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Codec.CBOR.Decoding as D
 import qualified Codec.CBOR.Encoding as E
@@ -59,9 +57,9 @@ import qualified Data.Text.Lazy.Builder as Builder
 import           Formatting (Format, bprint, build, fitLeft, formatToString,
                      later, sformat, (%.))
 import qualified Formatting.Buildable as B
-import           Prelude (show)
 import           Text.JSON.Canonical (JSValue (..))
 import qualified Text.JSON.Canonical as TJC (FromJSON (..), ToJSON (..))
+import qualified Text.Show
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
 import           Cardano.Crypto.Hashing (hash)

--- a/crypto/src/Cardano/Crypto/Signing/Types/Tag.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Types/Tag.hs
@@ -4,8 +4,6 @@ module Cardano.Crypto.Signing.Types.Tag
        ( SignTag(..)
        ) where
 
-import           Cardano.Prelude
-
 import           Formatting (bprint, shown)
 import           Formatting.Buildable (Buildable (..))
 

--- a/crypto/stack.yaml
+++ b/crypto/stack.yaml
@@ -6,7 +6,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: d3a3dfc451725cc3e17f47677739ba3dc7d9bbee
+    commit: 339d7384c263a234ff553fe731bed2d7091c9e10
     subdirs:
       - .
       - test

--- a/crypto/test/Test/Cardano/Crypto/Arbitrary.hs
+++ b/crypto/test/Test/Cardano/Crypto/Arbitrary.hs
@@ -15,7 +15,6 @@ module Test.Cardano.Crypto.Arbitrary
        , genRedeemSignature
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import qualified Data.ByteArray as ByteArray

--- a/crypto/test/Test/Cardano/Crypto/Arbitrary/Unsafe.hs
+++ b/crypto/test/Test/Cardano/Crypto/Arbitrary/Unsafe.hs
@@ -8,7 +8,6 @@
 
 module Test.Cardano.Crypto.Arbitrary.Unsafe () where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Data.Coerce (coerce)

--- a/crypto/test/Test/Cardano/Crypto/Bi.hs
+++ b/crypto/test/Test/Cardano/Crypto/Bi.hs
@@ -12,7 +12,6 @@ module Test.Cardano.Crypto.Bi
     , tests
     ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Cardano.Crypto.Wallet (XPrv, unXPrv, xprv, xpub)

--- a/crypto/test/Test/Cardano/Crypto/CborSpec.hs
+++ b/crypto/test/Test/Cardano/Crypto/CborSpec.hs
@@ -11,8 +11,6 @@ module Test.Cardano.Crypto.CborSpec
        ( spec
        ) where
 
-import           Cardano.Prelude
-
 import           Crypto.Hash (Blake2b_224, Blake2b_256)
 import           Test.Hspec (Spec, describe)
 

--- a/crypto/test/Test/Cardano/Crypto/CryptoSpec.hs
+++ b/crypto/test/Test/Cardano/Crypto/CryptoSpec.hs
@@ -7,8 +7,6 @@ module Test.Cardano.Crypto.CryptoSpec
        ( spec
        ) where
 
-import           Cardano.Prelude
-
 import qualified Data.ByteString as BS
 import           Formatting (sformat)
 

--- a/crypto/test/Test/Cardano/Crypto/CryptoSpec2.hs
+++ b/crypto/test/Test/Cardano/Crypto/CryptoSpec2.hs
@@ -9,7 +9,6 @@ module Test.Cardano.Crypto.CryptoSpec2
        ( spec
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Crypto.Hash (Blake2b_224, Blake2b_256)

--- a/crypto/test/Test/Cardano/Crypto/Example.hs
+++ b/crypto/test/Test/Cardano/Crypto/Example.hs
@@ -10,8 +10,6 @@ module Test.Cardano.Crypto.Example
        , staticSafeSigners
        ) where
 
-import           Cardano.Prelude
-
 import qualified Cardano.Crypto.Wallet as CC
 import           Data.List ((!!))
 import           Data.Maybe (fromJust)

--- a/crypto/test/Test/Cardano/Crypto/Gen.hs
+++ b/crypto/test/Test/Cardano/Crypto/Gen.hs
@@ -48,7 +48,6 @@ module Test.Cardano.Crypto.Gen
         , feedPM
         ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import qualified Data.ByteArray as ByteArray

--- a/crypto/test/cardano-crypto-test.cabal
+++ b/crypto/test/cardano-crypto-test.cabal
@@ -27,7 +27,7 @@ library
   other-modules:
                        Test.Cardano.Crypto.Arbitrary.Unsafe
 
-  build-depends:       base
+  build-depends:       base-noprelude
                      , bytestring
                      , cardano-binary
                      , cardano-binary-test
@@ -43,9 +43,9 @@ library
                      , quickcheck-instances
 
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
 
   ghc-options:         -Weverything
+                       -fno-warn-implicit-prelude
                        -fno-warn-missing-import-lists
                        -fno-warn-unsafe
                        -fno-warn-safe

--- a/crypto/test/test.hs
+++ b/crypto/test/test.hs
@@ -1,4 +1,3 @@
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Test.Hspec (hspec)

--- a/src/Cardano/Chain/Block/Block.hs
+++ b/src/Cardano/Chain/Block/Block.hs
@@ -36,8 +36,6 @@ module Cardano.Chain.Block.Block
        , dropBoundaryBlock
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (..))
 import           Formatting (bprint, build, int, shown)
 import qualified Formatting.Buildable as B

--- a/src/Cardano/Chain/Block/Body.hs
+++ b/src/Cardano/Chain/Block/Body.hs
@@ -12,8 +12,6 @@ module Cardano.Chain.Block.Body
        , verifyBody
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (..))
 import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B

--- a/src/Cardano/Chain/Block/ExtraBodyData.hs
+++ b/src/Cardano/Chain/Block/ExtraBodyData.hs
@@ -7,8 +7,6 @@ module Cardano.Chain.Block.ExtraBodyData
        ( ExtraBodyData (..)
        ) where
 
-import           Cardano.Prelude
-
 import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 

--- a/src/Cardano/Chain/Block/ExtraHeaderData.hs
+++ b/src/Cardano/Chain/Block/ExtraHeaderData.hs
@@ -11,8 +11,6 @@ module Cardano.Chain.Block.ExtraHeaderData
        , verifyExtraHeaderData
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (..))
 import           Formatting (bprint, build, builder)
 import qualified Formatting.Buildable as B

--- a/src/Cardano/Chain/Block/Header.hs
+++ b/src/Cardano/Chain/Block/Header.hs
@@ -40,8 +40,6 @@ module Cardano.Chain.Block.Header
        , verifyConsensusData
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (..))
 import           Formatting (Format, bprint, build, int)
 import qualified Formatting.Buildable as B

--- a/src/Cardano/Chain/Block/Proof.hs
+++ b/src/Cardano/Chain/Block/Proof.hs
@@ -12,8 +12,6 @@ module Cardano.Chain.Block.Proof
        , checkProof
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (..))
 import           Formatting (bprint, build, shown)
 import qualified Formatting.Buildable as B

--- a/src/Cardano/Chain/Block/SlogUndo.hs
+++ b/src/Cardano/Chain/Block/SlogUndo.hs
@@ -8,8 +8,6 @@ module Cardano.Chain.Block.SlogUndo
        , buildSlogUndo
        ) where
 
-import           Cardano.Prelude
-
 import           Formatting (Format, bprint, later)
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)

--- a/src/Cardano/Chain/Block/Undo.hs
+++ b/src/Cardano/Chain/Block/Undo.hs
@@ -9,8 +9,6 @@ module Cardano.Chain.Block.Undo
        , Blund
        ) where
 
-import           Cardano.Prelude
-
 import           Formatting (Format, bprint, build, later)
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)

--- a/src/Cardano/Chain/Common/AddrAttributes.hs
+++ b/src/Cardano/Chain/Common/AddrAttributes.hs
@@ -6,8 +6,6 @@ module Cardano.Chain.Common.AddrAttributes
        ( AddrAttributes (..)
        ) where
 
-import           Cardano.Prelude
-
 import qualified Data.ByteString.Lazy as LBS
 import           Formatting (bprint, build, builder)
 import qualified Formatting.Buildable as B

--- a/src/Cardano/Chain/Common/AddrSpendingData.hs
+++ b/src/Cardano/Chain/Common/AddrSpendingData.hs
@@ -9,8 +9,6 @@ module Cardano.Chain.Common.AddrSpendingData
        , addrSpendingDataToType
        ) where
 
-import           Cardano.Prelude
-
 import qualified Data.ByteString.Lazy as LBS
 import           Formatting (bprint, build, int)
 import qualified Formatting.Buildable as B

--- a/src/Cardano/Chain/Common/AddrStakeDistribution.hs
+++ b/src/Cardano/Chain/Common/AddrStakeDistribution.hs
@@ -11,8 +11,6 @@ module Cardano.Chain.Common.AddrStakeDistribution
        , MultiKeyDistrError (..)
        ) where
 
-import           Cardano.Prelude hiding (id)
-
 import           Control.Monad.Except (MonadError (..))
 import           Formatting (bprint, build, sformat)
 import qualified Formatting.Buildable as B (Buildable (..))

--- a/src/Cardano/Chain/Common/Address.hs
+++ b/src/Cardano/Chain/Common/Address.hs
@@ -66,8 +66,6 @@ module Cardano.Chain.Common.Address
 
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Lens (makePrisms)
 import           Control.Monad.Except (MonadError)
 import qualified Data.Aeson as Aeson (FromJSON (..), FromJSONKey (..),

--- a/src/Cardano/Chain/Common/AddressHash.hs
+++ b/src/Cardano/Chain/Common/AddressHash.hs
@@ -4,8 +4,6 @@ module Cardano.Chain.Common.AddressHash
        , unsafeAddressHash
        ) where
 
-import           Cardano.Prelude
-
 import           Crypto.Hash (Blake2b_224, Digest, SHA3_256)
 import qualified Crypto.Hash as CryptoHash
 

--- a/src/Cardano/Chain/Common/Attributes.hs
+++ b/src/Cardano/Chain/Common/Attributes.hs
@@ -22,9 +22,6 @@ module Cardano.Chain.Common.Attributes
        , dropAttributes
        ) where
 
-import           Cardano.Prelude
-import qualified Prelude
-
 import           Data.Aeson (FromJSON (..), ToJSON (..))
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Data.ByteString.Base64.Type (getByteString64, makeByteString64)
@@ -33,6 +30,7 @@ import qualified Data.Map as M
 import           Formatting (bprint, build, int)
 import           Formatting.Buildable (Buildable)
 import qualified Formatting.Buildable as Buildable
+import qualified Text.Show
 
 import           Cardano.Binary.Class (Bi (..), Decoder, Dropper, Encoding,
                      dropBytes, dropMap, dropWord8)

--- a/src/Cardano/Chain/Common/BlockCount.hs
+++ b/src/Cardano/Chain/Common/BlockCount.hs
@@ -6,8 +6,6 @@ module Cardano.Chain.Common.BlockCount
        ( BlockCount (..)
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Formatting.Buildable (Buildable)
 

--- a/src/Cardano/Chain/Common/ChainDifficulty.hs
+++ b/src/Cardano/Chain/Common/ChainDifficulty.hs
@@ -8,8 +8,6 @@ module Cardano.Chain.Common.ChainDifficulty
        , dropChainDifficulty
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Formatting.Buildable (Buildable)
 

--- a/src/Cardano/Chain/Common/Coeff.hs
+++ b/src/Cardano/Chain/Common/Coeff.hs
@@ -11,8 +11,6 @@ module Cardano.Chain.Common.Coeff
        ( Coeff (..)
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError)
 import qualified Data.Aeson as Aeson
 import           Data.Fixed (Fixed (..), Nano, resolution, showFixed)

--- a/src/Cardano/Chain/Common/Coin.hs
+++ b/src/Cardano/Chain/Common/Coin.hs
@@ -37,8 +37,6 @@ module Cardano.Chain.Common.Coin
        , divCoin
        ) where
 
-import           Cardano.Prelude
-
 import qualified Data.Aeson as Aeson (FromJSON (..), ToJSON (..))
 import           Data.Data (Data)
 import           Formatting (Format, bprint, build, int)

--- a/src/Cardano/Chain/Common/CoinPortion.hs
+++ b/src/Cardano/Chain/Common/CoinPortion.hs
@@ -19,8 +19,6 @@ module Cardano.Chain.Common.CoinPortion
        , applyCoinPortionUp
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (..))
 import qualified Data.Aeson as Aeson (FromJSON (..), ToJSON (..))
 import           Formatting (bprint, build, float, int, sformat)

--- a/src/Cardano/Chain/Common/Merkle.hs
+++ b/src/Cardano/Chain/Common/Merkle.hs
@@ -25,8 +25,6 @@ module Cardano.Chain.Common.Merkle
 -- but HLint insists that this is not OK because toList and foldMap are never
 -- used unqualified. The hiding in fact makes it clearer for the human reader
 -- what's going on.
-import           Cardano.Prelude
-
 import           Data.Bits (Bits (..))
 import           Data.ByteArray (ByteArrayAccess, convert)
 import           Data.ByteString.Builder (Builder, byteString, word8)
@@ -35,7 +33,7 @@ import qualified Data.ByteString.Lazy as LBS
 import           Data.Coerce (coerce)
 import qualified Data.Foldable as Foldable
 import           Formatting.Buildable (Buildable (..))
-import qualified Prelude
+import qualified Text.Show
 
 import           Cardano.Binary.Class (Bi (..), Raw, serializeBuilder)
 import           Cardano.Crypto (AbstractHash (..), Hash, hashRaw)

--- a/src/Cardano/Chain/Common/Script.hs
+++ b/src/Cardano/Chain/Common/Script.hs
@@ -9,8 +9,6 @@ module Cardano.Chain.Common.Script
        , Script_v0
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson (FromJSON (..), ToJSON (toJSON), object, withObject,
                      (.:), (.=))
 import           Data.ByteString.Base64.Type (getByteString64, makeByteString64)

--- a/src/Cardano/Chain/Common/StakeholderId.hs
+++ b/src/Cardano/Chain/Common/StakeholderId.hs
@@ -11,8 +11,6 @@ module Cardano.Chain.Common.StakeholderId
        , shortStakeholderF
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError)
 import           Data.Aeson (FromJSONKey, ToJSONKey)
 import           Formatting (Format, formatToString, mapf)

--- a/src/Cardano/Chain/Common/TxFeePolicy.hs
+++ b/src/Cardano/Chain/Common/TxFeePolicy.hs
@@ -13,8 +13,6 @@ module Cardano.Chain.Common.TxFeePolicy
        ( TxFeePolicy (..)
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError)
 import           Data.Aeson (object, (.:?), (.=))
 import qualified Data.Aeson as Aeson

--- a/src/Cardano/Chain/Common/TxSizeLinear.hs
+++ b/src/Cardano/Chain/Common/TxSizeLinear.hs
@@ -9,8 +9,6 @@ module Cardano.Chain.Common.TxSizeLinear
        , calculateTxSizeLinear
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson (object, (.=))
 import qualified Data.Aeson as Aeson
 import           Data.Fixed (Nano)

--- a/src/Cardano/Chain/Constants.hs
+++ b/src/Cardano/Chain/Constants.hs
@@ -7,8 +7,6 @@ module Cardano.Chain.Constants
        , wAddressGenesisIndex
        ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Crypto.HD (firstHardened)
 
 -- | First index in derivation path for HD account, which is put to genesis utxo

--- a/src/Cardano/Chain/Delegation/HeavyDlgIndex.hs
+++ b/src/Cardano/Chain/Delegation/HeavyDlgIndex.hs
@@ -13,8 +13,6 @@ module Cardano.Chain.Delegation.HeavyDlgIndex
        , ProxySKBlockInfo
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError)
 import qualified Data.Aeson as Aeson (FromJSON (..), ToJSON (..))
 import           Formatting (bprint, build)

--- a/src/Cardano/Chain/Delegation/LightDlgIndices.hs
+++ b/src/Cardano/Chain/Delegation/LightDlgIndices.hs
@@ -9,8 +9,6 @@ module Cardano.Chain.Delegation.LightDlgIndices
        , ProxySKLight
        ) where
 
-import           Cardano.Prelude
-
 import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B (Buildable (..))
 

--- a/src/Cardano/Chain/Delegation/Payload.hs
+++ b/src/Cardano/Chain/Delegation/Payload.hs
@@ -10,8 +10,6 @@ module Cardano.Chain.Delegation.Payload
        , checkPayload
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (throwError))
 import           Formatting (bprint, int, stext)
 import           Formatting.Buildable (Buildable (..))

--- a/src/Cardano/Chain/Delegation/Undo.hs
+++ b/src/Cardano/Chain/Delegation/Undo.hs
@@ -10,8 +10,6 @@ module Cardano.Chain.Delegation.Undo
        , isRevokePsk
        ) where
 
-import           Cardano.Prelude
-
 import           Formatting (bprint)
 import           Formatting.Buildable (Buildable (..))
 

--- a/src/Cardano/Chain/Epoch/File.hs
+++ b/src/Cardano/Chain/Epoch/File.hs
@@ -26,8 +26,6 @@ import           Cardano.Binary.Class (DecoderError, decodeFull,
                      decodeFullDecoder)
 import           Cardano.Chain.Block.Block (Block, decodeBlock)
 import           Cardano.Chain.Block.Undo (Undo)
-import           Cardano.Prelude
-
 -- Epoch file format:
 --
 -- EpochFile := "Epoch data v1\n" *SlotData

--- a/src/Cardano/Chain/Epoch/Index.hs
+++ b/src/Cardano/Chain/Epoch/Index.hs
@@ -12,8 +12,6 @@ import qualified Data.ByteString.Lazy as LBS
 import           Data.Word (Word64)
 import           System.IO (IOMode (..), SeekMode (..), hSeek, withBinaryFile)
 
-import           Cardano.Prelude
-
 -- Index format:
 --
 -- EpochIndex := "Epoch Index v1\n\n" *Offset

--- a/src/Cardano/Chain/ProtocolConstants.hs
+++ b/src/Cardano/Chain/ProtocolConstants.hs
@@ -27,8 +27,6 @@ module Cardano.Chain.ProtocolConstants
        , kEpochSlots
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError)
 import qualified Data.Aeson as Aeson (FromJSON (..), ToJSON (..))
 import           Text.JSON.Canonical (FromJSON (..), ToJSON (..))

--- a/src/Cardano/Chain/Slotting/Data.hs
+++ b/src/Cardano/Chain/Slotting/Data.hs
@@ -24,8 +24,6 @@ module Cardano.Chain.Slotting.Data
        , computeSlotStart
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Map.Strict as M
 import           Data.Semigroup (Semigroup)
 import           Data.Time (NominalDiffTime, UTCTime, addUTCTime)

--- a/src/Cardano/Chain/Slotting/EpochIndex.hs
+++ b/src/Cardano/Chain/Slotting/EpochIndex.hs
@@ -12,8 +12,6 @@ module Cardano.Chain.Slotting.EpochIndex
        , isBootstrapEra
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError)
 import qualified Data.Aeson as Aeson (FromJSON (..), ToJSON (..))
 import           Data.Ix (Ix)

--- a/src/Cardano/Chain/Slotting/LocalSlotIndex.hs
+++ b/src/Cardano/Chain/Slotting/LocalSlotIndex.hs
@@ -23,8 +23,6 @@ module Cardano.Chain.Slotting.LocalSlotIndex
        , localSlotIndices
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (throwError))
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Data.Ix (Ix)

--- a/src/Cardano/Chain/Slotting/SlotCount.hs
+++ b/src/Cardano/Chain/Slotting/SlotCount.hs
@@ -6,8 +6,6 @@ module Cardano.Chain.Slotting.SlotCount
        ( SlotCount (..)
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson (ToJSON (..))
 import           Formatting.Buildable (Buildable)
 

--- a/src/Cardano/Chain/Slotting/SlotId.hs
+++ b/src/Cardano/Chain/Slotting/SlotId.hs
@@ -24,8 +24,6 @@ module Cardano.Chain.Slotting.SlotId
        , crucialSlot
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Lens (Iso', iso, makeLensesFor)
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Formatting (Format, bprint, build, ords, sformat)

--- a/src/Cardano/Chain/Ssc.hs
+++ b/src/Cardano/Chain/Ssc.hs
@@ -23,8 +23,6 @@ module Cardano.Chain.Ssc
        , dropVssCertificate
        ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Binary.Class (Bi (..), DecoderError (..), Dropper,
                      decodeListLenCanonical, dropBytes, dropList, dropMap,
                      dropSet, dropTriple, dropWord64, encodeListLen,

--- a/src/Cardano/Chain/Txp/Tx.hs
+++ b/src/Cardano/Chain/Txp/Tx.hs
@@ -21,8 +21,6 @@ module Cardano.Chain.Txp.Tx
        , _TxOut
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Lens (makeLenses, makePrisms)
 import           Data.Aeson (FromJSON (..), FromJSONKey (..),
                      FromJSONKeyFunction (..), ToJSON (toJSON), ToJSONKey (..),

--- a/src/Cardano/Chain/Txp/TxAux.hs
+++ b/src/Cardano/Chain/Txp/TxAux.hs
@@ -8,8 +8,6 @@ module Cardano.Chain.Txp.TxAux
        , txaF
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Formatting (Format, bprint, build, later)
 import qualified Formatting.Buildable as B

--- a/src/Cardano/Chain/Txp/TxOutAux.hs
+++ b/src/Cardano/Chain/Txp/TxOutAux.hs
@@ -6,8 +6,6 @@ module Cardano.Chain.Txp.TxOutAux
        ( TxOutAux (..)
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B

--- a/src/Cardano/Chain/Txp/TxPayload.hs
+++ b/src/Cardano/Chain/Txp/TxPayload.hs
@@ -10,8 +10,6 @@ module Cardano.Chain.Txp.TxPayload
        , txpWitnesses
        ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Binary.Class (Bi (..))
 import           Cardano.Chain.Txp.Tx (Tx)
 import           Cardano.Chain.Txp.TxAux (TxAux (..))

--- a/src/Cardano/Chain/Txp/TxProof.hs
+++ b/src/Cardano/Chain/Txp/TxProof.hs
@@ -6,8 +6,6 @@ module Cardano.Chain.Txp.TxProof
        , mkTxProof
        ) where
 
-import           Cardano.Prelude
-
 import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 

--- a/src/Cardano/Chain/Txp/TxWitness.hs
+++ b/src/Cardano/Chain/Txp/TxWitness.hs
@@ -12,8 +12,6 @@ module Cardano.Chain.Txp.TxWitness
        , TxSig
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson (FromJSON (..), ToJSON (toJSON), object, withObject,
                      (.:), (.=))
 import           Data.Aeson.TH (defaultOptions, deriveJSON)

--- a/src/Cardano/Chain/Txp/Undo.hs
+++ b/src/Cardano/Chain/Txp/Undo.hs
@@ -3,8 +3,6 @@ module Cardano.Chain.Txp.Undo
        , TxUndo
        ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Chain.Txp.TxOutAux
 
 

--- a/src/Cardano/Chain/Update/ApplicationName.hs
+++ b/src/Cardano/Chain/Update/ApplicationName.hs
@@ -12,8 +12,6 @@ module Cardano.Chain.Update.ApplicationName
        , checkApplicationName
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (throwError))
 import           Data.Aeson (FromJSON (..))
 import           Data.Aeson.TH (defaultOptions, deriveToJSON)

--- a/src/Cardano/Chain/Update/BlockVersion.hs
+++ b/src/Cardano/Chain/Update/BlockVersion.hs
@@ -8,12 +8,10 @@ module Cardano.Chain.Update.BlockVersion
        ( BlockVersion (..)
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Formatting (bprint, shown)
 import           Formatting.Buildable (Buildable (..))
-import qualified Prelude
+import qualified Text.Show
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
 

--- a/src/Cardano/Chain/Update/BlockVersionData.hs
+++ b/src/Cardano/Chain/Update/BlockVersionData.hs
@@ -12,8 +12,6 @@ module Cardano.Chain.Update.BlockVersionData
        , isBootstrapEraBVD
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError)
 import qualified Data.Aeson.Options as S (defaultOptions)
 import           Data.Aeson.TH (deriveJSON)

--- a/src/Cardano/Chain/Update/BlockVersionModifier.hs
+++ b/src/Cardano/Chain/Update/BlockVersionModifier.hs
@@ -10,8 +10,6 @@ module Cardano.Chain.Update.BlockVersionModifier
        , applyBVM
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Text.Lazy.Builder (Builder)
 import           Data.Time (NominalDiffTime)
 import           Formatting (Format, bprint, build, bytes, int, later, shortest)

--- a/src/Cardano/Chain/Update/Data.hs
+++ b/src/Cardano/Chain/Update/Data.hs
@@ -7,8 +7,6 @@ module Cardano.Chain.Update.Data
        ( UpdateData (..)
        ) where
 
-import           Cardano.Prelude
-
 import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 

--- a/src/Cardano/Chain/Update/Payload.hs
+++ b/src/Cardano/Chain/Update/Payload.hs
@@ -9,8 +9,6 @@ module Cardano.Chain.Update.Payload
        , checkPayload
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (..))
 import           Formatting (bprint, build)
 import qualified Formatting.Buildable as B

--- a/src/Cardano/Chain/Update/SoftforkRule.hs
+++ b/src/Cardano/Chain/Update/SoftforkRule.hs
@@ -12,8 +12,6 @@ module Cardano.Chain.Update.SoftforkRule
        ( SoftforkRule (..)
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError)
 import qualified Data.Aeson.Options as S (defaultOptions)
 import           Data.Aeson.TH (deriveJSON)

--- a/src/Cardano/Chain/Update/SoftwareVersion.hs
+++ b/src/Cardano/Chain/Update/SoftwareVersion.hs
@@ -13,13 +13,11 @@ module Cardano.Chain.Update.SoftwareVersion
        , checkSoftwareVersion
        ) where
 
-import           Cardano.Prelude
-import qualified Prelude
-
 import           Control.Monad.Except (MonadError (..))
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Formatting (bprint, build, formatToString, int, stext)
 import qualified Formatting.Buildable as B (Buildable (..))
+import qualified Text.Show
 
 import           Cardano.Binary.Class (Bi (..), encodeListLen, enforceSize)
 import           Cardano.Chain.Update.ApplicationName

--- a/src/Cardano/Chain/Update/SystemTag.hs
+++ b/src/Cardano/Chain/Update/SystemTag.hs
@@ -16,8 +16,6 @@ module Cardano.Chain.Update.SystemTag
        , archHelper
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (throwError))
 import           Data.Aeson (FromJSON (..))
 import           Data.Aeson.Options (defaultOptions)

--- a/src/Cardano/Chain/Update/Undo.hs
+++ b/src/Cardano/Chain/Update/Undo.hs
@@ -51,8 +51,6 @@ module Cardano.Chain.Update.Undo
        , newVoteState
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Lens (makeLensesFor)
 import           Data.Time (NominalDiffTime)
 import           Formatting.Buildable (Buildable (..))

--- a/src/Cardano/Chain/Update/Vote.hs
+++ b/src/Cardano/Chain/Update/Vote.hs
@@ -28,8 +28,6 @@ module Cardano.Chain.Update.Vote
        , mkVoteId
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Except (MonadError (throwError))
 import qualified Data.Map.Strict as Map
 import           Data.Text.Lazy.Builder (Builder)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,20 +1,19 @@
 resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/5943cb9701516a47de86fa7eb22eb790c613d70a/snapshot.yaml
 
 packages:
+  - binary
+  - binary/test
+  - crypto
+  - crypto/test
   - .
   - test
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: d3a3dfc451725cc3e17f47677739ba3dc7d9bbee
+    commit: 339d7384c263a234ff553fe731bed2d7091c9e10
     subdirs:
       - .
       - test
-
-  - binary
-  - binary/test
-  - crypto
-  - crypto/test
 
 nix:
   shell-file: scripts/nix/stack-shell.nix

--- a/test/Test/Cardano/Chain/Block/Bi.hs
+++ b/test/Test/Cardano/Chain/Block/Bi.hs
@@ -11,7 +11,6 @@ module Test.Cardano.Chain.Block.Bi
        , exampleBlockPSignatureHeavy
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Data.Coerce (coerce)

--- a/test/Test/Cardano/Chain/Block/Gen.hs
+++ b/test/Test/Cardano/Chain/Block/Gen.hs
@@ -13,8 +13,6 @@ module Test.Cardano.Chain.Block.Gen
        , genUndo
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Coerce (coerce)
 import           Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen

--- a/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/test/Test/Cardano/Chain/Common/Gen.hs
@@ -21,7 +21,6 @@ module Test.Cardano.Chain.Common.Gen
        , genTxSizeLinear
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Data.Fixed (Fixed (..))

--- a/test/Test/Cardano/Chain/Delegation/Bi.hs
+++ b/test/Test/Cardano/Chain/Delegation/Bi.hs
@@ -4,7 +4,6 @@ module Test.Cardano.Chain.Delegation.Bi
        ( tests
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Data.List ((!!))

--- a/test/Test/Cardano/Chain/Delegation/Example.hs
+++ b/test/Test/Cardano/Chain/Delegation/Example.hs
@@ -6,8 +6,6 @@ module Test.Cardano.Chain.Delegation.Example
        , staticProxySKHeavys
        ) where
 
-import           Cardano.Prelude
-
 import           Data.List (zipWith4, (!!))
 import qualified Data.Set as Set
 

--- a/test/Test/Cardano/Chain/Delegation/Gen.hs
+++ b/test/Test/Cardano/Chain/Delegation/Gen.hs
@@ -7,8 +7,6 @@ module Test.Cardano.Chain.Delegation.Gen
        , genUndo
        ) where
 
-import           Cardano.Prelude
-
 import           Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range

--- a/test/Test/Cardano/Chain/Epoch/File.hs
+++ b/test/Test/Cardano/Chain/Epoch/File.hs
@@ -3,8 +3,6 @@ module Test.Cardano.Chain.Epoch.File
        ( tests
        ) where
 
-import           Cardano.Prelude
-
 import           Control.Monad.Trans.Resource (runResourceT)
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H

--- a/test/Test/Cardano/Chain/Genesis/Dummy.hs
+++ b/test/Test/Cardano/Chain/Genesis/Dummy.hs
@@ -23,8 +23,6 @@ module Test.Cardano.Chain.Genesis.Dummy
        , dummyGenesisHash
        ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Chain.Genesis (Config (..), FakeAvvmOptions (..),
                      GeneratedGenesisData (..), GeneratedSecrets (..),
                      GenesisAvvmBalances (..), GenesisData (..),

--- a/test/Test/Cardano/Chain/Genesis/Example.hs
+++ b/test/Test/Cardano/Chain/Genesis/Example.hs
@@ -7,8 +7,6 @@ module Test.Cardano.Chain.Genesis.Example
        , exampleProtocolConstants
        ) where
 
-import           Cardano.Prelude
-
 import qualified Data.HashMap.Strict as HM
 import           Data.Maybe (fromJust)
 import qualified Serokell.Util.Base16 as B16

--- a/test/Test/Cardano/Chain/Genesis/Gen.hs
+++ b/test/Test/Cardano/Chain/Genesis/Gen.hs
@@ -10,8 +10,6 @@ module Test.Cardano.Chain.Genesis.Gen
        , genStaticConfig
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Coerce (coerce)
 import qualified Data.HashMap.Strict as HM
 

--- a/test/Test/Cardano/Chain/Genesis/Json.hs
+++ b/test/Test/Cardano/Chain/Genesis/Json.hs
@@ -4,8 +4,6 @@ module Test.Cardano.Chain.Genesis.Json
        ( tests
        ) where
 
-import           Cardano.Prelude
-
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 

--- a/test/Test/Cardano/Chain/Slotting/Example.hs
+++ b/test/Test/Cardano/Chain/Slotting/Example.hs
@@ -4,8 +4,6 @@ module Test.Cardano.Chain.Slotting.Example
        , exampleSlottingData
        ) where
 
-import           Cardano.Prelude
-
 import qualified Data.Map.Strict as M
 
 import           Cardano.Chain.Slotting (EpochIndex (..),

--- a/test/Test/Cardano/Chain/Slotting/Gen.hs
+++ b/test/Test/Cardano/Chain/Slotting/Gen.hs
@@ -11,7 +11,6 @@ module Test.Cardano.Chain.Slotting.Gen
        , feedPMEpochSlots
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import qualified Data.Map.Strict as Map

--- a/test/Test/Cardano/Chain/Ssc/Bi.hs
+++ b/test/Test/Cardano/Chain/Ssc/Bi.hs
@@ -5,7 +5,6 @@ module Test.Cardano.Chain.Ssc.Bi
        ( tests
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Hedgehog (Property)

--- a/test/Test/Cardano/Chain/Txp/Bi.hs
+++ b/test/Test/Cardano/Chain/Txp/Bi.hs
@@ -6,7 +6,6 @@ module Test.Cardano.Chain.Txp.Bi
        ( tests
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import qualified Data.Map as M

--- a/test/Test/Cardano/Chain/Txp/Example.hs
+++ b/test/Test/Cardano/Chain/Txp/Example.hs
@@ -19,8 +19,6 @@ module Test.Cardano.Chain.Txp.Example
        , exampleHashTx
        ) where
 
-import           Cardano.Prelude
-
 import           Data.Coerce (coerce)
 import           Data.List.NonEmpty (fromList)
 import           Data.Maybe (fromJust)

--- a/test/Test/Cardano/Chain/Txp/Gen.hs
+++ b/test/Test/Cardano/Chain/Txp/Gen.hs
@@ -25,7 +25,6 @@ module Test.Cardano.Chain.Txp.Gen
        , genUnknownWitnessType
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Data.ByteString.Base16 as B16

--- a/test/Test/Cardano/Chain/Txp/Json.hs
+++ b/test/Test/Cardano/Chain/Txp/Json.hs
@@ -5,8 +5,6 @@
 module Test.Cardano.Chain.Txp.Json
        ( tests
        ) where
-import           Cardano.Prelude
-
 import qualified Data.Set as S
 import           Hedgehog (Property)
 import qualified Hedgehog as H

--- a/test/Test/Cardano/Chain/Update/Bi.hs
+++ b/test/Test/Cardano/Chain/Update/Bi.hs
@@ -5,7 +5,6 @@ module Test.Cardano.Chain.Update.Bi
        ( tests
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import qualified Data.Map.Strict as Map

--- a/test/Test/Cardano/Chain/Update/Example.hs
+++ b/test/Test/Cardano/Chain/Update/Example.hs
@@ -18,7 +18,6 @@ module Test.Cardano.Chain.Update.Example
        , exampleVoteId
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Data.Fixed (Fixed (..))

--- a/test/Test/Cardano/Chain/Update/Gen.hs
+++ b/test/Test/Cardano/Chain/Update/Gen.hs
@@ -19,7 +19,6 @@ module Test.Cardano.Chain.Update.Gen
        , genVoteId
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Data.Coerce (coerce)

--- a/test/Test/Cardano/Chain/Update/Json.hs
+++ b/test/Test/Cardano/Chain/Update/Json.hs
@@ -4,7 +4,6 @@ module Test.Cardano.Chain.Update.Json
        ( tests
        ) where
 
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import           Hedgehog (Property)

--- a/test/cardano-chain-test.cabal
+++ b/test/cardano-chain-test.cabal
@@ -27,7 +27,7 @@ library
                        Test.Cardano.Chain.Update.Example
                        Test.Cardano.Chain.Update.Gen
 
-  build-depends:       base
+  build-depends:       base-noprelude
                      , base16-bytestring
                      , binary
                      , cardano-binary
@@ -47,7 +47,6 @@ library
                      , vector
 
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
 
   ghc-options:         -Wall
                        -Werror

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,4 +1,3 @@
-import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import qualified Test.Cardano.Chain.Block.Bi


### PR DESCRIPTION
  - Updated git commit in `cardano-chain`
  - Replaced `base` with `base-noprelude` in cabal files
  - Removed `NoImplicitPrelude` and added `-fno-warn-implicit-prelude`
  - Removed references to `Cardano.Prelude`
  - Fixed up a few places where `base`s `Prelude` was imported
  - Exported `id` from `Control.Category` as `identity`
  - Made `binary` and `crypto` packages rather than extra-deps so they're tested

Maybe some people think being explicit with the import is better, so let me know!