### PR TITLE
Update to latest cardano-snapshot

### DIFF
--- a/binary/stack.yaml
+++ b/binary/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/5943cb9701516a47de86fa7eb22eb790c613d70a/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/0a32ec92c461e144f981864c97546db11b52e46a/snapshot.yaml
 
 packages:
   - ./

--- a/crypto/stack.yaml
+++ b/crypto/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/5943cb9701516a47de86fa7eb22eb790c613d70a/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/0a32ec92c461e144f981864c97546db11b52e46a/snapshot.yaml
 
 packages:
   - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/5943cb9701516a47de86fa7eb22eb790c613d70a/snapshot.yaml
-compiler: ghc-8.4.4
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/0a32ec92c461e144f981864c97546db11b52e46a/snapshot.yaml
 
 packages:
   - .


### PR DESCRIPTION
This updates `ghc` to `8.4.4` by using the latest `cardano-snapshot` from `cardano-prelude`