### PR TITLE
Candidate design for tracking original bytes in deserialized data

### DIFF
--- a/binary/cardano-binary.cabal
+++ b/binary/cardano-binary.cabal
@@ -28,6 +28,7 @@ library
                        Cardano.Binary.Class.Core
                        Cardano.Binary.Class.Drop
                        Cardano.Binary.Class.Primitive
+                       Cardano.Binary.Class.Annotated
 
   build-depends:       base
                      , bytestring

--- a/binary/src/Cardano/Binary/Class.hs
+++ b/binary/src/Cardano/Binary/Class.hs
@@ -5,3 +5,4 @@ module Cardano.Binary.Class
 import           Cardano.Binary.Class.Core as X
 import           Cardano.Binary.Class.Drop as X
 import           Cardano.Binary.Class.Primitive as X
+import           Cardano.Binary.Class.Annotated as X

--- a/binary/src/Cardano/Binary/Class/Annotated.hs
+++ b/binary/src/Cardano/Binary/Class/Annotated.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Cardano.Binary.Class.Annotated
+  ( Annotated (..)
+  , ByteSpan (..)
+  , slice
+  , decodeAnnotated
+  )
+  where
+
+import qualified Codec.CBOR.Decoding as D
+import           Codec.CBOR.Read (ByteOffset)
+import qualified Data.ByteString.Lazy as BSL
+
+import           Cardano.Binary.Class.Core (Bi (..))
+import           Cardano.Prelude
+
+
+slice :: BSL.ByteString -> ByteSpan -> BSL.ByteString
+slice bytes (ByteSpan start end) = BSL.take (end - start) $ BSL.drop start $ bytes
+
+data ByteSpan = ByteSpan !ByteOffset !ByteOffset
+
+data Annotated b a = Annotated { unAnnotated :: !b, annotation :: !a }
+  deriving (Eq, Show, Functor, Generic)
+  deriving anyclass NFData
+
+annotatedDecoder :: D.Decoder s a -> D.Decoder s (Annotated a ByteSpan)
+annotatedDecoder d = flip fmap (D.decodeWithByteSpan d) $ \(x, start, end) ->
+  Annotated x (ByteSpan start end)
+
+decodeAnnotated :: (Bi a) => D.Decoder s (Annotated a ByteSpan)
+decodeAnnotated = annotatedDecoder decode

--- a/binary/src/Cardano/Binary/Class/Annotated.hs
+++ b/binary/src/Cardano/Binary/Class/Annotated.hs
@@ -31,7 +31,7 @@ data Annotated b a = Annotated { unAnnotated :: !b, annotation :: !a }
   deriving anyclass NFData
 
 annotatedDecoder :: D.Decoder s a -> D.Decoder s (Annotated a ByteSpan)
-annotatedDecoder d = flip fmap (D.decodeWithByteSpan d) $ \(x, start, end) ->
+annotatedDecoder d = D.decodeWithByteSpan d <&> \(x, start, end) ->
   Annotated x (ByteSpan start end)
 
 decodeAnnotated :: (Bi a) => D.Decoder s (Annotated a ByteSpan)

--- a/cardano-chain.cabal
+++ b/cardano-chain.cabal
@@ -21,6 +21,7 @@ library
   hs-source-dirs:      src
   exposed-modules:
                        Cardano.Chain.Block
+                       Cardano.Chain.Block.Header
                        Cardano.Chain.Common
                        Cardano.Chain.Constants
                        Cardano.Chain.Delegation
@@ -38,7 +39,6 @@ library
                        Cardano.Chain.Block.Boundary
                        Cardano.Chain.Block.ExtraBodyData
                        Cardano.Chain.Block.ExtraHeaderData
-                       Cardano.Chain.Block.Header
                        Cardano.Chain.Block.Proof
                        Cardano.Chain.Block.SlogUndo
                        Cardano.Chain.Block.Undo
@@ -140,6 +140,7 @@ test-suite test
   other-modules:
                        Test.Cardano.Chain.Block.Bi
                        Test.Cardano.Chain.Block.Gen
+                       Test.Cardano.Chain.Block.Header
                        Test.Cardano.Chain.Common.Example
                        Test.Cardano.Chain.Common.Gen
                        Test.Cardano.Chain.Delegation.Bi

--- a/crypto/src/Cardano/Crypto/Signing/Check.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Check.hs
@@ -10,6 +10,7 @@
 
 module Cardano.Crypto.Signing.Check
        ( checkSig
+       , checkSigAnnotated
        , checkSigRaw
        , verifyProxyCert
        , validateProxySecretKey
@@ -22,7 +23,7 @@ import qualified Cardano.Crypto.Wallet as CC
 import           Control.Monad.Except (MonadError, throwError)
 import           Data.Coerce (coerce)
 
-import           Cardano.Binary.Class (Bi, Raw)
+import           Cardano.Binary.Class (Annotated (..), Bi, Raw)
 import qualified Cardano.Binary.Class as Bi
 import           Cardano.Crypto.ProtocolMagic (ProtocolMagic)
 import           Cardano.Crypto.Signing.Tag (SignTag (..), signTag)
@@ -37,6 +38,10 @@ import           Cardano.Crypto.Signing.Types.Signing (ProxyCert (..),
 checkSig
   :: Bi a => ProtocolMagic -> SignTag -> PublicKey -> a -> Signature a -> Bool
 checkSig pm t k x s = checkSigRaw pm (Just t) k (Bi.serialize' x) (coerce s)
+
+checkSigAnnotated
+  :: ProtocolMagic -> SignTag -> PublicKey -> (Annotated a ByteString) -> Signature a -> Bool
+checkSigAnnotated pm t k x s = checkSigRaw pm (Just t) k (annotation x) (coerce s)
 
 -- CHECK: @checkSigRaw
 -- | Verify raw 'ByteString'

--- a/src/Cardano/Chain/Block/Block.hs
+++ b/src/Cardano/Chain/Block/Block.hs
@@ -50,12 +50,12 @@ import           Cardano.Chain.Block.Boundary (dropBoundaryBody,
                      dropBoundaryExtraBodyData)
 import           Cardano.Chain.Block.ExtraBodyData (ExtraBodyData (..))
 import           Cardano.Chain.Block.ExtraHeaderData (ExtraHeaderData (..))
-import           Cardano.Chain.Block.Header (BlockSignature (..), Header (..),
+import           Cardano.Chain.Block.Header (BlockSignature (..), Header,
                      HeaderError, HeaderHash, dropBoundaryHeader, hashHeader,
                      headerAttributes, headerBlockVersion, headerDifficulty,
                      headerEBDataProof, headerLeaderKey, headerSignature,
                      headerSlot, headerSoftwareVersion, mkHeaderExplicit,
-                     verifyHeader)
+                     verifyHeader, headerPrevHash, headerProof)
 import           Cardano.Chain.Block.Proof (Proof (..), ProofError, checkProof)
 import           Cardano.Chain.Common (Attributes, ChainDifficulty,
                      mkAttributes)

--- a/src/Cardano/Chain/Block/ExtraHeaderData.hs
+++ b/src/Cardano/Chain/Block/ExtraHeaderData.hs
@@ -66,6 +66,7 @@ instance Bi ExtraHeaderData where
 
 data ExtraHeaderDataError =
   ExtraHeaderDataSoftwareVersionError SoftwareVersionError
+  deriving (Eq, Show)
 
 instance B.Buildable ExtraHeaderDataError where
   build = \case

--- a/src/Cardano/Chain/Update/ApplicationName.hs
+++ b/src/Cardano/Chain/Update/ApplicationName.hs
@@ -41,6 +41,7 @@ instance FromJSON ApplicationName where
 data ApplicationNameError
   = ApplicationNameTooLong Text
   | ApplicationNameNotAscii Text
+  deriving (Eq, Show)
 
 instance B.Buildable ApplicationNameError where
   build = \case

--- a/src/Cardano/Chain/Update/SoftwareVersion.hs
+++ b/src/Cardano/Chain/Update/SoftwareVersion.hs
@@ -51,6 +51,7 @@ instance Bi SoftwareVersion where
 
 data SoftwareVersionError =
   SoftwareVersionApplicationNameError ApplicationNameError
+  deriving (Eq, Show)
 
 instance B.Buildable SoftwareVersionError where
   build = \case

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,11 @@ extra-deps:
     subdirs:
       - .
       - test
+  - git: https://github.com/well-typed/cborg
+    commit: 80fbe0ee5e67a5622e2cb9eaa9d8594a2214322d
+    subdirs:
+      - cborg
+
 
 nix:
   shell-file: scripts/nix/stack-shell.nix

--- a/test/Test/Cardano/Chain/Block/Bi.hs
+++ b/test/Test/Cardano/Chain/Block/Bi.hs
@@ -24,7 +24,7 @@ import qualified Hedgehog as H
 import           Cardano.Binary.Class (decodeFullDecoder, dropBytes,
                      serializeEncoding)
 import           Cardano.Chain.Block (BlockSignature (..), Body (..),
-                     ConsensusData (..), ExtraBodyData (..),
+                     ConsensusData, consensusData, ExtraBodyData (..),
                      ExtraHeaderData (..), Header, HeaderHash, Proof (..),
                      SlogUndo (..), ToSign (..), Undo (..), decodeBlock,
                      decodeHeader, dropBoundaryBody, dropBoundaryConsensusData,
@@ -193,7 +193,7 @@ roundTripBodyBi = eachOf 20 (feedPM genBody) roundTripsBiShow
 golden_ConsensusData :: Property
 golden_ConsensusData = goldenTestBi mcd "test/golden/block/ConsensusData"
  where
-  mcd = ConsensusData
+  mcd = consensusData
     exampleSlotId
     examplePublicKey
     exampleChainDifficulty
@@ -301,7 +301,7 @@ exampleBlockPSignatureHeavy = BlockPSignatureHeavy sig
   pm = ProtocolMagic 2
 
 exampleConsensusData :: ConsensusData
-exampleConsensusData = ConsensusData
+exampleConsensusData = consensusData
   exampleSlotId
   examplePublicKey
   exampleChainDifficulty

--- a/test/Test/Cardano/Chain/Block/Gen.hs
+++ b/test/Test/Cardano/Chain/Block/Gen.hs
@@ -20,7 +20,7 @@ import           Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
 
 import           Cardano.Chain.Block (Block, BlockSignature (..), Body (..),
-                     ConsensusData (..), ExtraBodyData (..),
+                     ConsensusData, consensusData, ExtraBodyData (..),
                      ExtraHeaderData (..), Header, HeaderHash, Proof (..),
                      SlogUndo (..), ToSign (..), Undo (..), mkBlockExplicit,
                      mkHeaderExplicit)
@@ -75,7 +75,7 @@ genHeader pm epochSlots =
 
 genConsensusData :: ProtocolMagic -> SlotCount -> Gen ConsensusData
 genConsensusData pm epochSlots =
-  ConsensusData
+  consensusData
     <$> genSlotId epochSlots
     <*> genPublicKey
     <*> genChainDifficulty

--- a/test/Test/Cardano/Chain/Block/Header.hs
+++ b/test/Test/Cardano/Chain/Block/Header.hs
@@ -39,4 +39,4 @@ validateAnnotatedHeader = H.property $ do
   recover pm bytes = do
     header <- first ErrorD $ decodeFullAnnotatedBytes "Header" decodeAHeader bytes
     first ErrorH $ verifyAHeader pm header
-    pure $ map (const ()) header
+    pure $ void header

--- a/test/Test/Cardano/Chain/Block/Header.hs
+++ b/test/Test/Cardano/Chain/Block/Header.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Cardano.Chain.Block.Header
+  ( tests
+  ) where
+
+import           Cardano.Prelude
+
+import qualified Data.ByteString.Lazy as BSL
+import           Hedgehog (Property, (===))
+import qualified Hedgehog as H
+
+import           Cardano.Binary.Class (Bi (..), DecoderError,
+                     decodeFullAnnotatedBytes, serializeEncoding)
+import           Cardano.Chain.Block.Header (Header, HeaderError, decodeAHeader,
+                     verifyAHeader)
+import           Cardano.Crypto (ProtocolMagic)
+import           Test.Cardano.Chain.Block.Gen (genHeader)
+import           Test.Cardano.Chain.Slotting.Gen (genSlotCount)
+import           Test.Cardano.Crypto.Gen (genProtocolMagic)
+
+
+tests :: IO Bool
+tests = H.checkSequential $ H.Group "Test.Cardano.Chain.Block.Header"
+  [ ("validate headers using annotation", validateAnnotatedHeader)
+  ]
+
+data Error = ErrorH HeaderError | ErrorD DecoderError
+  deriving (Show, Eq)
+
+validateAnnotatedHeader :: Property
+validateAnnotatedHeader = H.property $ do
+  pm <- H.forAll genProtocolMagic
+  sc <- H.forAll genSlotCount
+  header <- H.forAll $ genHeader pm sc
+  let bytes = (serializeEncoding . encode) header
+  recover pm bytes === Right header
+  where
+  recover :: ProtocolMagic -> BSL.ByteString -> Either Error Header
+  recover pm bytes = do
+    header <- first ErrorD $ decodeFullAnnotatedBytes "Header" decodeAHeader bytes
+    first ErrorH $ verifyAHeader pm header
+    pure $ map (const ()) header

--- a/test/Test/Cardano/Chain/Block/Header.hs
+++ b/test/Test/Cardano/Chain/Block/Header.hs
@@ -10,8 +10,8 @@ import qualified Data.ByteString.Lazy as BSL
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 
-import           Cardano.Binary.Class (Bi (..), DecoderError,
-                     decodeFullAnnotatedBytes, serializeEncoding)
+import           Cardano.Binary.Class (DecoderError, decodeFullAnnotatedBytes,
+                     serialize)
 import           Cardano.Chain.Block.Header (Header, HeaderError, decodeAHeader,
                      verifyAHeader)
 import           Cardano.Crypto (ProtocolMagic)
@@ -33,8 +33,7 @@ validateAnnotatedHeader = H.property $ do
   pm <- H.forAll genProtocolMagic
   sc <- H.forAll genSlotCount
   header <- H.forAll $ genHeader pm sc
-  let bytes = (serializeEncoding . encode) header
-  recover pm bytes === Right header
+  recover pm (serialize header) === Right header
   where
   recover :: ProtocolMagic -> BSL.ByteString -> Either Error Header
   recover pm bytes = do

--- a/test/Test/Cardano/Chain/Slotting/Gen.hs
+++ b/test/Test/Cardano/Chain/Slotting/Gen.hs
@@ -54,7 +54,7 @@ genLocalSlotIndex epochSlots = mkLocalSlotIndex'
     Right lsi -> lsi
 
 genSlotCount :: Gen SlotCount
-genSlotCount = SlotCount <$> Gen.word64 Range.constantBounded
+genSlotCount = SlotCount <$> Gen.word64 (Range.constantFrom 1 1 maxBound)
 
 genSlotId :: SlotCount -> Gen SlotId
 genSlotId epochSlots =

--- a/test/cardano-chain-test.cabal
+++ b/test/cardano-chain-test.cabal
@@ -15,6 +15,7 @@ library
   exposed-modules:
                        Test.Cardano.Chain.Block.Bi
                        Test.Cardano.Chain.Block.Gen
+                       Test.Cardano.Chain.Block.Header
                        Test.Cardano.Chain.Common.Example
                        Test.Cardano.Chain.Common.Gen
                        Test.Cardano.Chain.Delegation.Example
@@ -30,6 +31,7 @@ library
   build-depends:       base
                      , base16-bytestring
                      , binary
+                     , bytestring
                      , cardano-binary
                      , cardano-binary-test
                      , cardano-chain

--- a/test/test.hs
+++ b/test/test.hs
@@ -2,6 +2,7 @@ import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
 import qualified Test.Cardano.Chain.Block.Bi
+import qualified Test.Cardano.Chain.Block.Header
 import qualified Test.Cardano.Chain.Delegation.Bi
 import qualified Test.Cardano.Chain.Epoch.File
 import qualified Test.Cardano.Chain.Ssc.Bi
@@ -12,6 +13,7 @@ import qualified Test.Cardano.Chain.Update.Json
 main :: IO ()
 main = runTests
     [ Test.Cardano.Chain.Block.Bi.tests
+    , Test.Cardano.Chain.Block.Header.tests
     , Test.Cardano.Chain.Delegation.Bi.tests
     , Test.Cardano.Chain.Epoch.File.tests
     , Test.Cardano.Chain.Ssc.Bi.tests


### PR DESCRIPTION
The goal of this changeset is to (eventually) stop deserializing-then-reserializing during validation of incoming data.
This PR only does this for the header data and not the entire block.

For review only. Do not merge.