### PR TITLE
[#93] Add cardano-mainnet-mirror as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cardano-mainnet-mirror"]
+	path = cardano-mainnet-mirror
+	url = git@github.com:input-output-hk/cardano-mainnet-mirror.git

--- a/binary/stack.yaml
+++ b/binary/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/0a32ec92c461e144f981864c97546db11b52e46a/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/4b4457e75303ce352223b9723f7771fac6fe0600/snapshot.yaml
 
 packages:
   - ./

--- a/cardano-chain.cabal
+++ b/cardano-chain.cabal
@@ -175,6 +175,8 @@ test-suite test
                      , cardano-prelude-test
                      , containers
                      , cryptonite
+                     , directory
+                     , filepath
                      , formatting
                      , hedgehog
                      , resourcet

--- a/crypto/stack.yaml
+++ b/crypto/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/0a32ec92c461e144f981864c97546db11b52e46a/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/4b4457e75303ce352223b9723f7771fac6fe0600/snapshot.yaml
 
 packages:
   - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/0a32ec92c461e144f981864c97546db11b52e46a/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/4b4457e75303ce352223b9723f7771fac6fe0600/snapshot.yaml
 
 packages:
   - .

--- a/test/Test/Cardano/Chain/Epoch/File.hs
+++ b/test/Test/Cardano/Chain/Epoch/File.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 
 module Test.Cardano.Chain.Epoch.File
        ( tests
@@ -5,26 +6,42 @@ module Test.Cardano.Chain.Epoch.File
 
 import           Cardano.Prelude
 
-import           Control.Monad.Trans.Resource (ResIO, runResourceT)
-import           Hedgehog (Property, (===))
+import           Control.Monad.Trans.Resource
+    (ResIO, runResourceT)
+import           Hedgehog
+    (Property, (===))
 import qualified Hedgehog as H
-import           Streaming (Of ((:>)))
+import           Streaming
+    (Of ((:>)))
 import qualified Streaming as S
+import           System.Directory
+    (getDirectoryContents)
+import           System.FilePath
+    (isExtensionOf, (</>))
 
-import           Cardano.Chain.Epoch.File (ParseError, parseEpochFiles)
+import           Cardano.Chain.Epoch.File
+    (ParseError, parseEpochFiles)
 
 
 tests :: IO Bool
-tests = H.check testDeserializeEpochs
+tests = H.checkSequential $$(H.discoverPrefix "prop")
 
-testDeserializeEpochs :: Property
-testDeserializeEpochs =
-  let files = [ "test/resources/epochs/00000.epoch"
-              , "test/resources/epochs/00001.epoch"
-              ]
-      stream = parseEpochFiles files
-      discard :: Of a m -> ExceptT ParseError ResIO m
-      discard (_ :> rest) = pure rest
-  in H.withTests 1 $ H.property $ do
-     result <- (liftIO . runResourceT . runExceptT . S.run) (S.maps discard stream)
-     result === Right ()
+propDeserializeEpochs :: Property
+propDeserializeEpochs = H.withTests 1 $ H.property $ do
+  files <- liftIO getEpochFiles
+  H.assert $ not (null files)
+  let stream = parseEpochFiles files
+  result <- (liftIO . runResourceT . runExceptT . S.run) (S.maps discard stream)
+  result === Right ()
+ where
+  epochDir = "cardano-mainnet-mirror/epochs"
+
+  getEpochFiles :: IO [FilePath]
+  getEpochFiles =
+    take 10
+      .   fmap (epochDir </>)
+      .   filter ("epoch" `isExtensionOf`)
+      <$> getDirectoryContents epochDir
+
+  discard :: Of a m -> ExceptT ParseError ResIO m
+  discard (_ :> rest) = pure rest


### PR DESCRIPTION
`cardano-mainnet-mirror` contains a copy of the mainnet blockchain. We can use this to perform tests for validation, deserialisation, etc., without running a full node.

Closes #93 