### PR TITLE
[#87] Move Bi round trip tests to hedgehog

### DIFF
--- a/binary/cardano-binary.cabal
+++ b/binary/cardano-binary.cabal
@@ -64,6 +64,7 @@ test-suite test
 
   other-modules:
                        Spec
+                       Test.Cardano.Binary.Bi
                        Test.Cardano.Binary.BiSizeBounds
                        Test.Cardano.Binary.Cbor.CborSpec
                        Test.Cardano.Binary.Helpers

--- a/binary/test/Test/Cardano/Binary/Bi.hs
+++ b/binary/test/Test/Cardano/Binary/Bi.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE NumDecimals      #-}
+{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Binary.Bi
+       ( tests
+       ) where
+
+import           Cardano.Prelude
+import           Test.Cardano.Prelude
+
+import           Data.Fixed
+    (E9, Fixed (..))
+import           Hedgehog
+    (Property, Range, checkParallel)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import           Test.Cardano.Binary.Helpers.GoldenRoundTrip
+    (roundTripsBiBuildable, roundTripsBiShow)
+
+
+tests :: IO Bool
+tests = checkParallel $$discoverRoundTrip
+
+roundTripUnitBi :: Property
+roundTripUnitBi = eachOf 1 (pure ()) roundTripsBiBuildable
+
+roundTripBoolBi :: Property
+roundTripBoolBi = eachOf 10 Gen.bool roundTripsBiBuildable
+
+roundTripCharBi :: Property
+roundTripCharBi = eachOf 1000 Gen.unicode roundTripsBiBuildable
+
+-- | Tests up to 'Integer's with multiple machine words using large upper bound
+roundTripIntegerBi :: Property
+roundTripIntegerBi = eachOf
+  1000
+  (Gen.integral (Range.linearFrom 0 (- 1e40) 1e40 :: Range Integer))
+  roundTripsBiBuildable
+
+roundTripWordBi :: Property
+roundTripWordBi =
+  eachOf 1000 (Gen.word Range.constantBounded) roundTripsBiBuildable
+
+roundTripWord8Bi :: Property
+roundTripWord8Bi =
+  eachOf 1000 (Gen.word8 Range.constantBounded) roundTripsBiBuildable
+
+roundTripWord16Bi :: Property
+roundTripWord16Bi =
+  eachOf 1000 (Gen.word16 Range.constantBounded) roundTripsBiBuildable
+
+roundTripWord32Bi :: Property
+roundTripWord32Bi =
+  eachOf 1000 (Gen.word32 Range.constantBounded) roundTripsBiBuildable
+
+roundTripWord64Bi :: Property
+roundTripWord64Bi =
+  eachOf 1000 (Gen.word64 Range.constantBounded) roundTripsBiBuildable
+
+roundTripIntBi :: Property
+roundTripIntBi =
+  eachOf 1000 (Gen.int Range.constantBounded) roundTripsBiBuildable
+
+roundTripFloatBi :: Property
+roundTripFloatBi =
+  eachOf 1000 (Gen.float (Range.constant (- 1e12) 1e12)) roundTripsBiBuildable
+
+roundTripInt32Bi :: Property
+roundTripInt32Bi =
+  eachOf 1000 (Gen.int32 Range.constantBounded) roundTripsBiBuildable
+
+roundTripInt64Bi :: Property
+roundTripInt64Bi =
+  eachOf 1000 (Gen.int64 Range.constantBounded) roundTripsBiBuildable
+
+roundTripNanoBi :: Property
+roundTripNanoBi = eachOf
+  1000
+  (MkFixed @E9 <$> Gen.integral (Range.constantFrom 0 (-1e12) 1e12))
+  roundTripsBiShow
+
+roundTripMapBi :: Property
+roundTripMapBi = eachOf
+  100
+  (Gen.map
+    (Range.constant 0 50)
+    ((,) <$> Gen.int Range.constantBounded <*> Gen.int Range.constantBounded)
+  )
+  roundTripsBiShow
+
+roundTripSetBi :: Property
+roundTripSetBi = eachOf
+  100
+  (Gen.set (Range.constant 0 50) (Gen.int Range.constantBounded))
+  roundTripsBiShow
+
+roundTripByteStringBi :: Property
+roundTripByteStringBi =
+  eachOf 100 (Gen.bytes $ Range.constant 0 100) roundTripsBiShow
+
+roundTripTextBi :: Property
+roundTripTextBi =
+  eachOf 100 (Gen.text (Range.constant 0 100) Gen.unicode) roundTripsBiBuildable

--- a/binary/test/Test/Cardano/Binary/Cbor/CborSpec.hs
+++ b/binary/test/Test/Cardano/Binary/Cbor/CborSpec.hs
@@ -19,18 +19,23 @@ module Test.Cardano.Binary.Cbor.CborSpec
 
 import           Cardano.Prelude
 
-import           Data.Bits (shiftL)
+import           Data.Bits
+    (shiftL)
 import qualified Data.ByteString as BS
-import           Data.Fixed (Nano)
-import           Data.String (String)
+import           Data.String
+    (String)
 
-import           Test.Hspec (Spec, describe)
-import           Test.Hspec.QuickCheck (modifyMaxSize, modifyMaxSuccess, prop)
-import           Test.QuickCheck (Arbitrary (..), choose, sized, (===))
+import           Test.Hspec
+    (Spec, describe)
+import           Test.Hspec.QuickCheck
+    (modifyMaxSize, modifyMaxSuccess, prop)
+import           Test.QuickCheck
+    (Arbitrary (..), choose, sized, (===))
 
 import           Cardano.Binary.Class
 
-import           Test.Cardano.Binary.Helpers (U, binaryTest, extensionProperty)
+import           Test.Cardano.Binary.Helpers
+    (U, extensionProperty)
 import qualified Test.Cardano.Cbor.RefImpl as R
 
 
@@ -132,25 +137,3 @@ spec = do
         -- Using once inside the property would be lovely (as it tests
         -- all the Halfs) but it doesn't work for some reason.
         prop "Numeric.Half to/from Float" R.prop_halfToFromFloat
-
-  describe "Cbor.Bi instances" $
-    modifyMaxSuccess (const 1000) $ do
-        binaryTest @()
-        binaryTest @Bool
-        binaryTest @Char
-        binaryTest @Integer
-        binaryTest @LargeInteger
-        binaryTest @Word
-        binaryTest @Word8
-        binaryTest @Word16
-        binaryTest @Word32
-        binaryTest @Word64
-        binaryTest @Int
-        binaryTest @Float
-        binaryTest @Int32
-        binaryTest @Int64
-        binaryTest @Nano
-        binaryTest @(Map Int Int)
-        binaryTest @(Set Int)
-        binaryTest @ByteString
-        binaryTest @Text

--- a/binary/test/test.hs
+++ b/binary/test/test.hs
@@ -1,15 +1,18 @@
 import           Cardano.Prelude
 import           Test.Cardano.Prelude
 
-import           Test.Hspec (hspec)
+import           Test.Hspec
+    (hspec)
 
-import           Spec (spec)
+import           Spec
+    (spec)
 
+import qualified Test.Cardano.Binary.Bi
 import qualified Test.Cardano.Binary.BiSizeBounds
+
 
 main :: IO ()
 main = do
-    hspec spec
-    runTests
-        [ Test.Cardano.Binary.BiSizeBounds.tests
-        ]
+  hspec spec
+  runTests
+    [Test.Cardano.Binary.Bi.tests, Test.Cardano.Binary.BiSizeBounds.tests]


### PR DESCRIPTION
Move round trip testing for primitive types to use `hedgehog`.