### PR TITLE
[DEVOPS-1028] Add bors-ng config

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,12 @@
+status = [
+  # Hydra: build for Linux and macOS (TODO)
+  # "ci/hydra:serokell:cardano-chain:cardano-chain.x86_64-linux",
+  # "ci/hydra:serokell:cardano-chain:cardano-chain.x86_64-darwin",
+
+  # Buildkite: stack build
+  "buildkite/cardano-chain",
+]
+timeout_sec = 3600
+required_approvals = 1
+delete_merged_branches = true
+block_labels = [ "DO NOT MERGE", "wip" ]


### PR DESCRIPTION
This is the config for Bors.

The `iohk-bors` application is added to this repo.

After merging this, branch protection needs to be added so that PRs can't be merged into `master` by anyone but `iohk-bors`.

Currently the developer documentation for bors is here:
https://github.com/input-output-hk/cardano-sl/blob/devops-1028-enable-bors/docs/how-to/bors.md