### PR TITLE
[#115] Add witness to UTxO validation

### DIFF
--- a/binary/stack.yaml
+++ b/binary/stack.yaml
@@ -6,7 +6,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 3793d79323f2e7c34711cba80e6b24d01937d8f5
+    commit: 0889d18d3581026598b9268637475525064b76fe
     subdirs:
       - .
       - test

--- a/crypto/stack.yaml
+++ b/crypto/stack.yaml
@@ -6,7 +6,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 3793d79323f2e7c34711cba80e6b24d01937d8f5
+    commit: 0889d18d3581026598b9268637475525064b76fe
     subdirs:
       - .
       - test

--- a/src/Cardano/Chain/Txp/TxWitness.hs
+++ b/src/Cardano/Chain/Txp/TxWitness.hs
@@ -12,26 +12,47 @@ module Cardano.Chain.Txp.TxWitness
        , TxSig
        ) where
 
-import           Cardano.Prelude
+import Cardano.Prelude
 
-import           Data.Aeson (FromJSON (..), ToJSON (toJSON), object, withObject,
-                     (.:), (.=))
-import           Data.Aeson.TH (defaultOptions, deriveJSON)
-import           Data.ByteString.Base64.Type (getByteString64, makeByteString64)
+import Data.Aeson
+  (FromJSON (..), ToJSON (toJSON), object, withObject, (.:), (.=))
+import Data.Aeson.TH
+  (defaultOptions, deriveJSON)
+import Data.ByteString.Base64.Type
+  (getByteString64, makeByteString64)
 import qualified Data.ByteString.Lazy as LBS
-import           Data.Vector (Vector)
-import           Formatting (bprint, build)
+import Data.Vector
+  (Vector)
+import Formatting
+  (bprint, build)
 import qualified Formatting.Buildable as B
 
-import           Cardano.Binary.Class (Bi (..), Case (..),
-                     decodeKnownCborDataItem, decodeListLenCanonical,
-                     decodeUnknownCborDataItem, encodeKnownCborDataItem,
-                     encodeListLen, encodeUnknownCborDataItem,
-                     knownCborDataItemSizeExpr, matchSize, szCases)
-import           Cardano.Chain.Common (Script, addressHash)
-import           Cardano.Chain.Txp.Tx (Tx)
-import           Cardano.Crypto (Hash, PublicKey, RedeemPublicKey,
-                     RedeemSignature, Signature, hash, shortHashF)
+import Cardano.Binary.Class
+  ( Bi (..)
+  , Case (..)
+  , decodeKnownCborDataItem
+  , decodeListLenCanonical
+  , decodeUnknownCborDataItem
+  , encodeKnownCborDataItem
+  , encodeListLen
+  , encodeUnknownCborDataItem
+  , knownCborDataItemSizeExpr
+  , matchSize
+  , szCases
+  )
+import Cardano.Chain.Common
+  (Script, addressHash)
+import Cardano.Chain.Txp.Tx
+  (Tx)
+import Cardano.Crypto
+  ( Hash
+  , PublicKey
+  , RedeemPublicKey
+  , RedeemSignature
+  , Signature
+  , hash
+  , shortHashF
+  )
 
 
 -- | A witness is a proof that a transaction is allowed to spend the funds it

--- a/src/Cardano/Chain/Txp/Validation.hs
+++ b/src/Cardano/Chain/Txp/Validation.hs
@@ -2,48 +2,79 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TypeApplications  #-}
 
 module Cardano.Chain.Txp.Validation
        ( validateTx
        , updateUTxO
+       , updateUTxOWitness
        , TxValidationError
        , UTxOValidationError
        ) where
 
+
 import Cardano.Prelude
+
 
 import Control.Monad.Except
   (MonadError, liftEither)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as S
+import qualified Data.Vector as V
+
 
 import Cardano.Binary.Class
   (biSize)
 import Cardano.Chain.Common
-  ( Coeff (..)
+  ( Address
+  , Coeff (..)
   , Coin
   , CoinError
+  , Script (..)
   , TxFeePolicy (..)
   , TxSizeLinear (..)
   , calculateTxSizeLinear
+  , checkPubKeyAddress
+  , checkRedeemAddress
+  , checkScriptAddress
   , integerToCoin
   , mkKnownCoin
   , subCoin
   )
 import Cardano.Chain.Txp.Tx
   (Tx (..), TxIn)
+import Cardano.Chain.Txp.TxAux
+  (TxAux (..))
+import Cardano.Chain.Txp.TxWitness
+  (TxInWitness (..), TxSigData (..))
 import Cardano.Chain.Txp.UTxO
   (UTxO, UTxOError, balance, isRedeemUTxO, txOutputUTxO, (</|), (<|))
 import qualified Cardano.Chain.Txp.UTxO as UTxO
+import Cardano.Crypto
+  (ProtocolMagic, SignTag (..), checkSig, hash, redeemCheckSig)
 
 
+-- | A representation of all the ways a transaction might be invalid
 data TxValidationError
-  = TxValidationFeeTooSmall Tx Coin Coin
+  = TxValidationCoinError Text CoinError
+  | TxValidationFeeTooSmall Tx Coin Coin
+  | TxValidationInvalidWitness TxInWitness
   | TxValidationMissingInput TxIn
-  | TxValidationCoinError Text CoinError
+  | TxValidationScriptWitness
+  -- ^ TODO: Remove this once support for script witnesses is added
   | TxValidationUnknownFeePolicy TxFeePolicy
+  | TxValidationUnknownWitnessType Word8
   deriving (Eq, Show)
+
+
+-- | A helper for lifting an 'Either' to a 'MonadError'
+--
+--   By using this function infix we can move the error handling to the end of
+--   an expression, hopefully improving readability.
+wrapError :: MonadError e' m => Either e a -> (e -> e') -> m a
+wrapError m wrapper = liftEither $ first wrapper m
+
 
 -- | Validate that:
 --
@@ -56,6 +87,7 @@ data TxValidationError
 validateTx
   :: MonadError TxValidationError m => TxFeePolicy -> UTxO -> Tx -> m ()
 validateTx feePolicy utxo tx = do
+
   -- Check that every input is in the domain of 'utxo'
   _txInputs tx `forM_` validateTxIn utxo
 
@@ -65,40 +97,34 @@ validateTx feePolicy utxo tx = do
     else calculateMinimumFee feePolicy
 
   -- Calculate the balance of the output 'UTxO'
-  balanceOut <-
-    liftEither
-    . first (TxValidationCoinError "Output Balance")
-    $ balance
-    $ txOutputUTxO tx
+  balanceOut <- balance (txOutputUTxO tx)
+    `wrapError` TxValidationCoinError "Output Balance"
 
   -- Calculate the balance of the restricted input 'UTxO'
-  balanceIn <-
-    liftEither . first (TxValidationCoinError "Input Balance") $ balance
-      inputUTxO
+  balanceIn <- balance inputUTxO
+    `wrapError` TxValidationCoinError "Input Balance"
 
   -- Calculate the 'fee' as the difference of the balances
-  fee <-
-    liftEither
-    .         first (TxValidationCoinError "Fee")
-    $         balanceIn
-    `subCoin` balanceOut
+  fee <- subCoin balanceIn balanceOut `wrapError` TxValidationCoinError "Fee"
 
   -- Check that the fee is greater than the minimum
-  unless (minFee <= fee) $ throwError $ TxValidationFeeTooSmall tx minFee fee
+  unless (minFee <= fee) (throwError $ TxValidationFeeTooSmall tx minFee fee)
  where
-  txSize              = biSize tx
 
-  inputUTxO           = S.fromList (NE.toList (_txInputs tx)) <| utxo
+  txSize    = biSize tx
 
-  calculateMinimumFee :: MonadError TxValidationError m => TxFeePolicy -> m Coin
+  inputUTxO = S.fromList (NE.toList (_txInputs tx)) <| utxo
+
+  calculateMinimumFee
+    :: MonadError TxValidationError m => TxFeePolicy -> m Coin
   calculateMinimumFee = \case
+
     TxFeePolicyTxSizeLinear txSizeLinear ->
-      liftEither
-        . first (TxValidationCoinError "Minimum Fee")
-        . integerToCoin
-        . ceiling
-        $ calculateTxSizeLinear txSizeLinear txSize
+      integerToCoin (ceiling $ calculateTxSizeLinear txSizeLinear txSize)
+        `wrapError` TxValidationCoinError "Minimum Fee"
+
     policy -> throwError $ TxValidationUnknownFeePolicy policy
+
 
 -- | Validate that 'TxIn' is in the domain of 'UTxO'
 validateTxIn :: MonadError TxValidationError m => UTxO -> TxIn -> m ()
@@ -106,20 +132,86 @@ validateTxIn utxo txIn
   | txIn `UTxO.member` utxo = pure ()
   | otherwise               = throwError $ TxValidationMissingInput txIn
 
+
+-- | Verify that a 'TxInWitness' is a valid witness for the supplied 'TxSigData'
+validateWitness
+  :: MonadError TxValidationError m
+  => ProtocolMagic
+  -> TxSigData
+  -> Address
+  -> TxInWitness
+  -> m ()
+validateWitness pm sigData addr witness = case witness of
+
+  PkWitness pk sig -> unless
+    (checkSig pm SignTx pk sigData sig && checkPubKeyAddress pk addr)
+    (throwError $ TxValidationInvalidWitness witness)
+
+  RedeemWitness pk sig -> unless
+    (redeemCheckSig pm SignRedeemTx pk sigData sig && checkRedeemAddress pk addr
+    )
+    (throwError $ TxValidationInvalidWitness witness)
+
+  -- TODO: Support script witnesses for Shelley
+  ScriptWitness validator redeemer -> do
+    let
+      valVersion = scrVersion validator
+      redVersion = scrVersion redeemer
+    unless
+      (valVersion == redVersion && checkScriptAddress validator addr)
+      (throwError $ TxValidationInvalidWitness witness)
+    txScriptCheck sigData validator redeemer
+
+  UnknownWitnessType t _ -> throwError $ TxValidationUnknownWitnessType t
+ where
+
+  txScriptCheck
+    :: MonadError TxValidationError m => TxSigData -> Script -> Script -> m ()
+  txScriptCheck _ _ _ = throwError TxValidationScriptWitness
+
+
 data UTxOValidationError
   = UTxOValidationTxValidationError TxValidationError
   | UTxOValidationUTxOError UTxOError
   deriving (Eq, Show)
 
+
+-- | Validate a transaction and use it to update the 'UTxO'
 updateUTxO :: MonadError UTxOValidationError m => UTxO -> Tx -> m UTxO
 updateUTxO utxo tx = do
-  liftEither . first UTxOValidationTxValidationError $ validateTx
-    hardcodedTxFeePolicy
-    utxo
-    tx
-  liftEither . first UTxOValidationUTxOError $ UTxO.union
-    (S.fromList (NE.toList (_txInputs tx)) </| utxo)
-    (txOutputUTxO tx)
+
+  validateTx hardcodedTxFeePolicy utxo tx
+    `wrapError` UTxOValidationTxValidationError
+
+  UTxO.union (S.fromList (NE.toList (_txInputs tx)) </| utxo) (txOutputUTxO tx)
+    `wrapError` UTxOValidationUTxOError
+
  where
+
   hardcodedTxFeePolicy =
     TxFeePolicyTxSizeLinear $ TxSizeLinear (Coeff 155381) (Coeff 43.946)
+
+
+-- | Validate a transaction with a witness and use it to update the 'UTxO'
+updateUTxOWitness
+  :: MonadError UTxOValidationError m
+  => ProtocolMagic
+  -> UTxO
+  -> TxAux
+  -> m UTxO
+updateUTxOWitness pm utxo (TxAux tx witness) = do
+  let sigData = TxSigData $ hash tx
+
+  -- Get the signing addresses for each transaction input from the 'UTxO'
+  addresses <-
+    mapM (`UTxO.lookupAddress` utxo) (NE.toList $ _txInputs tx)
+      `wrapError` UTxOValidationUTxOError
+
+  -- Validate witnesses and their signing addresses
+  mapM_
+      (uncurry $ validateWitness pm sigData)
+      (zip addresses (V.toList witness))
+    `wrapError` UTxOValidationTxValidationError
+
+  -- Update 'UTxO' ignoring witnesses
+  updateUTxO utxo tx

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 3793d79323f2e7c34711cba80e6b24d01937d8f5
+    commit: 0889d18d3581026598b9268637475525064b76fe
     subdirs:
       - .
       - test

--- a/test/Test/Cardano/Chain/Txp/Validation.hs
+++ b/test/Test/Cardano/Chain/Txp/Validation.hs
@@ -34,52 +34,79 @@ import Cardano.Chain.Block
 import Cardano.Chain.Epoch.File
   (ParseError, parseEpochFile)
 import Cardano.Chain.Genesis
-  (readGenesisData)
+  (GenesisData (..), GenesisProtocolConstants (..), readGenesisData)
 import Cardano.Chain.Slotting
   (SlotId)
 import Cardano.Chain.Txp
-  (UTxO, UTxOValidationError, genesisUtxo, txpTxs, updateUTxO)
+  (TxPayload (..), UTxO, UTxOValidationError, genesisUtxo, updateUTxOWitness)
+import Cardano.Crypto
+  (ProtocolMagic)
 
 import Test.Cardano.Chain.Epoch.File
   (getEpochFiles)
 
 
+-- | These tests perform transaction validation over mainnet epoch files
+--
+--   We have chosen to split each epoch file into its own 'Property', because
+--   this leads to a clearer log of progress during testing. This requires an
+--   'IORef' to synchronise the 'UTxO' between epochs, as 'Property's do not
+--   return values.
 tests :: IO Bool
 tests = do
+
+  -- Get 'GenesisData' from the mainnet JSON configuration
   genesisData <- either (panic . sformat build) identity
     <$> runExceptT (readGenesisData "test/mainnet-genesis.json")
-  let utxo = genesisUtxo genesisData
-  utxoRef <- newIORef utxo
+
+  -- Extract mainnet 'ProtocolMagic'
+  let pm = gpcProtocolMagic $ gdProtocolConsts genesisData
+
+  -- Create an 'IORef' containing the genesis 'UTxO'
+  utxoRef <- newIORef $ genesisUtxo genesisData
+
+  -- Get a list of epoch files to perform validation on
   files   <- take 15 <$> getEpochFiles
+
+  -- Validate the transactions of each epoch file in a single 'Property' and
+  -- check them all sequentially
   let
     properties :: [(PropertyName, Property)]
-    properties = zip (fromString <$> files) (epochValid utxoRef <$> files)
+    properties = zip (fromString <$> files) (epochValid pm utxoRef <$> files)
   checkSequential $ Group "Test.Cardano.Chain.Txp.Validation" properties
+
 
 data Error
   = ErrorParseError ParseError
   | ErrorUTxOValidationError SlotId UTxOValidationError
   deriving (Eq, Show)
 
-epochValid :: IORef UTxO -> FilePath -> Property
-epochValid utxoRef fp = withTests 1 . property $ do
+
+-- | Check that a single epoch's transactions are valid by folding over 'Blund's
+epochValid :: ProtocolMagic -> IORef UTxO -> FilePath -> Property
+epochValid pm utxoRef fp = withTests 1 . property $ do
   utxo <- liftIO $ readIORef utxoRef
   let stream = parseEpochFile fp
-  result <- (liftIO . runResourceT . runExceptT) (foldUTxO utxo stream)
+  result <- (liftIO . runResourceT . runExceptT) (foldUTxO pm utxo stream)
   newUtxo <- evalEither result
   liftIO $ writeIORef utxoRef newUtxo
 
+
+-- | Fold transaction validation over a 'Stream' of 'Blund's
 foldUTxO
-  :: UTxO
+  :: ProtocolMagic
+  -> UTxO
   -> Stream (Of Blund) (ExceptT ParseError ResIO) ()
   -> ExceptT Error ResIO UTxO
-foldUTxO utxo blunds = S.foldM_
-  foldUTxOBlund
+foldUTxO pm utxo blunds = S.foldM_
+  (foldUTxOBlund pm)
   (pure utxo)
   pure
   (hoist (withExceptT ErrorParseError) blunds)
 
-foldUTxOBlund :: UTxO -> Blund -> ExceptT Error ResIO UTxO
-foldUTxOBlund utxo (block, _) =
+
+-- | Fold 'updateUTxO' over the transactions in a single 'Blund'
+foldUTxOBlund :: ProtocolMagic -> UTxO -> Blund -> ExceptT Error ResIO UTxO
+foldUTxOBlund pm utxo (block, _) =
   withExceptT (ErrorUTxOValidationError $ blockSlot block)
-    $ foldM updateUTxO utxo (txpTxs $ blockTxPayload block)
+    $ foldM (updateUTxOWitness pm) utxo (unTxPayload $ blockTxPayload block)


### PR DESCRIPTION
Added `updateUTxOWitness` to perform witness validation commposed with `updateUTxO` to match the style of the specs. This does not perform validation on `ScriptWitness`es.

I also cleaned up some of the other validation code and added more documentation. I have run this validation over the whole of mainnet and it was successful.