### PR TITLE
[#112] Add simple conditional testing infrastructure

### DIFF
--- a/binary/test/test.hs
+++ b/binary/test/test.hs
@@ -1,6 +1,8 @@
 import Cardano.Prelude
 import Test.Cardano.Prelude
 
+import System.Environment (withArgs)
+
 import Test.Hspec (hspec)
 
 import Spec (spec)
@@ -9,8 +11,13 @@ import qualified Test.Cardano.Binary.Bi
 import qualified Test.Cardano.Binary.BiSizeBounds
 
 
+-- | Main testing action
+--
+--   We use 'withArgs' to swallow common testing arguments that we want to parse
+--   with `optparse-applicative`. This is only temporary until we remove
+--   `hspec`, which is interfering.
 main :: IO ()
-main = do
+main = withArgs [] $ do
   hspec spec
   runTests
     [Test.Cardano.Binary.Bi.tests, Test.Cardano.Binary.BiSizeBounds.tests]

--- a/cardano-chain.cabal
+++ b/cardano-chain.cabal
@@ -180,6 +180,8 @@ test-suite cardano-chain-test
                        Test.Cardano.Chain.Update.Gen
                        Test.Cardano.Chain.Update.Json
 
+                       Test.Options
+
   build-depends:       base
                      , base16-bytestring
                      , bytestring
@@ -197,6 +199,7 @@ test-suite cardano-chain-test
                      , filepath
                      , formatting
                      , hedgehog
+                     , optparse-applicative
                      , resourcet
                      , streaming
                      , text

--- a/crypto/test/test.hs
+++ b/crypto/test/test.hs
@@ -1,13 +1,21 @@
 import Cardano.Prelude
 import Test.Cardano.Prelude
 
+import System.Environment (withArgs)
+
 import Test.Hspec (hspec)
 
 import Spec (spec)
 
 import qualified Test.Cardano.Crypto.Bi
 
+
+-- | Main testing action
+--
+--   We use 'withArgs' to swallow common testing arguments that we want to parse
+--   with `optparse-applicative`. This is only temporary until we remove
+--   `hspec`, which is interfering.
 main :: IO ()
-main = do
+main = withArgs [] $ do
   hspec spec
   runTests [Test.Cardano.Crypto.Bi.tests]

--- a/scripts/buildkite/rebuild.hs
+++ b/scripts/buildkite/rebuild.hs
@@ -44,7 +44,8 @@ buildStep = do
   buildArgs    = ["--bench", "--no-run-benchmarks", "--no-haddock-deps"]
   buildAndTest = stackBuild $ ["--tests"] ++ buildArgs
   build        = stackBuild $ ["--no-run-tests"] ++ buildArgs
-  test         = stackBuild ["--test", "--jobs", "1"]
+  test         = stackBuild
+    ["--test", "--jobs", "1", "--ta", "--scenario=ContinuousIntegration"]
 
 -- buildkite agents have S3 creds installed, but under different names
 awsCreds :: IO ()

--- a/test/Test/Options.hs
+++ b/test/Test/Options.hs
@@ -1,0 +1,60 @@
+module Test.Options
+  ( Opts(..)
+  , optsParser
+  , TestScenario(..)
+  )
+where
+
+import Cardano.Prelude
+
+import Options.Applicative as Opts
+  ( Parser
+  , ParserInfo
+  , auto
+  , help
+  , helper
+  , info
+  , long
+  , metavar
+  , option
+  , short
+  , value
+  )
+
+
+--------------------------------------------------------------------------------
+-- Opts
+--------------------------------------------------------------------------------
+
+newtype Opts = Opts
+  { optsTestScenario :: TestScenario
+  }
+
+optsParser :: ParserInfo Opts
+optsParser = info (parser <**> helper) mempty
+  where parser = Opts <$> testScenarioParser
+
+
+--------------------------------------------------------------------------------
+-- TestScenario
+--------------------------------------------------------------------------------
+
+data TestScenario
+  = ContinuousIntegration
+  | Development
+  | QualityAssurance
+  deriving (Read)
+
+testScenarioParser :: Parser TestScenario
+testScenarioParser = Opts.option
+  auto
+  (  short 's'
+  <> long "scenario"
+  <> metavar "TEST_SCENARIO"
+  <> help helpText
+  <> value Development
+  )
+ where
+  helpText =
+    "Run under one of Development (default), ContinuousIntegration, or "
+      <> "QualityAssurance, to affect how tests are run"

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,6 +1,10 @@
 import Cardano.Prelude
 import Test.Cardano.Prelude
 
+import Options.Applicative (execParser)
+
+import Test.Options (Opts(..), optsParser)
+
 import qualified Test.Cardano.Chain.Block.Bi
 import qualified Test.Cardano.Chain.Delegation.Bi
 import qualified Test.Cardano.Chain.Epoch.File
@@ -13,15 +17,17 @@ import qualified Test.Cardano.Chain.Update.Bi
 import qualified Test.Cardano.Chain.Update.Json
 
 main :: IO ()
-main = runTests
-  [ Test.Cardano.Chain.Block.Bi.tests
-  , Test.Cardano.Chain.Delegation.Bi.tests
-  , Test.Cardano.Chain.Epoch.File.tests
-  , Test.Cardano.Chain.Genesis.Json.tests
-  , Test.Cardano.Chain.Ssc.Bi.tests
-  , Test.Cardano.Chain.Txp.Bi.tests
-  , Test.Cardano.Chain.Txp.Json.tests
-  , Test.Cardano.Chain.Txp.Validation.tests
-  , Test.Cardano.Chain.Update.Bi.tests
-  , Test.Cardano.Chain.Update.Json.tests
-  ]
+main = do
+  opts <- execParser optsParser
+  runTests
+    [ Test.Cardano.Chain.Block.Bi.tests
+    , Test.Cardano.Chain.Delegation.Bi.tests
+    , Test.Cardano.Chain.Epoch.File.tests
+    , Test.Cardano.Chain.Genesis.Json.tests
+    , Test.Cardano.Chain.Ssc.Bi.tests
+    , Test.Cardano.Chain.Txp.Bi.tests
+    , Test.Cardano.Chain.Txp.Json.tests
+    , Test.Cardano.Chain.Txp.Validation.tests $ optsTestScenario opts
+    , Test.Cardano.Chain.Update.Bi.tests
+    , Test.Cardano.Chain.Update.Json.tests
+    ]


### PR DESCRIPTION
- Added `TestScenario` and `optparse-applicative` option for it
- Used it to modify number of epoch files read during txp validation, so CI now validates the whole chain
- Update buildkite config to use `--ta --scenario=ContinuousIntegration`