### PR TITLE
[#146] Import and clean up configuration functions

### DIFF
--- a/cardano-chain.cabal
+++ b/cardano-chain.cabal
@@ -67,6 +67,7 @@ library
                        Cardano.Chain.Genesis.Config
                        Cardano.Chain.Genesis.Data
                        Cardano.Chain.Genesis.Delegation
+                       Cardano.Chain.Genesis.Generate
                        Cardano.Chain.Genesis.Hash
                        Cardano.Chain.Genesis.Initializer
                        Cardano.Chain.Genesis.NonAvvmBalances
@@ -120,6 +121,7 @@ library
                      , containers
                      , cryptonite
                      , Cabal
+                     , filepath
                      , formatting
                      , lens
                      , memory

--- a/crypto/src/Cardano/Crypto/Signing/Safe.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Safe.hs
@@ -50,6 +50,7 @@ import Cardano.Crypto.Signing.Types.Safe
   , checkPassMatches
   , emptyPassphrase
   , encToPublic
+  , encToSecret
   , mkEncSecretUnsafe
   , mkEncSecretWithSaltUnsafe
   , noPassEncrypt

--- a/src/Cardano/Chain/Common/Lovelace.hs
+++ b/src/Cardano/Chain/Common/Lovelace.hs
@@ -27,7 +27,7 @@ module Cardano.Chain.Common.Lovelace
   , mkKnownLovelace
   , lovelaceF
   , maxLovelaceVal
-  , sumLovelaces
+  , sumLovelace
 
        -- * Conversions
   , unsafeGetLovelace
@@ -39,6 +39,7 @@ module Cardano.Chain.Common.Lovelace
   , subLovelace
   , scaleLovelace
   , divLovelace
+  , modLovelace
   )
 where
 
@@ -144,9 +145,9 @@ unsafeGetLovelace = getLovelace
 
 -- | Compute sum of all lovelace in container. Result is 'Integer' as a
 --   protection against possible overflow.
-sumLovelaces
+sumLovelace
   :: (Foldable t, Functor t) => t Lovelace -> Either LovelaceError Lovelace
-sumLovelaces = integerToLovelace . sum . map lovelaceToInteger
+sumLovelace = integerToLovelace . sum . map lovelaceToInteger
 
 lovelaceToInteger :: Lovelace -> Integer
 lovelaceToInteger = toInteger . unsafeGetLovelace
@@ -180,6 +181,11 @@ scaleLovelace (unsafeGetLovelace -> a) b
 divLovelace :: Integral b => Lovelace -> b -> Lovelace
 divLovelace (unsafeGetLovelace -> a) b = Lovelace (a `div` fromIntegral b)
 {-# INLINE divLovelace #-}
+
+-- | Integer modulus of a 'Lovelace' by an 'Integral' factor
+modLovelace :: Integral b => Lovelace -> b -> Lovelace
+modLovelace (Lovelace a) b = Lovelace (a `mod` fromIntegral b)
+{-# INLINE modLovelace #-}
 
 integerToLovelace :: Integer -> Either LovelaceError Lovelace
 integerToLovelace n

--- a/src/Cardano/Chain/Common/StakeholderId.hs
+++ b/src/Cardano/Chain/Common/StakeholderId.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE UndecidableInstances       #-}
 
 module Cardano.Chain.Common.StakeholderId
-  ( StakeholderId(..)
+  ( StakeholderId
   , mkStakeholderId
   , shortStakeholderF
   )

--- a/src/Cardano/Chain/Genesis/AvvmBalances.hs
+++ b/src/Cardano/Chain/Genesis/AvvmBalances.hs
@@ -22,7 +22,7 @@ import Cardano.Crypto.Signing.Redeem (RedeemPublicKey)
 -- | Predefined balances of avvm entries.
 newtype GenesisAvvmBalances = GenesisAvvmBalances
   { getGenesisAvvmBalances :: Map RedeemPublicKey Lovelace
-  } deriving (Show, Eq)
+  } deriving (Show, Eq, Semigroup)
 
 instance Monad m => ToJSON m GenesisAvvmBalances where
     toJSON = toJSON . getGenesisAvvmBalances

--- a/src/Cardano/Chain/Genesis/Config.hs
+++ b/src/Cardano/Chain/Genesis/Config.hs
@@ -1,12 +1,31 @@
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
 
 module Cardano.Chain.Genesis.Config
   ( StaticConfig(..)
+  , Config(..)
+  , configK
+  , configSlotSecurityParam
+  , configChainQualityThreshold
+  , configEpochSlots
+  , configGeneratedSecretsThrow
+  , configBootStakeholders
+  , configHeavyDelegation
+  , configStartTime
+  , configNonAvvmBalances
+  , configBlockVersionData
+  , configAvvmDistr
+  , mkConfig
+  , mkConfigFromStaticConfig
   )
 where
 
 import Cardano.Prelude
 
+import Control.Monad.Except (MonadError(..), liftEither)
 import Data.Aeson
   ( FromJSON
   , ToJSON
@@ -22,25 +41,40 @@ import Data.Aeson
   )
 import Data.Aeson.Encoding (pairStr)
 import Data.Aeson.Encoding.Internal (pair)
+import Data.Coerce (coerce)
+import Data.Time (UTCTime)
+import System.FilePath ((</>))
+import System.IO.Error (userError)
 
 import Cardano.Binary.Class (Raw)
+import Cardano.Chain.Genesis.Data
+  (GenesisData(..), GenesisDataError, readGenesisData)
+import Cardano.Chain.Genesis.Hash (GenesisHash(..))
 import Cardano.Chain.Genesis.AvvmBalances (GenesisAvvmBalances(..))
 import Cardano.Chain.Genesis.Initializer (GenesisInitializer(..))
+import Cardano.Chain.Genesis.Generate
+  (GeneratedSecrets, GenesisDataGenerationError, generateGenesisData)
 import Cardano.Chain.Genesis.Spec (GenesisSpec(..))
-import Cardano.Crypto.Hashing (Hash)
+import Cardano.Chain.Genesis.WStakeholders (GenesisWStakeholders)
+import Cardano.Chain.Genesis.Delegation (GenesisDelegation)
+import Cardano.Chain.Genesis.NonAvvmBalances (GenesisNonAvvmBalances)
+import Cardano.Crypto (Hash, hash)
+import Cardano.Chain.Common (BlockCount)
+import Cardano.Chain.Slotting (SlotCount)
+import Cardano.Chain.Update (BlockVersionData)
+import Cardano.Chain.ProtocolConstants
+  (kEpochSlots, kSlotSecurityParam, kChainQualityThreshold)
+
 
 --------------------------------------------------------------------------------
 -- StaticConfig
 --------------------------------------------------------------------------------
 
 data StaticConfig
-    -- | Genesis from a 'GenesisSpec'.
   = GCSpec !GenesisSpec
-    -- | 'GenesisData' is stored in a file.
+  -- ^ Genesis from a 'GenesisSpec'
   | GCSrc !FilePath !(Hash Raw)
-    -- !FilePath = Path to file where 'GenesisData' is stored. Must be
-    -- in JSON, not necessary canonical.
-    -- !(Hash Raw) = Hash of canonically encoded 'GenesisData'.
+  -- ^ 'GenesisData' is stored in at 'FilePath' with expected 'Hash Raw'
   deriving (Eq, Show)
 
 instance ToJSON StaticConfig where
@@ -62,10 +96,7 @@ instance FromJSON StaticConfig where
   parseJSON = withObject "StaticConfig" $ \o -> do
     src <- o .:? "src"
     case src of
-      Just src' -> do
-        file <- src' .: "file"
-        hash <- src' .: "hash"
-        pure $ GCSrc file hash
+      Just src' -> GCSrc <$> src' .: "file" <*> src' .: "hash"
       Nothing -> do
         specO <- o .: "spec"
         -- GenesisAvvmBalances
@@ -106,3 +137,150 @@ instance FromJSON StaticConfig where
               avvmBalanceFactor
               useHeavyDlg
               seed)
+
+
+--------------------------------------------------------------------------------
+-- Config
+--------------------------------------------------------------------------------
+
+data Config = Config
+    { configGenesisData       :: GenesisData
+    -- ^ The data needed at genesis
+    , configGenesisHash       :: GenesisHash
+    -- ^ The hash of the canonical JSON representation of the 'GenesisData'
+    , configGeneratedSecrets  :: Maybe GeneratedSecrets
+    -- ^ Secrets needed to access 'GenesisData' in testing
+    --
+    --   TODO: Figure out how to split testing and mainnet needs
+    }
+
+configK :: Config -> BlockCount
+configK = gdK . configGenesisData
+
+configSlotSecurityParam :: Config -> SlotCount
+configSlotSecurityParam = kSlotSecurityParam . configK
+
+configChainQualityThreshold :: Fractional f => Config -> f
+configChainQualityThreshold = kChainQualityThreshold . configK
+
+configEpochSlots :: Config -> SlotCount
+configEpochSlots = kEpochSlots . configK
+
+configGeneratedSecretsThrow :: MonadIO m => Config -> m GeneratedSecrets
+configGeneratedSecretsThrow =
+  maybe
+      (liftIO $ throwIO $ userError
+        "GeneratedSecrets missing from Genesis.Config"
+      )
+      pure
+    . configGeneratedSecrets
+
+configBootStakeholders :: Config -> GenesisWStakeholders
+configBootStakeholders = gdBootStakeholders . configGenesisData
+
+configHeavyDelegation :: Config -> GenesisDelegation
+configHeavyDelegation = gdHeavyDelegation . configGenesisData
+
+configStartTime :: Config -> UTCTime
+configStartTime = gdStartTime . configGenesisData
+
+configNonAvvmBalances :: Config -> GenesisNonAvvmBalances
+configNonAvvmBalances = gdNonAvvmBalances . configGenesisData
+
+configBlockVersionData :: Config -> BlockVersionData
+configBlockVersionData = gdBlockVersionData . configGenesisData
+
+configAvvmDistr :: Config -> GenesisAvvmBalances
+configAvvmDistr = gdAvvmDistr . configGenesisData
+
+-- | Construct a 'Config' from a 'StaticConfig'
+--
+--   If the 'StaticConfig' refers to a canonical JSON file, then it will be
+--   hashed and checked against the expected hash.
+--
+--   If the 'StaticConfig' contains a 'GenesisSpec', then a full 'GenesisData'
+--   will be generated. In this case a start time must be provided.
+mkConfigFromStaticConfig
+  :: (MonadError ConfigurationError m, MonadIO m)
+  => FilePath
+  -- ^ Directory where 'configuration.yaml' is stored
+  -> Maybe UTCTime
+  -- ^ Optional system start time.
+  --   It must be given when the genesis spec uses a testnet initializer.
+  -> Maybe Integer
+  -- ^ Optional seed which overrides one from testnet initializer if provided
+  -> StaticConfig
+  -> m Config
+mkConfigFromStaticConfig confDir mSystemStart mSeed = \case
+  -- If a 'GenesisData' source file is given, we check its hash against the
+  -- given expected hash, parse it, and use the GenesisData to fill in all of
+  -- the obligations.
+  GCSrc fp expectedHash -> do
+
+    when (isJust mSystemStart) $ throwError UnnecessarySystemStartTime
+
+    when (isJust mSeed) $ throwError MeaninglessSeed
+
+    (genesisData, genesisHash) <-
+      liftEither . first ConfigurationGenesisDataError =<< runExceptT
+        (readGenesisData (confDir </> fp))
+
+    unless
+      (getGenesisHash genesisHash == expectedHash)
+      (throwError $ GenesisHashMismatch genesisHash expectedHash)
+
+    pure $ Config
+      { configGenesisData      = genesisData
+      , configGenesisHash      = genesisHash
+      , configGeneratedSecrets = Nothing
+      }
+
+  -- If a 'GenesisSpec' is given, we ensure we have a start time (needed if it's
+  -- a testnet initializer) and then make a 'GenesisData' from it.
+  GCSpec spec -> do
+
+    systemStart <- maybe (throwError MissingSystemStartTime) pure mSystemStart
+
+    -- Override seed if necessary
+    let
+      overrideSeed :: Integer -> GenesisInitializer -> GenesisInitializer
+      overrideSeed newSeed gi = gi { giSeed = newSeed }
+
+    let
+      spec' = case mSeed of
+        Nothing -> spec
+        Just newSeed ->
+          spec { gsInitializer = overrideSeed newSeed (gsInitializer spec) }
+
+    mkConfig systemStart spec'
+
+mkConfig
+  :: MonadError ConfigurationError m => UTCTime -> GenesisSpec -> m Config
+mkConfig startTime genesisSpec = do
+  (genesisData, generatedSecrets) <-
+    liftEither . first ConfigurationGenerationError $ generateGenesisData
+      startTime
+      genesisSpec
+
+  pure $ Config
+    { configGenesisData      = genesisData
+    , configGenesisHash      = genesisHash
+    , configGeneratedSecrets = Just generatedSecrets
+    }
+  where
+    -- Anything will do for the genesis hash. A hash of "patak" was used before,
+    -- and so it remains.
+        genesisHash = GenesisHash $ coerce $ hash @Text "patak"
+
+data ConfigurationError
+  = MissingSystemStartTime
+  -- ^ A system start time must be given when a testnet genesis is used
+  | UnnecessarySystemStartTime
+  -- ^ Must not give a custom system start time when using a mainnet genesis
+  | ConfigurationGenesisDataError GenesisDataError
+  -- ^ An error in constructing 'GenesisData'
+  | GenesisHashMismatch GenesisHash (Hash Raw)
+  -- ^ The GenesisData canonical JSON hash is different than expected
+  | MeaninglessSeed
+  -- ^ Custom seed was provided, but it doesn't make sense
+  | ConfigurationGenerationError GenesisDataGenerationError

--- a/src/Cardano/Chain/Genesis/Delegation.hs
+++ b/src/Cardano/Chain/Genesis/Delegation.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
@@ -8,21 +9,22 @@
 
 module Cardano.Chain.Genesis.Delegation
   ( GenesisDelegation(..)
+  , GenesisDelegationError
   , mkGenesisDelegation
   )
 where
 
 import Cardano.Prelude
 
-import Control.Lens (at, (^.))
 import Control.Monad.Except (MonadError)
 import qualified Data.Aeson as Aeson
 import Data.List (nub)
 import qualified Data.Map.Strict as M
-import Formatting (build, sformat)
+import Formatting (build, formatToString, bprint)
+import qualified Formatting.Buildable as B
 import Text.JSON.Canonical (FromJSON(..), ReportSchemaErrors(..), ToJSON(..))
 
-import Cardano.Chain.Common (StakeholderId(..), addressHash)
+import Cardano.Chain.Common (StakeholderId, mkStakeholderId)
 import Cardano.Chain.Delegation.HeavyDlgIndex (ProxySKHeavy)
 import Cardano.Crypto (isSelfSignedPsk, pskDelegatePk, pskIssuerPk)
 
@@ -48,7 +50,7 @@ instance MonadError SchemaError m => FromJSON m GenesisDelegation where
   fromJSON val = do
     psks <- fromJSON val
     case recreateGenesisDelegation psks of
-      Left err -> expected "GenesisDelegation" (Just $ "Error: " <> toS err)
+      Left err -> expected "GenesisDelegation" (Just $ "Error: " <> formatToString build err)
       Right delegation -> pure delegation
 
 instance Aeson.ToJSON GenesisDelegation where
@@ -59,39 +61,67 @@ instance Aeson.FromJSON GenesisDelegation where
     (elems' :: Map StakeholderId ProxySKHeavy) <- mapM Aeson.parseJSON v
     toAesonError $ recreateGenesisDelegation elems'
 
+data GenesisDelegationError
+  = GenesisDelegationDuplicateIssuer
+  | GenesisDelegationInvalidKey StakeholderId StakeholderId
+  | GenesisDelegationMultiLayerDelegation StakeholderId
+  | GenesisDelegationSelfSignedPsk ProxySKHeavy
+  deriving (Eq, Show)
+
+instance B.Buildable GenesisDelegationError where
+  build = \case
+    GenesisDelegationDuplicateIssuer ->
+      bprint
+        "Encountered duplicate issuer PublicKey while constructing GenesisDelegation."
+    GenesisDelegationInvalidKey k k' -> bprint
+      ( "Invalid key in GenesisDelegation map.\nExpected: "
+      . build
+      . "\nGot: "
+      . build
+      )
+      k
+      k'
+    GenesisDelegationMultiLayerDelegation k -> bprint
+      ( "Encountered multi-layer delegation.\n"
+      . build
+      . " is a delegate and an issuer."
+      )
+      k
+    GenesisDelegationSelfSignedPsk psk -> bprint
+      ("Encountered self-signed ProxySecretKey while constructing GenesisDelegation.\n"
+      . build
+      )
+      psk
+
 -- | Safe constructor of 'GenesisDelegation' from a list of PSKs.
 mkGenesisDelegation
-  :: MonadError Text m => [ProxySKHeavy] -> m GenesisDelegation
+  :: MonadError GenesisDelegationError m
+  => [ProxySKHeavy]
+  -> m GenesisDelegation
 mkGenesisDelegation psks = do
-  unless ((length . nub $ pskIssuerPk <$> psks) == length psks)
-    $ throwError "all issuers must be distinct"
+  unless
+    ((length . nub $ pskIssuerPk <$> psks) == length psks)
+    (throwError GenesisDelegationDuplicateIssuer)
   let
-    res = M.fromList
-      [ (StakeholderId $ addressHash (pskIssuerPk psk), psk) | psk <- psks ]
+    res = M.fromList [ (mkStakeholderId $ pskIssuerPk psk, psk) | psk <- psks ]
   recreateGenesisDelegation res
 
 -- | Safe constructor of 'GenesisDelegation' from existing map.
 recreateGenesisDelegation
-  :: MonadError Text m => Map StakeholderId ProxySKHeavy -> m GenesisDelegation
+  :: MonadError GenesisDelegationError m
+  => Map StakeholderId ProxySKHeavy
+  -> m GenesisDelegation
 recreateGenesisDelegation pskMap = do
-  forM_ (M.toList pskMap) $ \(k, psk) ->
-    when ((StakeholderId $ addressHash (pskIssuerPk psk)) /= k)
-      $ throwError
-      $ sformat
-          ( "wrong issuerPk set as key for delegation map: "
-          . "issuer id = "
-          . build
-          . ", cert id = "
-          . build
-          )
-          k
-          (addressHash (pskIssuerPk psk))
-  when (any isSelfSignedPsk pskMap)
-    $ throwError "there is a self-signed (revocation) psk"
-  let
-    isIssuer psk =
-      isJust $ pskMap ^. at (StakeholderId $ addressHash (pskDelegatePk psk))
+  forM_ (M.toList pskMap) $ \(k, psk) -> do
 
-  when (any isIssuer pskMap)
-    $ throwError "one of the delegates is also an issuer, don't do it"
-  return $ UnsafeGenesisDelegation pskMap
+    let k' = mkStakeholderId $ pskIssuerPk psk
+    unless (k == k') (throwError $ GenesisDelegationInvalidKey k k')
+
+    when (isSelfSignedPsk psk) (throwError $ GenesisDelegationSelfSignedPsk psk)
+
+    let delegateId = mkStakeholderId $ pskDelegatePk psk
+    when
+      (delegateId `M.member` pskMap)
+      (throwError $ GenesisDelegationMultiLayerDelegation delegateId)
+
+  pure $ UnsafeGenesisDelegation pskMap

--- a/src/Cardano/Chain/Genesis/Generate.hs
+++ b/src/Cardano/Chain/Genesis/Generate.hs
@@ -1,0 +1,343 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE TypeApplications  #-}
+
+-- | Generation of genesis data for testnet
+
+module Cardano.Chain.Genesis.Generate
+  ( GeneratedSecrets(..)
+  , gsSecretKeys
+  , gsSecretKeysPoor
+  , PoorSecret(..)
+  , generateGenesisData
+  , GenesisDataGenerationError(..)
+
+  -- * Helpers which are also used by keygen.
+  , poorSecretToEncKey
+  , poorSecretToKey
+  )
+where
+
+import Cardano.Prelude
+
+import Control.Lens (coerced, (%~))
+import Control.Monad.Except (liftEither)
+import Crypto.Random (MonadRandom, getRandomBytes)
+import qualified Data.Map.Strict as M
+import Data.Time (UTCTime)
+
+import Cardano.Binary.Class (serialize')
+import Cardano.Chain.Common
+  ( Address
+  , IsBootstrapEraAddr(..)
+  , Lovelace
+  , LovelaceError
+  , addLovelace
+  , applyLovelacePortionDown
+  , deriveFirstHDAddress
+  , divLovelace
+  , makePubKeyAddressBoot
+  , mkKnownLovelace
+  , mkStakeholderId
+  , modLovelace
+  , scaleLovelace
+  , subLovelace
+  , sumLovelace
+  )
+import Cardano.Chain.Delegation.HeavyDlgIndex (HeavyDlgIndex(..), ProxySKHeavy)
+import Cardano.Chain.Genesis.AvvmBalances (GenesisAvvmBalances(..))
+import Cardano.Chain.Genesis.Data (GenesisData(..))
+import Cardano.Chain.Genesis.Delegation
+  (GenesisDelegation(..), GenesisDelegationError, mkGenesisDelegation)
+import Cardano.Chain.Genesis.Initializer
+  (FakeAvvmOptions(..), GenesisInitializer(..), TestnetBalanceOptions(..))
+import Cardano.Chain.Genesis.NonAvvmBalances (GenesisNonAvvmBalances(..))
+import Cardano.Chain.Genesis.Spec (GenesisSpec(..))
+import Cardano.Chain.Genesis.WStakeholders (GenesisWStakeholders(..))
+import Cardano.Crypto
+  ( EncryptedSecretKey
+  , SecretKey
+  , createPsk
+  , deterministic
+  , emptyPassphrase
+  , encToSecret
+  , keyGen
+  , noPassEncrypt
+  , redeemDeterministicKeyGen
+  , safeKeyGen
+  , toPublic
+  )
+
+
+-- | Poor node secret
+data PoorSecret = PoorSecret SecretKey | PoorEncryptedSecret EncryptedSecretKey
+
+-- | Valuable secrets which can unlock genesis data.
+data GeneratedSecrets = GeneratedSecrets
+    { gsDlgIssuersSecrets :: ![SecretKey]
+    -- ^ Secret keys which issued heavyweight delegation certificates
+    -- in genesis data. If genesis heavyweight delegation isn't used,
+    -- this list is empty.
+    , gsRichSecrets       :: ![SecretKey]
+    -- ^ All secrets of rich nodes.
+    , gsPoorSecrets       :: ![PoorSecret]
+    -- ^ Keys for HD addresses of poor nodes.
+    , gsFakeAvvmSeeds     :: ![ByteString]
+    -- ^ Fake avvm seeds.
+    }
+
+gsSecretKeys :: GeneratedSecrets -> [SecretKey]
+gsSecretKeys gs = gsRichSecrets gs <> gsSecretKeysPoor gs
+
+gsSecretKeysPoor :: GeneratedSecrets -> [SecretKey]
+gsSecretKeysPoor = map poorSecretToKey . gsPoorSecrets
+
+data GenesisDataGenerationError
+  = GenesisDataAddressBalanceMismatch Text Int Int
+  | GenesisDataGenerationDelegationError GenesisDelegationError
+  | GenesisDataGenerationDistributionMismatch Lovelace Lovelace
+  | GenesisDataGenerationLovelaceError LovelaceError
+  | GenesisDataGenerationPassPhraseMismatch
+  | GenesisDataGenerationRedeemKeyGen
+  deriving (Eq, Show)
+
+generateGenesisData
+  :: MonadError GenesisDataGenerationError m
+  => UTCTime
+  -> GenesisSpec
+  -> m (GenesisData, GeneratedSecrets)
+generateGenesisData startTime genesisSpec = do
+
+  -- Bootstrap stakeholders
+  let
+    bootSecrets = if giUseHeavyDlg gi then dlgIssuersSecrets else richSecrets
+
+    bootStakeholders :: GenesisWStakeholders
+    bootStakeholders = GenesisWStakeholders $ M.fromList $ map
+      ((, 1) . mkStakeholderId . toPublic)
+      bootSecrets
+
+  -- Heavyweight delegation.
+  -- genesisDlgList is empty if giUseHeavyDlg = False
+  let
+    genesisDlgList :: [ProxySKHeavy]
+    genesisDlgList =
+      (\(issuerSK, delegateSK) ->
+          createPsk pm issuerSK (toPublic delegateSK) (HeavyDlgIndex 0)
+        )
+        <$> zip dlgIssuersSecrets richSecrets
+
+  genesisDlg <-
+    liftEither
+    .  first GenesisDataGenerationDelegationError
+    $  mkGenesisDelegation
+    $  M.elems (unGenesisDelegation $ gsHeavyDelegation genesisSpec)
+    <> genesisDlgList
+
+  -- Real AVVM Balances
+  let
+    applyAvvmBalanceFactor :: Map k Lovelace -> Map k Lovelace
+    applyAvvmBalanceFactor =
+      map (applyLovelacePortionDown $ giAvvmBalanceFactor gi)
+
+    realAvvmMultiplied :: GenesisAvvmBalances
+    realAvvmMultiplied = realAvvmBalances & coerced %~ applyAvvmBalanceFactor
+
+  -- Fake AVVM Balances
+  fakeAvvmPublicKeys <-
+    mapM (maybe (throwError GenesisDataGenerationRedeemKeyGen) (pure . fst))
+      $ fmap redeemDeterministicKeyGen (gsFakeAvvmSeeds generatedSecrets)
+  let
+    fakeAvvmDistr = GenesisAvvmBalances . M.fromList $ map
+      (, faoOneBalance fao)
+      fakeAvvmPublicKeys
+
+  -- Non AVVM balances
+  ---- Addresses
+  let
+    createAddressPoor
+      :: MonadError GenesisDataGenerationError m => PoorSecret -> m Address
+    createAddressPoor (PoorEncryptedSecret hdwSk) =
+      maybe (throwError GenesisDataGenerationPassPhraseMismatch) (pure . fst)
+        $ deriveFirstHDAddress (IsBootstrapEraAddr True) emptyPassphrase hdwSk
+    createAddressPoor (PoorSecret secret) =
+      pure $ makePubKeyAddressBoot (toPublic secret)
+  let richAddresses = map (makePubKeyAddressBoot . toPublic) richSecrets
+
+  poorAddresses        <- mapM createAddressPoor poorSecrets
+
+  ---- Balances
+  totalFakeAvvmBalance <-
+    liftEither . first GenesisDataGenerationLovelaceError $ scaleLovelace
+      (faoOneBalance fao)
+      (faoCount fao)
+
+  -- Compute total balance to generate
+  avvmSum <-
+    liftEither
+    . first GenesisDataGenerationLovelaceError
+    $ sumLovelace
+    $ getGenesisAvvmBalances realAvvmMultiplied
+  maxTnBalance <-
+    liftEither . first GenesisDataGenerationLovelaceError $ subLovelace
+      maxBound
+      avvmSum
+  let tnBalance = min maxTnBalance (tboTotalBalance tbo)
+
+  let
+    safeZip
+      :: MonadError GenesisDataGenerationError m
+      => Text
+      -> [a]
+      -> [b]
+      -> m [(a, b)]
+    safeZip s a b = if length a /= length b
+      then throwError
+        $ GenesisDataAddressBalanceMismatch s (length a) (length b)
+      else pure $ zip a b
+
+  nonAvvmBalance <-
+    liftEither . first GenesisDataGenerationLovelaceError $ subLovelace
+      tnBalance
+      totalFakeAvvmBalance
+
+  (richBals, poorBals) <- genTestnetDistribution tbo nonAvvmBalance
+
+  richDistr            <- safeZip "richDistr" richAddresses richBals
+  poorDistr            <- safeZip "poorDistr" poorAddresses poorBals
+
+  let
+    nonAvvmDistr = GenesisNonAvvmBalances . M.fromList $ richDistr ++ poorDistr
+
+  let
+    genesisData = GenesisData
+      { gdBootStakeholders = bootStakeholders
+      , gdHeavyDelegation  = genesisDlg
+      , gdStartTime        = startTime
+      , gdNonAvvmBalances  = nonAvvmDistr
+      , gdBlockVersionData = gsBlockVersionData genesisSpec
+      , gdK                = gsK genesisSpec
+      , gdProtocolMagic    = pm
+      , gdAvvmDistr        = fakeAvvmDistr <> realAvvmMultiplied
+      }
+
+  pure (genesisData, generatedSecrets)
+ where
+  pm                = gsProtocolMagic genesisSpec
+  realAvvmBalances  = gsAvvmDistr genesisSpec
+
+  gi                = gsInitializer genesisSpec
+
+  generatedSecrets  = generateSecrets gi
+  dlgIssuersSecrets = gsDlgIssuersSecrets generatedSecrets
+  richSecrets       = gsRichSecrets generatedSecrets
+  poorSecrets       = gsPoorSecrets generatedSecrets
+
+  fao               = giFakeAvvmBalance gi
+  tbo               = giTestBalance gi
+
+
+generateSecrets :: GenesisInitializer -> GeneratedSecrets
+generateSecrets gi = deterministic (serialize' $ giSeed gi) $ do
+
+  -- Generate fake AVVM seeds
+  fakeAvvmSeeds <- replicateM (fromIntegral $ faoCount fao) (getRandomBytes 32)
+
+  -- Generate secret keys
+  dlgIssuersSecrets <- if giUseHeavyDlg gi
+    then replicateRich (snd <$> keyGen)
+    else pure []
+
+  richSecrets <- replicateRich (snd <$> keyGen)
+
+  poorSecrets <- replicateM (fromIntegral $ tboPoors tbo) genPoorSecret
+
+  pure $ GeneratedSecrets
+    { gsDlgIssuersSecrets = dlgIssuersSecrets
+    , gsRichSecrets       = richSecrets
+    , gsPoorSecrets       = poorSecrets
+    , gsFakeAvvmSeeds     = fakeAvvmSeeds
+    }
+ where
+  fao = giFakeAvvmBalance gi
+  tbo = giTestBalance gi
+
+  replicateRich :: Applicative m => m a -> m [a]
+  replicateRich = replicateM (fromIntegral $ tboRichmen tbo)
+
+  genPoorSecret :: MonadRandom m => m PoorSecret
+  genPoorSecret = if tboUseHDAddresses tbo
+    then PoorEncryptedSecret . snd <$> safeKeyGen emptyPassphrase
+    else PoorSecret . snd <$> keyGen
+
+
+----------------------------------------------------------------------------
+-- Exported helpers
+----------------------------------------------------------------------------
+
+poorSecretToKey :: PoorSecret -> SecretKey
+poorSecretToKey (PoorSecret          key   ) = key
+poorSecretToKey (PoorEncryptedSecret encKey) = encToSecret encKey
+
+poorSecretToEncKey :: PoorSecret -> EncryptedSecretKey
+poorSecretToEncKey (PoorSecret          key ) = noPassEncrypt key
+poorSecretToEncKey (PoorEncryptedSecret encr) = encr
+
+
+----------------------------------------------------------------------------
+-- Internal helpers
+----------------------------------------------------------------------------
+
+-- | Generates balance distribution for testnet
+genTestnetDistribution
+  :: MonadError GenesisDataGenerationError m
+  => TestnetBalanceOptions
+  -> Lovelace
+  -> m ([Lovelace], [Lovelace])
+genTestnetDistribution tbo testBalance = do
+
+  (richBalances, poorBalances, totalBalance) <-
+    liftEither . first GenesisDataGenerationLovelaceError $ do
+      oneRichmanBalance <- if numRichmen == 0
+        then pure $ mkKnownLovelace @0
+        else addLovelace
+          (divLovelace desiredRichBalance numRichmen)
+          (if modLovelace desiredRichBalance numRichmen > mkKnownLovelace @0
+            then mkKnownLovelace @1
+            else mkKnownLovelace @0
+          )
+
+      realRichBalance     <- scaleLovelace oneRichmanBalance numRichmen
+
+      desiredPoorsBalance <- subLovelace testBalance realRichBalance
+
+      let
+        onePoorBalance = if numPoors == 0
+          then mkKnownLovelace @0
+          else divLovelace desiredPoorsBalance numPoors
+
+      realPoorBalance <- scaleLovelace onePoorBalance numPoors
+
+      totalBalance    <- addLovelace realRichBalance realPoorBalance
+
+      pure
+        ( replicate numRichmen oneRichmanBalance
+        , replicate numPoors   onePoorBalance
+        , totalBalance
+        )
+
+  if totalBalance <= testBalance
+    then pure (richBalances, poorBalances)
+    else throwError
+      $ GenesisDataGenerationDistributionMismatch testBalance totalBalance
+ where
+  numRichmen :: Int
+  numRichmen = fromIntegral $ tboRichmen tbo
+
+  numPoors :: Int
+  numPoors = fromIntegral $ tboPoors tbo
+
+  desiredRichBalance =
+    applyLovelacePortionDown (tboRichmenShare tbo) testBalance

--- a/src/Cardano/Chain/Genesis/Initializer.hs
+++ b/src/Cardano/Chain/Genesis/Initializer.hs
@@ -10,50 +10,47 @@ where
 
 import Cardano.Prelude
 
-import Cardano.Chain.Common (LovelacePortion)
+import Cardano.Chain.Common (Lovelace, LovelacePortion)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
 
--- | This data type contains various options which determine genesis
--- stakes, balanaces, heavy delegation, etc.
+-- | Options determining generated genesis stakes, balances, and delegation
 data GenesisInitializer = GenesisInitializer
   { giTestBalance       :: !TestnetBalanceOptions
   , giFakeAvvmBalance   :: !FakeAvvmOptions
   , giAvvmBalanceFactor :: !LovelacePortion
-  -- ^ Avvm balances will be multiplied by this factor.
+  -- ^ Avvm balances will be multiplied by this factor
   , giUseHeavyDlg       :: !Bool
-  -- ^ Whether to use heavyweight delegation for bootstrap era
-  -- stakeholders.
+  -- ^ Whether to use heavyweight delegation for bootstrap era stakeholders
   , giSeed              :: !Integer
-    -- ^ Seed to use to generate secret data. There are two
-    -- ways to use it:
-    --
-    -- 1. Keep it secret and use genesis data generated from it.
-    -- 2. Just use it directly and keep it public if you want
-    -- to deploy testing cluster.
+  -- ^ Seed to use to generate secret data. There are two ways to use it:
+  --
+  --   1. Keep it secret and use genesis data generated from it
+  --   2. Just use it directly and keep it public if you want to deploy testing
+  --      cluster
   } deriving (Eq, Show)
 
 
--- | These options determine balances of nodes specific for testnet.
+-- | These options determine balances of nodes specific for testnet
 data TestnetBalanceOptions = TestnetBalanceOptions
   { tboPoors          :: !Word
   -- ^ Number of poor nodes (with small balance).
   , tboRichmen        :: !Word
   -- ^ Number of rich nodes (with huge balance).
-  , tboTotalBalance   :: !Word64
+  , tboTotalBalance   :: !Lovelace
   -- ^ Total balance owned by these nodes.
-  , tboRichmenShare   :: !Double
+  , tboRichmenShare   :: !LovelacePortion
   -- ^ Portion of stake owned by all richmen together.
   , tboUseHDAddresses :: !Bool
   -- ^ Whether generate plain addresses or with hd payload.
   } deriving (Eq, Show)
 
 
--- | These options determines balances of fake AVVM nodes which didn't
--- really go through vending, but pretend they did.
+-- | These options determines balances of fake AVVM nodes which didn't really go
+--   through vending, but pretend they did
 data FakeAvvmOptions = FakeAvvmOptions
   { faoCount      :: !Word
-  , faoOneBalance :: !Word64
+  , faoOneBalance :: !Lovelace
   } deriving (Eq, Show, Generic)
 
 deriveJSON defaultOptions ''GenesisInitializer

--- a/src/Cardano/Chain/Txp/UTxO.hs
+++ b/src/Cardano/Chain/Txp/UTxO.hs
@@ -21,7 +21,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 
 import Cardano.Chain.Common
-  (Address, Lovelace, LovelaceError, isRedeemAddress, sumLovelaces)
+  (Address, Lovelace, LovelaceError, isRedeemAddress, sumLovelace)
 import Cardano.Chain.Txp.Tx (Tx(..), TxId, TxIn(..), TxOut(..))
 import Cardano.Crypto (hash)
 
@@ -54,7 +54,7 @@ union (UTxO m) (UTxO m') = do
   pure $ UTxO m''
 
 balance :: UTxO -> Either LovelaceError Lovelace
-balance = sumLovelaces . fmap txOutValue . M.elems . unUTxO
+balance = sumLovelace . fmap txOutValue . M.elems . unUTxO
 
 (<|) :: Set TxIn -> UTxO -> UTxO
 (<|) inputs = UTxO . flip M.restrictKeys inputs . unUTxO

--- a/test/Test/Cardano/Chain/Common/Example.hs
+++ b/test/Test/Cardano/Chain/Common/Example.hs
@@ -26,14 +26,13 @@ import Cardano.Chain.Common
   , ChainDifficulty(..)
   , LovelacePortion(..)
   , Script(..)
-  , StakeholderId(..)
+  , StakeholderId
   , lovelacePortionDenominator
   , makeAddress
   , mkAttributes
   , mkMultiKeyDistr
   , mkStakeholderId
   )
-import Cardano.Crypto.Hashing (abstractHash)
 import Cardano.Crypto.HD (HDAddressPayload(..))
 import qualified Data.Map as M
 
@@ -98,7 +97,7 @@ exampleMultiKeyDistr = case mkMultiKeyDistr (M.fromList pairs) of
   pairs :: [(StakeholderId, LovelacePortion)]
   pairs = zip stakeIds (map LovelacePortion (remainderCP : lovelacePortions))
   stakeIds :: [StakeholderId]
-  stakeIds = map (StakeholderId . abstractHash) (examplePublicKeys 7 4)
+  stakeIds = exampleStakeholderIds 7 4
   lovelacePortions =
     [ (10 :: Word64) ^ (12 :: Word64)
     , (7 :: Word64) ^ (11 :: Word64)
@@ -110,8 +109,7 @@ exampleScript :: Script
 exampleScript = Script 601 (getBytes 4 32)
 
 exampleStakeholderIds :: Int -> Int -> [StakeholderId]
-exampleStakeholderIds offset l =
-  map (StakeholderId . abstractHash) $ examplePublicKeys offset l
+exampleStakeholderIds offset l = mkStakeholderId <$> examplePublicKeys offset l
 
 exampleStakeholderId :: StakeholderId
 exampleStakeholderId = mkStakeholderId examplePublicKey

--- a/test/Test/Cardano/Chain/Genesis/Example.hs
+++ b/test/Test/Cardano/Chain/Genesis/Example.hs
@@ -21,7 +21,11 @@ import Data.Maybe (fromJust)
 
 import Cardano.Binary.Class (Raw(..))
 import Cardano.Chain.Common
-  (LovelacePortion(..), StakeholderId(..), addressHash, mkKnownLovelace)
+  ( LovelacePortion(..)
+  , mkKnownLovelace
+  , mkKnownLovelacePortion
+  , mkStakeholderId
+  )
 import Cardano.Chain.Delegation (HeavyDlgIndex(..))
 import Cardano.Chain.Genesis
   ( FakeAvvmOptions(..)
@@ -75,7 +79,7 @@ exampleGenesisAvvmBalances = GenesisAvvmBalances
 exampleGenesisDelegation :: GenesisDelegation
 exampleGenesisDelegation = UnsafeGenesisDelegation
   (M.fromList
-    [ ( StakeholderId $ addressHash issuePubKey
+    [ ( mkStakeholderId issuePubKey
       , unsafeProxySecretKey
         (HeavyDlgIndex $ EpochIndex 68300481033)
         issuePubKey
@@ -123,13 +127,13 @@ exampleGenesisInitializer = GenesisInitializer
   { giTestBalance       = TestnetBalanceOptions
     { tboPoors          = 2448641325904532856
     , tboRichmen        = 14071205313513960321
-    , tboTotalBalance   = 10953275486128625216
-    , tboRichmenShare   = 4.2098713311249885
+    , tboTotalBalance   = mkKnownLovelace @10953275486128625
+    , tboRichmenShare   = mkKnownLovelacePortion @366832547637728
     , tboUseHDAddresses = True
     }
   , giFakeAvvmBalance   = FakeAvvmOptions
     { faoCount      = 17853231730478779264
-    , faoOneBalance = 15087947214890024355
+    , faoOneBalance = mkKnownLovelace @15087947214890024
     }
   , giAvvmBalanceFactor = LovelacePortion {getLovelacePortion = 366832547637728}
   , giUseHeavyDlg       = False

--- a/test/Test/Cardano/Chain/Genesis/Gen.hs
+++ b/test/Test/Cardano/Chain/Genesis/Gen.hs
@@ -14,6 +14,8 @@ import Cardano.Prelude
 
 import Data.Coerce (coerce)
 import qualified Data.Map.Strict as M
+import Formatting (build, sformat)
+
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -52,15 +54,13 @@ genStaticConfig pm = Gen.choice
 
 genFakeAvvmOptions :: Gen FakeAvvmOptions
 genFakeAvvmOptions =
-  FakeAvvmOptions
-    <$> Gen.word Range.constantBounded
-    <*> Gen.word64 Range.constantBounded
+  FakeAvvmOptions <$> Gen.word Range.constantBounded <*> genLovelace
 
 genGenesisDelegation :: ProtocolMagic -> Gen GenesisDelegation
 genGenesisDelegation pm = do
   proxySKHeavyList <- genProxySKHeavyDistinctList pm
   case mkGenesisDelegation proxySKHeavyList of
-    Left  err    -> panic err
+    Left  err    -> panic $ sformat build err
     Right genDel -> pure genDel
 
 genGenesisInitializer :: Gen GenesisInitializer
@@ -89,8 +89,8 @@ genTestnetBalanceOptions =
   TestnetBalanceOptions
     <$> Gen.word Range.constantBounded
     <*> Gen.word Range.constantBounded
-    <*> Gen.word64 Range.constantBounded
-    <*> Gen.double (Range.constant 0 10)
+    <*> genLovelace
+    <*> genLovelacePortion
     <*> Gen.bool
 
 genGenesisAvvmBalances :: Gen GenesisAvvmBalances

--- a/test/Test/Cardano/Chain/Txp/Validation.hs
+++ b/test/Test/Cardano/Chain/Txp/Validation.hs
@@ -47,7 +47,7 @@ tests :: TestScenario -> IO Bool
 tests scenario = do
 
   -- Get 'GenesisData' from the mainnet JSON configuration
-  genesisData <- either (panic . sformat build) identity
+  genesisData <- either (panic . sformat build) fst
     <$> runExceptT (readGenesisData "test/mainnet-genesis.json")
 
   -- Extract mainnet 'ProtocolMagic'

--- a/test/golden/json/genesis/StaticConfig_GCSpec
+++ b/test/golden/json/genesis/StaticConfig_GCSpec
@@ -38,14 +38,14 @@
             "avvmBalanceFactor": 0.366832547637728,
             "seed": 0,
             "testBalance": {
-                "totalBalance": 1.0953275486128625216e19,
-                "richmenShare": 4.2098713311249885,
+                "totalBalance": 10953275486128625,
+                "richmenShare": 0.366832547637728,
                 "useHDAddresses": true,
                 "richmen": 1.4071205313513960321e19,
                 "poors": 2448641325904532856
             },
             "fakeAvvmBalance": {
-                "oneBalance": 1.5087947214890024355e19,
+                "oneBalance": 15087947214890024,
                 "count": 1.7853231730478779264e19
             }
         },

--- a/test/golden/json/txp/TxpConfiguration2
+++ b/test/golden/json/txp/TxpConfiguration2
@@ -2,6 +2,6 @@
     "memPoolLimitTx": 700,
     "assetLockedSrcAddrs": [
         "2RhQhCGqYPDpFgTsnBTbnvPvCwpqAkjwLqQkWpkqXbLRmNxd4xNd262nGsr8JiynyKRUeMLSJ9Ntho9i76uvBTrVXdJJG5yiNLb8frmUe5qX7E",
-        "5FCjkr138i9wjRVwawmYMd4Vc9KxU7TuQhMyjMGpnykg9yb2qMpUCerDFzXvfAJMFgJTHyD7Sn4ybLXm2M6zeWAaWe7ctjq5QjVL427vGRx"
+        "5FCjkr138i9xVenAi73mkmc6P7AqGLKiZMoQnvcGZsGHBASTWm5nAjx6V3QnLizSQE8cucq6cPmRwNfT25YtBX9ZAm3eKqMenvaZw8yfX9F"
     ]
 }


### PR DESCRIPTION
This imports some functions for constructing configurations from `cardano-sl`. This will probably be reworked later down the line, but it is definitely cleaner than the old version.