### PR TITLE
Build Haskell specs in CI.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,6 +19,12 @@ steps:
     agents:
       system: x86_64-linux
 
+  - label: 'specs'
+    command:
+      - "nix build -f pkgs.nix haskell.packages.ghc861.small-steps"
+      - "nix build -f pkgs.nix haskell.packages.ghc861.cs-ledger"
+      - "nix build -f pkgs.nix haskell.packages.ghc861.cs-blockchain"
+
   - label: 'brittany'
     command:
       - "nix-build scripts/brittany -o check-brittany"


### PR DESCRIPTION
This doesn't currently exploit any caching (sounds like they should be built in hydra for that), but at least means we are building the specs. It takes less time than to build the cardano-chain package, so given they're done in parallel this shouldn't add any time to CI.