### PR TITLE
[DEVOPS-1033] include the gitrev in a dummy derivation

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,10 +1,12 @@
+{ chain ? { outPath = ./.; rev = "abcdef"; } }:
 let
   pkgs = import ./pkgs.nix;
 in pkgs.lib.fix (self: {
+  forceNewEval = pkgs.writeText "forceNewEval" chain.rev;
 
   required = pkgs.lib.hydraJob (pkgs.releaseTools.aggregate {
     name = "cardano-chain-required-checks";
-    constituents = with self; [ byronLedgerSpec byronChainSpec semanticsSpec ];
+    constituents = with self; [ byronLedgerSpec byronChainSpec semanticsSpec forceNewEval ];
   });
 
   byronLedgerSpec = import ./specs/ledger/latex {};


### PR DESCRIPTION
this forces hydra to create a new eval for every rev, even if nothing has changed