### PR TITLE
Replace unless/when ... throwError with orThrowError

### DIFF
--- a/crypto/src/Cardano/Crypto/Signing/Proxy/SecretKey.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Proxy/SecretKey.hs
@@ -126,12 +126,11 @@ isSelfSignedPsk psk = pskIssuerPk psk == pskDelegatePk psk
 --   TODO: Make this unnecessary by performing validation in the decoder
 validateProxySecretKey
   :: MonadError Text m => ProtocolMagic -> AProxySecretKey w ByteString -> m ()
-validateProxySecretKey pm psk = unless
-  (verifyProxyCert
-    pm
-    (pskIssuerPk psk)
-    (pskDelegatePk psk)
-    (aPskOmega psk)
-    (pskCert psk)
-  )
-  (throwError "a ProxySecretKey has an invalid signature")
+validateProxySecretKey pm psk =
+  verifyProxyCert
+      pm
+      (pskIssuerPk psk)
+      (pskDelegatePk psk)
+      (aPskOmega psk)
+      (pskCert psk)
+    `orThrowError` "a ProxySecretKey has an invalid signature"

--- a/crypto/src/Cardano/Crypto/Signing/Redeem/PublicKey.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Redeem/PublicKey.hs
@@ -99,10 +99,10 @@ fromAvvmPk addrText = do
   let base64rify = T.replace "-" "+" . T.replace "_" "/"
   let parsedM    = B64.decode . toS $ base64rify addrText
   addrParsed <- case parsedM of
-    Left  _ -> Left (ApeAddressFormat addrText)
+    Left  _ -> throwError $ ApeAddressFormat addrText
     Right a -> Right a
   let len = BS.length addrParsed
-  unless (len == 32) $ Left (ApeAddressLength len)
+  (len == 32) `orThrowError` ApeAddressLength len
   pure $ redeemPkBuild addrParsed
 
 -- | Creates a public key from 32 byte bytestring, fails with 'error' otherwise

--- a/src/Cardano/Chain/Block/Block.hs
+++ b/src/Cardano/Chain/Block/Block.hs
@@ -315,8 +315,10 @@ verifyBlock pm block = do
   -- Check that the headers' extra body data hash is correct.
   -- This isn't subsumed by the body proof check.
   let extraDataHash = hashDecoded (aBlockExtraData block)
-  unless (extraDataHash == blockExtraDataProof block) $ throwError
-    (BlockInvalidExtraDataProof (blockExtraDataProof block) extraDataHash)
+  (extraDataHash == blockExtraDataProof block)
+    `orThrowError` BlockInvalidExtraDataProof
+                    (blockExtraDataProof block)
+                    extraDataHash
 
 
 --------------------------------------------------------------------------------

--- a/src/Cardano/Chain/Block/Proof.hs
+++ b/src/Cardano/Chain/Block/Proof.hs
@@ -87,6 +87,6 @@ instance B.Buildable ProofError where
       p'
 
 checkProof :: MonadError ProofError m => ABody ByteString -> Proof -> m ()
-checkProof body proof = unless (calculatedProof == proof)
-  $ throwError (ProofIncorrect proof calculatedProof)
+checkProof body proof =
+  (calculatedProof == proof) `orThrowError` ProofIncorrect proof calculatedProof
   where calculatedProof = recoverProof body

--- a/src/Cardano/Chain/Common/AddrStakeDistribution.hs
+++ b/src/Cardano/Chain/Common/AddrStakeDistribution.hs
@@ -106,9 +106,9 @@ mkMultiKeyDistr distrMap = UnsafeMultiKeyDistr distrMap <$ checkDistrMap
  where
   checkDistrMap :: m ()
   checkDistrMap = do
-    when (null distrMap) $ throwError MkdMapIsEmpty
-    when (length distrMap == 1) $ throwError MkdMapIsSingleton
-    unless (all ((> 0) . getLovelacePortion) distrMap)
-      $ throwError MkdNegativePortion
+    not (null distrMap) `orThrowError` MkdMapIsEmpty
+    (length distrMap /= 1) `orThrowError` MkdMapIsSingleton
+    all ((> 0) . getLovelacePortion) distrMap
+      `orThrowError` MkdNegativePortion
     let distrSum = sum $ map getLovelacePortion distrMap
-    unless (distrSum == lovelacePortionDenominator) $ throwError MkdSumNot1
+    (distrSum == lovelacePortionDenominator) `orThrowError` MkdSumNot1

--- a/src/Cardano/Chain/Delegation/Payload.hs
+++ b/src/Cardano/Chain/Delegation/Payload.hs
@@ -20,6 +20,7 @@ where
 import Cardano.Prelude
 
 import Control.Monad.Except (MonadError, liftEither)
+import Data.List (nub)
 import Formatting (bprint, int, stext)
 import Formatting.Buildable (Buildable(..))
 
@@ -34,7 +35,11 @@ import Cardano.Binary.Class
   )
 import qualified Cardano.Chain.Delegation.Certificate as Delegation
 import Cardano.Crypto
-  (ProtocolMagic, decodeAProxySecretKey, validateProxySecretKey)
+  ( ProtocolMagic
+  , decodeAProxySecretKey
+  , validateProxySecretKey
+  , AProxySecretKey(..)
+  )
 
 
 -- | 'Payload' is put into 'MainBlock' and is a set of heavyweight proxy signing
@@ -70,20 +75,26 @@ decodeAPayload = do
   (Annotated p a) <- annotatedDecoder (decodeListWith decodeAProxySecretKey)
   pure (UnsafeAPayload p a)
 
-data PayloadError = PayloadPSKError Text
+data PayloadError
+  = PayloadDuplicateIssuer
+  | PayloadPSKError Text
 
 instance Buildable PayloadError where
   build = \case
+    PayloadDuplicateIssuer -> bprint
+      "Encountered multiple delegation certificates from the same issuer."
     PayloadPSKError err -> bprint
-      ( "ProxySecretKey invalid when checing Delegation.Payload.\n Error: "
+      ( "ProxySecretKey invalid when checking Delegation.Payload.\n Error: "
       . stext
       )
       err
 
 checkPayload
   :: MonadError PayloadError m => ProtocolMagic -> APayload ByteString -> m ()
-checkPayload protocolMagic payload = forM_
-  (getPayload payload)
-  (liftEither . first PayloadPSKError . validateProxySecretKey protocolMagic)
-  -- unless (allDistinct $ map pskIssuerPk proxySKs) $
-  --     throwError "Some of block's PSKs have the same issuer, which is prohibited"
+checkPayload protocolMagic (UnsafeAPayload payload _) = do
+  let issuers = pskIssuerPk <$> payload
+  (length issuers == length (nub issuers)) `orThrowError` PayloadDuplicateIssuer
+
+  forM_
+    payload
+    (liftEither . first PayloadPSKError . validateProxySecretKey protocolMagic)

--- a/src/Cardano/Chain/Genesis/Config.hs
+++ b/src/Cardano/Chain/Genesis/Config.hs
@@ -222,9 +222,9 @@ mkConfigFromStaticConfig confDir mSystemStart mSeed = \case
   -- the obligations.
   GCSrc fp expectedHash -> do
 
-    when (isJust mSystemStart) $ throwError UnnecessarySystemStartTime
+    isNothing mSystemStart `orThrowError` UnnecessarySystemStartTime
 
-    when (isJust mSeed) $ throwError MeaninglessSeed
+    isNothing mSeed `orThrowError` MeaninglessSeed
 
     mkConfigFromFile (confDir </> fp) (Just expectedHash)
 
@@ -259,10 +259,10 @@ mkConfigFromFile fp mGenesisHash = do
       (readGenesisData fp)
 
   case mGenesisHash of
-    Nothing           -> pure ()
-    Just expectedHash -> unless
+    Nothing -> pure ()
+    Just expectedHash ->
       (getGenesisHash genesisHash == expectedHash)
-      (throwError $ GenesisHashMismatch genesisHash expectedHash)
+        `orThrowError` GenesisHashMismatch genesisHash expectedHash
 
   pure $ Config
     { configGenesisData      = genesisData

--- a/src/Cardano/Chain/Genesis/Spec.hs
+++ b/src/Cardano/Chain/Genesis/Spec.hs
@@ -10,7 +10,6 @@ where
 import Cardano.Prelude
 import Prelude (String)
 
-import Control.Monad.Except (MonadError(throwError))
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
 import Data.List (nub)
@@ -56,7 +55,7 @@ mkGenesisSpec
   -> Either String GenesisSpec
 mkGenesisSpec avvmDistr delega bvd k pm specType = do
   let avvmKeys = M.keys $ getGenesisAvvmBalances avvmDistr
-  unless (length (nub avvmKeys) == length avvmKeys)
-    $ throwError "mkGenesisSpec: there are duplicates in avvm balances"
+  (length (nub avvmKeys) == length avvmKeys)
+    `orThrowError` "mkGenesisSpec: there are duplicates in avvm balances"
   -- All checks passed
   pure $ UnsafeGenesisSpec avvmDistr delega bvd k pm specType

--- a/src/Cardano/Chain/Txp/UTxO.hs
+++ b/src/Cardano/Chain/Txp/UTxO.hs
@@ -50,7 +50,7 @@ lookupAddress txIn =
 union :: MonadError UTxOError m => UTxO -> UTxO -> m UTxO
 union (UTxO m) (UTxO m') = do
   let m'' = M.union m m'
-  unless (M.size m'' == M.size m + M.size m') $ throwError UTxOOverlappingUnion
+  (M.size m'' == M.size m + M.size m') `orThrowError` UTxOOverlappingUnion
   pure $ UTxO m''
 
 balance :: UTxO -> Either LovelaceError Lovelace

--- a/src/Cardano/Chain/Update/Vote.hs
+++ b/src/Cardano/Chain/Update/Vote.hs
@@ -248,8 +248,8 @@ checkProposal pm proposal = do
       (proposalIssuer proposal)
       (mappend bodyPrefix <$> aBody)
       (proposalSignature proposal)
-  unless sigIsValid $ throwError $ ProposalInvalidSignature
-    (proposalSignature proposal)
+  sigIsValid
+    `orThrowError` ProposalInvalidSignature (proposalSignature proposal)
 
 
 --------------------------------------------------------------------------------
@@ -397,9 +397,7 @@ instance B.Buildable VoteError where
       bprint ("Invalid signature, " . build . ", in Vote") sig
 
 checkVote :: MonadError VoteError m => ProtocolMagic -> AVote ByteString -> m ()
-checkVote pm uv = unless
-  sigValid
-  (throwError $ VoteInvalidSignature (uvSignature uv))
+checkVote pm uv = sigValid `orThrowError` VoteInvalidSignature (uvSignature uv)
  where
   sigValid = verifySignatureDecoded
     pm


### PR DESCRIPTION
The `unless condition (throwError Error)` pattern arises a lot in our code, and this replaces instances of it with ``condition `orThrowError` Error``. It also changes some `when inverseCondition` to use it too.