### PR TITLE
Incorporate additional feedback on the update-mechanism rules

### DIFF
--- a/specs/ledger/latex/blockchain-interface.tex
+++ b/specs/ledger/latex/blockchain-interface.tex
@@ -159,6 +159,16 @@
 \subsection{Update-proposals interface}
 \label{sec:update-proposals-interface}
 
+Figure~\ref{fig:ts-types:upi} defines the types of the transition systems
+related with the update-proposals interface. The acronyms in the transition
+labels have the following meaning:
+\begin{description}
+\item[UPIREG] Update-proposal registration.
+\item[UPIEND] Update-proposal vote.
+\item[UPIEND] Update-proposal endorsement.
+\item[UPIEC] Update-proposal epoch-change.
+\end{description}
+
 \begin{figure}[htb]
   \emph{Update-proposals interface environments}
   \begin{align*}
@@ -190,7 +200,7 @@
         \var{cps} & \UPropId \mapsto \BkNr & \text{confirmed proposals}\\
         \var{vts} & \powerset{(\UPropId \times \VKeyGen)} & \text{proposals votes}\\
         \var{bvs} & \powerset{(\ProtVer \times \VKeyGen)}
-                           & \text{keys ready to adopt versions}\\
+                           & \text{endorsement-key pairs}\\
         \var{pws} & \UPropId \mapsto \BkNr & \text{proposal timestamps}
       \end{array}\right)
   \end{align*}
@@ -202,7 +212,7 @@
       \powerset (\UPIEnv \times \UPIState \times \UProp \times \UPIState)\\
       \_ \vdash \_ \trans{upivote}{\_} \_ &
       \powerset (\UPIEnv \times \UPIState \times \Vote \times \UPIState)\\
-      \_ \vdash \_ \trans{upibvreg}{\_} \_ &
+      \_ \vdash \_ \trans{upiend}{\_} \_ &
       \powerset (\UPIEnv \times \UPIState
       \times (\ProtVer \times \VKey) \times \UPIState)\\
       \_ \vdash \_ \trans{upiec}{\_} \_ &
@@ -382,29 +392,33 @@
 
 The interface rule for protocol-block-version registration makes use of the
 $\trans{upbvreg}{}$ transition, passing only the portion of the state relevant
-to it. In addition, the proposals that are older than $u$ blocks are removed
-from the parts of the state that hold:
+to it. In addition, the unconfirmed proposals that are older than $u$ blocks
+are removed from the parts of the state that hold:
 \begin{itemize}
 \item the registered proposals,
-\item the confirmed proposals,
 \item the votes associated with the proposals,
-\item the set of keys ready to adopt the different proposals, and
+\item the set of endorsement-key pairs, and
 \item the block number in which proposals where added.
 \end{itemize}
-Note that a proposal that got adopted could be cleaned earlier in some other
-rule, however, by keeping all the cleanup logic associated to block number
-change in one place we make reasoning about state-size bounds simpler. The
-epoch-key pairs set ($\var{eps}$) that represents which stakeholder proposed an
-update in which epoch, is cleaned up in the rules given in
-\cref{fig:rules:upi-ec}, which deals with epoch change. Finally, in
-$\var{vs_{keep}}$ we compute the set of all the versions associated with
-proposals id's to be kept, and restrict the domain of $\var{bvs}$ to these
-versions.
+The epoch-key pairs set ($\var{eps}$) that represents which stakeholder
+proposed an update in which epoch, is cleaned up in the rules given in
+\cref{fig:rules:upi-ec}, which deals with epoch change.
 
+In Rule~\ref{eq:rule:upi-pend}, the set of proposal id's $\var{pid_{keep}}$
+contains only those proposals that haven't expired yet or that are confirmed.
+Once a proposal $\var{up}$ is confirmed, it is removed from the set of
+confirmed proposals ($\var{cps}$) either when it is adopted or when a protocol
+version higher than that of $\var{up}$ gets adopted (see
+Rule~\ref{eq:rule:upi-ec}).
+%
+The set of endorsement-key pairs is cleaned here as well as in the epoch change
+rule (Rule~\ref{eq:rule:upi-ec}). The reason for this is that this set grows at
+each block, and it can get considerably large if no proposal gets adopted at
+the end on an epoch.
 
 \begin{figure}[htb]
   \begin{equation}
-    \label{eq:rule:upi-bv-reg}
+    \label{eq:rule:upi-pend}
     \inference
     {
       {
@@ -435,8 +449,13 @@ versions.
           \end{array}
         \right)
       }\\
-      \var{pids_{keep}} = \dom~(pws \restrictrange [b_n - u, ..])
-      & \var{vs_{keep}} = \dom~(\range~(\var{pids_{keep}} \restrictdom \var{rups}))
+      {
+        \begin{array}{r@{~=~}l}
+          \var{pids_{keep}} & \dom~(pws \restrictrange [b_n - u, ..]) \cup \dom~\var{cps}\\
+          \var{vs_{keep}} & \dom~(\range~\var{rups'})\\
+          \var{rups'} & \var{pids_{keep}} \restrictdom \var{rups}
+        \end{array}
+      }
     }
     {
       {
@@ -464,16 +483,16 @@ versions.
           \end{array}
         \right)
       }
-      \trans{upibvreg}{(\var{bv}, \var{vk})}
+      \trans{upiend}{(\var{bv}, \var{vk})}
       {
         \left(
           \begin{array}{l}
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
             (\var{pv_c'}, \var{pps_c'})\\
-            \var{pids_{keep}} \restrictdom \var{rups}\\
+            \var{rups'}\\
             \var{eps}\\
-            \var{pids_{keep}} \restrictdom \var{cps}\\
+            \var{cps}\\
             \var{pids_{keep}} \restrictdom \var{vts}\\
             \var{vs_{keep}}  \restrictdom \var{bvs}\\
             \var{pids_{keep}} \restrictdom \var{pws}
@@ -482,8 +501,8 @@ versions.
       }
     }
   \end{equation}
-  \caption{Block version registration rules}
-  \label{fig:rules:upi-bv-reg}
+  \caption{Proposal endorsement rules}
+  \label{fig:rules:upi-pend}
 \end{figure}
 
 \clearpage
@@ -493,12 +512,18 @@ are changed depending on the epoch in the signal ($e_n$ in this case). A change
 only occurs if the new epoch is greater than the previously seen epoch ($e_p$).
 In such case, the current epoch is also updated accordingly. The candidate
 versions and parameters map $(\var{pv_c}, \var{pps_c})$ remain constant in this
-transition, even if they become adopted. Finally, the set $\var{eps}$ is
-updated so that only keys that proposed in epochs no earlier than $e_n$ are
-kept. Finally, note that we use $\var{pps} \unionoverride \var{pps'}$ in the
-final state, since the candidate proposal might only update some parameters of
-the protocol: by using union override $\var{pps'}$ overwrites the values of the
-parameters in $\var{pps}$.
+transition, even if they become adopted. Note that, in the final state, we use
+union override to define the updated parameters
+($\var{pps} \unionoverride \var{pps'}$). This is because candidate proposal
+might only update some parameters of the protocol.
+
+Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables. We keep
+only the information of proposals whose proposed protocol-versions are greater
+than the newly adopted protocol version ($\var{pv'}$). This means that active
+proposals will be discarded even if the voting period is not over (it makes no
+sense to vote on a proposal that proposes to upgrade to an older version of the
+protocol). Furthermore, the set $\var{eps}$ is updated so that only keys that
+proposed in epochs no earlier than $e_n$ are kept.
 
 \begin{figure}[htb]
   \begin{equation}
@@ -581,7 +606,10 @@ parameters in $\var{pps}$.
             \var{(\var{pv'}, \var{pps'})}\\
           \end{array}
         \right)
-      }
+      }\\ ~ \\
+      \var{pids_{keep}} = \{ \var{pid} \mid
+      \var{pid} \mapsto (\var{pv_i}, \wcard) \in \var{rups}
+      ,~ \var{pv'} \leq \var{pv_i}\}
     }
     {
       {
@@ -616,12 +644,12 @@ parameters in $\var{pps}$.
             \var{e'}\\
             \var{(\var{pv'}, \var{pps} \unionoverride \var{pps'})}\\
             \var{(\var{pv_c}, \var{pps_c})}\\
-            \var{rups}\\
+            \var{pids_{keep}} \restrictdom \var{rups}\\
             {[e_n, ..]} \restrictdom \var{eps}\\
-            \var{cps}\\
-            \var{vts}\\
-            \var{bvs}\\
-            \var{pws}
+            \var{pids_{keep}} \restrictdom \var{cps}\\
+            \var{pids_{keep}} \restrictdom \var{vts}\\
+            {[\var{pv'}, ..]} \restrictdom \var{bvs}\\
+            \var{pids_{keep}} \restrictdom \var{pws}
           \end{array}
         \right)
       }

--- a/specs/ledger/latex/blockchain-interface.tex
+++ b/specs/ledger/latex/blockchain-interface.tex
@@ -163,10 +163,10 @@ Figure~\ref{fig:ts-types:upi} defines the types of the transition systems
 related with the update-proposals interface. The acronyms in the transition
 labels have the following meaning:
 \begin{description}
-\item[UPIREG] Update-proposal registration.
-\item[UPIEND] Update-proposal vote.
-\item[UPIEND] Update-proposal endorsement.
-\item[UPIEC] Update-proposal epoch-change.
+\item[UPIREG] Update-proposal-interface registration.
+\item[UPIVOTE] Update-proposal-interface vote.
+\item[UPIEND] Update-proposal-interface endorsement.
+\item[UPIEC] Update-proposal-interface epoch-change.
 \end{description}
 
 \begin{figure}[htb]
@@ -185,16 +185,20 @@ labels have the following meaning:
   %
   \emph{Update-proposals interface states}
   \begin{align*}
-    & \UPIState
-      = \left(
+    & \UPIState = \\
+    & \left(
       \begin{array}{r@{~\in~}lr}
         \var{e_p} & \Epoch & \text{previously seen epoch}\\
         (\var{pv}, \var{pps}) & \ProtVer \times \PPMMap
         & \text{current protocol information}\\
         (\var{pv_c}, \var{pps_c}) & \ProtVer \times \PPMMap
         & \text{candidate protocol information}\\
-        \var{rups} & \Rups
-        & \text{registered update proposals}\\
+        \var{avs} & \ApName \mapsto (\mathbb{N} \times \BkNr)
+        & \text{application versions}\\
+        \var{rups} & \UPropId \mapsto (\ProtVer \times \PPMMap)
+        & \text{registered protocol update proposals}\\
+        \var{raus} & \UPropId \mapsto (\ApName \times \mathbb{N})
+        & \text{registered software update proposals}\\
         \var{eps} & \powerset{(\Epoch \times \VKeyGen)}
         & \text{proposals per-epoch per-key}\\
         \var{cps} & \UPropId \mapsto \BkNr & \text{confirmed proposals}\\
@@ -202,7 +206,7 @@ labels have the following meaning:
         \var{bvs} & \powerset{(\ProtVer \times \VKeyGen)}
                            & \text{endorsement-key pairs}\\
         \var{pws} & \UPropId \mapsto \BkNr & \text{proposal timestamps}
-      \end{array}\right)
+      \end{array}\right)\\
   \end{align*}
   %
   \emph{Update-proposals interface transitions}
@@ -223,7 +227,6 @@ labels have the following meaning:
   \label{fig:ts-types:upi}
 \end{figure}
 
-
 \begin{figure}[htb]
   \begin{equation}
     \label{eq:rule:upi-reg-interface}
@@ -234,6 +237,7 @@ labels have the following meaning:
           \var{pv}\\
           \var{pps}\\
           \var{e_c}\\
+          \var{avs}\\
           \var{dms}
         \end{array}
       }
@@ -242,6 +246,7 @@ labels have the following meaning:
         \left(
           \begin{array}{l}
             \var{rups}\\
+            \var{raus}\\
             \var{eps}
           \end{array}
         \right)
@@ -251,6 +256,7 @@ labels have the following meaning:
         \left(
           \begin{array}{l}
             \var{rups'}\\
+            \var{raus'}\\
             \var{eps'}
           \end{array}
         \right)
@@ -275,7 +281,9 @@ labels have the following meaning:
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
             (\var{pv_c}, \var{pps_c})\\
+            \var{avs}\\
             \var{rups}\\
+            \var{raus}\\
             \var{eps}\\
             \var{cps}\\
             \var{vts}\\
@@ -291,7 +299,9 @@ labels have the following meaning:
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
             (\var{pv_c}, \var{pps_c})\\
+            \var{avs}\\
             \var{rups'}\\
+            \var{raus'}\\
             \var{eps'}\\
             \var{cps}\\
             \var{vts}\\
@@ -307,6 +317,17 @@ labels have the following meaning:
 \end{figure}
 
 \clearpage
+
+Rule~\ref{eq:rule:upi-vote} models the effect of voting on an update proposal:
+after a vote, a proposal might get confirmed, which means that it will be added
+to the set $\var{cps'}$. In such case, the mapping of application names to
+their latest version known to the ledger will be updated to include the
+information in the confirmed proposal. Note that, unlike protocol updates,
+software updates take effect as soon as a proposal is confirmed. In this rule,
+we also delete the confirmed proposal id's from the set of registered
+application update proposals ($\var{raus}$), since this information is no
+longer needed once the application-name to software-version map ($\var{avs}$) is
+updated.
 
 \begin{figure}[htb]
   \begin{equation}
@@ -338,7 +359,11 @@ labels have the following meaning:
             \var{vts'}
           \end{array}
         \right)
-      }
+      }\\
+      \var{avs_{new}} = \{ \var{an} \mapsto (\var{av}, \var{b_n})
+      \mid \var{pid} \mapsto (\var{an}, \var{av}) \in \var{raus}
+      ,~ \var{pid} \in \dom~\var{cps'}
+      \}
     }
     {
       {
@@ -357,7 +382,9 @@ labels have the following meaning:
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
             (\var{pv_c}, \var{pps_c})\\
+            \var{avs}\\
             \var{rups}\\
+            \var{raus}\\
             \var{eps}\\
             \var{cps}\\
             \var{vts}\\
@@ -373,7 +400,9 @@ labels have the following meaning:
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
             (\var{pv_c}, \var{pps_c})\\
+            \var{avs} \unionoverride \var{avs_{new}}\\
             \var{rups}\\
+            \dom~ \var{cps} \subtractdom \var{raus}\\
             \var{eps}\\
             \var{cps'}\\
             \var{vts'}\\
@@ -388,14 +417,60 @@ labels have the following meaning:
   \label{fig:rules:upi-vote}
 \end{figure}
 
+Figure~\ref{fig:st-diagram-sw-up} shows the different states in which a
+software proposal update might be: if valid, a software update proposal becomes
+active whenever it is included in a block. If the update proposal gets enough
+votes, then the corresponding software update proposal becomes confirmed, and
+the ledger state reflects this. If the voting period ends without an update
+proposal being confirmed, then the corresponding software update proposal gets
+rejected.
+%
+Protocol updates on the other hand, involve a slightly different logic, and the
+state transition diagram for these kind of updates is shown in
+Figure~\ref{fig:st-diagram-pt-up}.
+
+\begin{figure}[ht]
+  \centering
+  \begin{tikzpicture}[ align = center
+                     , node distance = 6em and 12em
+                     , text width = 5em
+                     , font = \footnotesize
+                     , >={Latex[width=0.5em, length=0.5em]}
+                     , every node/.style = { rectangle
+                                         , rounded corners
+                                         , draw = black
+                                         , align = center
+                                         , minimum height = 4em }
+                     ]
+
+  \node (active) [fill = blue!10] {Active};
+  \node (rejected) [below = of active, fill = red!10] {Rejected};
+  \node (confirmed) [right = of active, fill = green!30] {Confirmed};
+
+  \tikzset{every node/.style={align=center, text width=10em, text=brown}}
+
+  \draw[->] (active)
+  edge node [above] {Software Update proposal\\ gets enough votes}
+  (confirmed);
+
+  \draw[->] (active)
+  edge node [left] {Voting period \\ends}
+  (rejected);
+
+  \end{tikzpicture}
+
+  \caption{State-transition diagram for software-updates}
+  \label{fig:st-diagram-sw-up}
+\end{figure}
+
 \clearpage
 
-The interface rule for protocol-block-version registration makes use of the
-$\trans{upbvreg}{}$ transition, passing only the portion of the state relevant
+The interface rule for protocol-version endorsement makes use of the
+$\trans{upend}{}$ transition, passing only the portion of the state relevant
 to it. In addition, the unconfirmed proposals that are older than $u$ blocks
 are removed from the parts of the state that hold:
 \begin{itemize}
-\item the registered proposals,
+\item the registered protocol and software update proposals,
 \item the votes associated with the proposals,
 \item the set of endorsement-key pairs, and
 \item the block number in which proposals where added.
@@ -440,7 +515,7 @@ the end on an epoch.
           \end{array}
         \right)
       }
-      \trans{upbvreg}{(\var{bv}, \var{vk})}
+      \trans{upend}{(\var{bv}, \var{vk})}
       {
         \left(
           \begin{array}{l}
@@ -474,7 +549,9 @@ the end on an epoch.
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
             (\var{pv_c}, \var{pps_c})\\
+            \var{avs}\\
             \var{rups}\\
+            \var{raus}\\
             \var{eps}\\
             \var{cps}\\
             \var{vts}\\
@@ -490,7 +567,9 @@ the end on an epoch.
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
             (\var{pv_c'}, \var{pps_c'})\\
+            \var{avs}\\
             \var{rups'}\\
+            \var{pids_{keep}} \restrictdom \var{raus}\\
             \var{eps}\\
             \var{cps}\\
             \var{pids_{keep}} \restrictdom \var{vts}\\
@@ -517,13 +596,18 @@ union override to define the updated parameters
 ($\var{pps} \unionoverride \var{pps'}$). This is because candidate proposal
 might only update some parameters of the protocol.
 
-Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables. We keep
-only the information of proposals whose proposed protocol-versions are greater
-than the newly adopted protocol version ($\var{pv'}$). This means that active
-proposals will be discarded even if the voting period is not over (it makes no
-sense to vote on a proposal that proposes to upgrade to an older version of the
-protocol). Furthermore, the set $\var{eps}$ is updated so that only keys that
-proposed in epochs no earlier than $e_n$ are kept.
+Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
+\begin{itemize}
+\item We keep only the information of proposals whose proposed
+  protocol-versions are greater than the newly adopted protocol version
+  ($\var{pv'}$). This means that active proposals will be discarded even if the
+  voting period is not over (it makes no sense to vote on a proposal that
+  proposes to upgrade to an older version of the protocol).
+\item The set $\var{eps}$ is updated so that only keys that proposed in epochs
+  no earlier than $e_n$ are kept.
+\item The registered software-update proposals need not be cleaned here, since
+  this is done either when a proposal gets confirmed or when it expires.
+\end{itemize}
 
 \begin{figure}[htb]
   \begin{equation}
@@ -628,7 +712,9 @@ proposed in epochs no earlier than $e_n$ are kept.
             \var{e_p}\\
             \var{(\var{pv}, \var{pps})}\\
             \var{(\var{pv_c}, \var{pps_c})}\\
+            \var{avs}\\
             \var{rups}\\
+            \var{raus}\\
             \var{eps}\\
             \var{cps}\\
             \var{vts}\\
@@ -644,7 +730,9 @@ proposed in epochs no earlier than $e_n$ are kept.
             \var{e'}\\
             \var{(\var{pv'}, \var{pps} \unionoverride \var{pps'})}\\
             \var{(\var{pv_c}, \var{pps_c})}\\
+            \var{avs}\\
             \var{pids_{keep}} \restrictdom \var{rups}\\
+            \var{raus}\\
             {[e_n, ..]} \restrictdom \var{eps}\\
             \var{pids_{keep}} \restrictdom \var{cps}\\
             \var{pids_{keep}} \restrictdom \var{vts}\\
@@ -657,4 +745,52 @@ proposed in epochs no earlier than $e_n$ are kept.
   \end{equation}
   \caption{Block version adoption on epoch change rules}
   \label{fig:rules:upi-ec}
+\end{figure}
+
+Figure~\ref{fig:st-diagram-pt-up} shows the different states a protocol-update
+proposal can be in, and what causes the transitions between them.
+
+\begin{figure}[ht]
+  \centering
+  \begin{tikzpicture}[ align = center
+                     , node distance = 8em and 16em
+                     , text width = 5em
+                     , font = \footnotesize
+                     , >={Latex[width=0.5em, length=0.5em]}
+                     , every node/.style = { rectangle
+                                         , rounded corners
+                                         , draw = black
+                                         , align = center
+                                         , minimum height = 4em }
+                     ]
+
+  \node (active) [fill = blue!10] {Active};
+  \node (rejected) [below = of active, fill = red!10] {Rejected};
+  \node (confirmed) [right = of active, fill = green!10] {Confirmed};
+  \node (adopted) [below = of confirmed, fill = green!30] {Adopted};
+
+  \tikzset{every node/.style={align=center, text width=10em, text=brown}}
+
+  \draw[->] (active)
+  edge node [above] {Protocol update proposal\\ gets enough votes}
+  (confirmed);
+
+  \draw[->] (active)
+  edge node [left] {Voting period \\ends}
+  (rejected);
+
+  \draw[->] (confirmed)
+  edge node [above left]
+  {Proposal with higher version adopted}
+  (rejected);
+
+  \draw[->] (confirmed)
+  edge node [right]
+  {Proposal gets enough endorsements}
+  (adopted);
+
+  \end{tikzpicture}
+
+  \caption{State-transition diagram for protocol-updates}
+  \label{fig:st-diagram-pt-up}
 \end{figure}

--- a/specs/ledger/latex/ledger-spec.tex
+++ b/specs/ledger/latex/ledger-spec.tex
@@ -24,6 +24,8 @@
 \usepackage{semantic}
 %% Setup for the semantic package
 \setpremisesspace{20pt}
+\usepackage{tikz}
+\usetikzlibrary{decorations.pathreplacing, positioning, arrows.meta, calc}
 
 \usepackage{tikz-cd}
 

--- a/specs/ledger/latex/update-mechanism.tex
+++ b/specs/ledger/latex/update-mechanism.tex
@@ -1,6 +1,6 @@
 \newcommand{\UProp}{\ensuremath{\type{UProp}}}
-\newcommand{\UPropId}{\ensuremath{\type{UPropId}}}
-\newcommand{\UPropSD}{\ensuremath{\type{UPropSD}}}
+\newcommand{\UPropId}{\ensuremath{\type{UpId}}}
+\newcommand{\UPropSD}{\ensuremath{\type{UpSD}}}
 \newcommand{\ProtVer}{\ensuremath{\type{ProtVer}}}
 \newcommand{\ProtPm}{\ensuremath{\type{Ppm}}}
 \newcommand{\Rups}{\ensuremath{\type{Rups}}}
@@ -74,10 +74,10 @@ this specification can be extended to incorporate the research results.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \var{up} & \UProp & \text{(protocol) update proposal}\\
-      \var{p} & \ProtPm & \text{protocol parameters}\\
+      \var{up} & \UProp & \text{update proposal}\\
+      \var{p} & \ProtPm & \text{protocol parameter}\\
       \var{upd} & \type{UpdData} & \text{update data}\\
-      \var{upa} & \type{UpdAttr} & \text{update attributes}\\
+      \var{upa} & \type{UpdAttrs} & \text{update attributes}\\
       \var{an} & \ApName & \text{application name}
     \end{array}
   \end{equation*}
@@ -85,6 +85,7 @@ this specification can be extended to incorporate the research results.
   \emph{Derived types}
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{~=~}r@{~\in~}lr}
+      \var{b_n} & \BkNr & n & \mathbb{N} & \text{block number}\\
       \var{pv} & \ProtVer & (\var{maj}, \var{min}, \var{alt})
       & (\mathbb{N}, \mathbb{N}, \mathbb{N}) & \text{protocol version}\\
       \var{pps} & \PPMMap & \var{pps} & \ProtPm \mapsto \Value
@@ -108,7 +109,7 @@ this specification can be extended to incorporate the research results.
           \PPMMap\\
           \type{SWVer}\\
           \type{UpdData}\\
-          \type{UpdAttr}\\
+          \type{UpdAttrs}\\
         \end{array}
                    \right)
                    }
@@ -119,13 +120,13 @@ this specification can be extended to incorporate the research results.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{upIssuer} & \UProp \to \VKeyGen & \text{issuer of the update proposal}\\
+      \fun{upIssuer} & \UProp \to \VKeyGen & \text{update proposal issuer}\\
       \fun{upSize} & \UProp \to \mathbb{N} & \text{update proposal size}\\
       \fun{upPV} & \UProp \to \ProtVer & \text{update proposal protocol version}\\
       \fun{upId} & \UProp \to \UPropId & \text{update proposal id}\\
       \fun{upParams} & \UProp \to \mathbb{\PPMMap}
-                                           & \text{new parameters that are proposed}\\
-      \fun{upSwVer} & \UProp \to \SWVer & \text{software version-update proposal}\\
+                                           & \text{proposed parameters update}\\
+      \fun{upSwVer} & \UProp \to \SWVer & \text{software-version update proposal}\\
       \fun{upSig} & \UProp \to \Sig & \text{update proposal signature}\\
       \fun{upSigdata} & \UProp \to \UPropSD & \text{update proposal signed data}\\
     \end{array}
@@ -134,11 +135,12 @@ this specification can be extended to incorporate the research results.
   \label{fig:defs:update-proposals}
 \end{figure}
 
-The set of protocol parameters is assumed to contain the following keys, which
+The set of protocol parameters ($\ProtPm$) is assumed to contain the following keys, which
 correspond with fields of the current `BlockVersionData` structure:
 \begin{itemize}
 \item Slot duration: $\var{slotDuration}$
 \item Maximum block size: $\var{maxBlockSize}$
+\item Maximum transaction size: $\var{maxTxSize}$
 \item Maximum header size: $\var{maxHeaderSize}$
 \item Maximum transaction size: $\var{maxTxSize}$
 \item Maximum proposal size: $\var{maxProposalSize}$
@@ -167,6 +169,8 @@ First we model the validity of a proposal.
       \begin{array}{r@{~\in~}lr}
         \var{pv} & \ProtVer & \text{adopted (current) protocol version}\\
         \var{pps} & \PPMMap & \text{adopted protocol parameters map}\\
+        \var{avs} & \ApName \mapsto (\mathbb{N} \times \BkNr)
+        & \text{application versions}\\
       \end{array}
     \right)
   \end{equation*}
@@ -177,7 +181,9 @@ First we model the validity of a proposal.
     = \left(
       \begin{array}{r@{~\in~}lr}
         \var{rups} & \UPropId \mapsto (\ProtVer \times \PPMMap)
-        & \text{registered update proposals}\\
+        & \text{registered protocol update proposals}\\
+        \var{raus} & \UPropId \mapsto (\ApName \times \mathbb{N})
+        & \text{registered software update proposals}\\
       \end{array}
     \right)
   \end{equation*}
@@ -209,8 +215,13 @@ In Rule~\ref{eq:rule:up-validity} we see that a new proposal:
   \begin{itemize}
   \item the proposal size must not exceed the maximum size specified by
     the current protocol parameters,
-  \item the proposed new maximum block should be not greater than twice current
-    maximum block size, and
+  \item the proposed new maximum block size should be not greater than twice
+    current maximum block size,
+  \item the maximum transaction size must be smaller than the maximum block
+    size (this requirement is \textbf{crucial} for having every transaction
+    fitting in a block \footnote{TODO: we should discuss if this is enough,
+      since a block might contain other data that contributes to its total
+      size}), and
   \item the proposed new script version can be incremented by at most 1.
   \end{itemize}
 \item must be new:
@@ -250,6 +261,9 @@ In Rule~\ref{eq:rule:up-validity} we see that a new proposal:
          & \wedge & (\var{maxBlockSize} \mapsto \var{bszm_{up}} \in (\upParams{up})\\
          & & \Rightarrow \var{maxBlockSize} \mapsto \var{bszm} \in \var{pps}
              \wedge  \var{bszm_{up}} \leq 2\var{bszm})\\
+         & \wedge & (\var{maxBlockSize} \mapsto \var{bszm_{up}} \in (\upParams{up})
+         \wedge \var{maxTxSize} \mapsto \var{txzm_{up}} \in (\upParams{up})\\
+         & & \Rightarrow \var{txzm_{up}} < \var{bszm_{up}})\\
          & \wedge & (\var{scriptVersion} \mapsto \var{sv_{up}} \in (\upParams{up}) \\
          & & \Rightarrow \var{scriptVersion} \mapsto \var{sv} \in \var{pps}
              \wedge  0 \leq \var{sv_{up}} - \var{sv} \leq 1)
@@ -269,7 +283,7 @@ In Rule~\ref{eq:rule:up-validity} we see that a new proposal:
   \begin{equation}
     \label{eq:func:av-can-follow}
     \begin{array}{r c l}
-      \fun{avCanFollow}~\var{avs}~(\var{an}, \var{av}) & =
+      \fun{svCanFollow}~\var{avs}~(\var{an}, \var{av}) & =
       & (\var{an} \mapsto (\var{av_c}, \wcard) \in \var{avs}
         \Rightarrow 0 \leq \var{av} - \var{av_c} \leq 1)\\
       & \vee & (\var{an} \notin \dom~\var{avs} \Rightarrow \var{av} = 0)
@@ -284,7 +298,7 @@ In Rule~\ref{eq:rule:up-validity} we see that a new proposal:
     \inference
     {
       (\var{an}, \var{av}) = \upSwVer{up}
-      & \fun{avCanFollow}~\var{avs}~(\var{an}, \var{av})
+      & \fun{svCanFollow}~\var{avs}~(\var{an}, \var{av})
       & (\var{an}, \var{av}) \notin \range~\var{raus}
     }
     {
@@ -528,22 +542,26 @@ In Rule~\ref{eq:rule:up-limits}:
         \var{pv} & \ProtVer & \text{adopted (current) protocol version}\\
         \var{pps} & \PPMMap & \text{adopted protocol parameters map}\\
         \var{e_c} & \Epoch & \text{current epoch}\\
+        \var{avs} & \ApName \mapsto (\mathbb{N} \times \BkNr)
+        & \text{application versions}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
       \end{array}
     \right)
   \end{equation*}
   %
   \emph{Update proposals registration states}
-  \begin{equation*}
-    \UPRState
-    = \left(
+  \begin{align*}
+    & \UPRState = \\
+    & \left(
       \begin{array}{r@{~\in~}lr}
         \var{rups} & \UPropId \mapsto (\ProtVer \times \PPMMap)
         & \text{registered update proposals}\\
+        \var{raus} & \UPropId \mapsto (\ApName \times \mathbb{N})
+        & \text{registered software update proposals}\\
         \var{eps} & \powerset{(\Epoch \times \VKeyGen)} & \text{proposals per-epoch per-key}\\
       \end{array}
     \right)
-  \end{equation*}
+  \end{align*}
   %
   \emph{Update proposals registration transitions}
   \begin{equation*}
@@ -563,7 +581,8 @@ In Rule~\ref{eq:rule:up-limits}:
       {
         \begin{array}{l}
           \var{pv}\\
-          \var{pps}
+          \var{pps}\\
+          \var{avs}
         \end{array}
       }
       \vdash
@@ -571,6 +590,7 @@ In Rule~\ref{eq:rule:up-limits}:
         \left(
           \begin{array}{l}
             \var{rups}\\
+            \var{raus}\\
           \end{array}
         \right)
       }
@@ -579,6 +599,7 @@ In Rule~\ref{eq:rule:up-limits}:
         \left(
           \begin{array}{l}
             \var{rups'}\\
+            \var{raus'}\\
           \end{array}
         \right)
       }
@@ -611,6 +632,7 @@ In Rule~\ref{eq:rule:up-limits}:
           \var{pv}\\
           \var{pps}\\
           \var{e_c}\\
+          \var{avs}\\
           \var{dms}
         \end{array}
       }
@@ -619,6 +641,7 @@ In Rule~\ref{eq:rule:up-limits}:
         \left(
           \begin{array}{l}
             \var{rups}\\
+            \var{raus}\\
             \var{eps}
           \end{array}
         \right)
@@ -628,6 +651,7 @@ In Rule~\ref{eq:rule:up-limits}:
         \left(
           \begin{array}{l}
             \var{rups'}\\
+            \var{raus'}\\
             \var{eps'}
           \end{array}
         \right)
@@ -649,14 +673,6 @@ In Rule~\ref{eq:rule:up-limits}:
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \var{v} & \Vote & \text{vote on an update proposal}
-    \end{array}
-  \end{equation*}
-  %
-  \emph{Derived types}
-  %
-  \begin{equation*}
-    \begin{array}{r@{~\in~}l@{~=~}r@{~\in~}lr}
-      \var{b_n} & \BkNr & n & \mathbb{N} & \text{block number}
     \end{array}
   \end{equation*}
   %
@@ -892,6 +908,7 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
       \var{pid} = \vPropId{v}
       & \var{cfmThd} \mapsto t \in \var{pps}
       & t \leq \size{\{\var{pid}\} \restrictdom \var{vts'}}
+      & \var{pid} \notin \dom~\var{cps}
     }
     {
       {
@@ -938,10 +955,6 @@ blocks. Some clarifications are in order:
 \item The $k$ parameter is used to determined when a confirmed proposal is
   stable. Given we are in a current block $b_n$, all update proposals confirmed
   at or before block $b_n - k$ are deemed stable.
-\item The type $\Rups$ is equal to
-  $\UPropId \mapsto (\ProtVer \times \PPMMap)$, we use this local
-  definition to be able to fit the description of the environment in the page
-  width.
 \item For the sake of conciseness, we omit the types associated to the
   transitions $\trans{addbvvk}{}$, since they can be inferred from the types of
   the $\trans{upend}{}$ transitions.
@@ -959,7 +972,7 @@ blocks. Some clarifications are in order:
                              & \text{current protocol parameters map}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
         \var{cps} & \UPropId \mapsto \BkNr & \text{confirmed proposals}\\
-        \var{rups} & \Rups
+        \var{rups} & \UPropId \mapsto (\ProtVer \times \PPMMap)
                              & \text{registered update proposals}\\
       \end{array}\right)
   \end{align*}
@@ -1008,23 +1021,26 @@ rule by $\var{bv}$:
   proposal (which are contained in $\var{rups}$), and this update proposal must
   have been confirmed at least $k$ blocks ago, to ensure stability of the
   confirmation. Note that this rule does not guarantee that a confirmed
-  proposal will have $k$ blocks (or $2k$ blocks) before the end of the epoch
+  proposal will have $k$ blocks (or $2k$ slots) before the end of the epoch
   where nodes can endorse this version. In such case, the proposal can only be
-  adopted in the next epoch. Figure~\ref{fig:proposal-confirmed-too-late} shows
+  adopted in the next epoch. Figure~\ref{fig:up-confirmed-too-late} shows
   an example of a proposal being confirmed too late in an epoch, where it is
   not possible to get the enough endorsements in the remaining window. In this
   Figure we take $k = 2$.
 \end{itemize}
 
-\begin{equation}
-  \label{eq:predicate:canadopt}
-  \begin{array}{r c l}
-    \fun{canAdopt}~\var{pps}~\var{bvs}~\var{bv}
-    & =
-    & \var{upAdptThd} \mapsto t \in pps \wedge
-    t \leq \size{\{\var{bv}\} \restrictdom \var{bvs}}\\
-  \end{array}
-\end{equation}
+\begin{figure}[htb]
+  \begin{equation}
+    \label{eq:predicate:canadopt}
+    \begin{array}{r c l}
+      \fun{canAdopt}~\var{pps}~\var{bvs}~\var{bv}
+      & =
+      & \var{upAdptThd} \mapsto t \in pps \wedge
+        t \leq \size{\{\var{bv}\} \restrictdom \var{bvs}}\\
+    \end{array}
+  \end{equation}
+  \caption{Update-proposal endorsement functions}
+\end{figure}
 
 \begin{figure}[htb]
   \begin{equation}
@@ -1273,7 +1289,8 @@ rule by $\var{bv}$:
     \pgfmathsetmacro{\eend}{7}
 
     % Draw the horizontal line
-    \draw[thick, -Triangle] (0,0) -- (\nrSlots,0) node[font=\scriptsize,below left=3pt and -8pt]{slots};
+    \draw[thick, -Triangle] (0,0) -- (\nrSlots,0)
+    node[font=\scriptsize,below left=3pt and -8pt]{slots};
 
     % % draw vertical lines
     \foreach \x in {0,1,...,10}
@@ -1321,11 +1338,15 @@ rule by $\var{bv}$:
 
     \draw[blue, line width=2pt] (\eend, 3pt) -- (\eend, -3pt);
 
+    \draw[<-] (\cSlot, 4pt) -- +(-1, 1)
+    node [above=2pt, black, font=\scriptsize]
+    {Proposal with id $\var{pid}$ gets confirmed};
+
     \draw[->] (\eend, -4pt) -- +(1, -1)
     node[right, blue, font=\scriptsize] {End of epoch};
   \end{tikzpicture}
-  \caption{A proposal confirmed too late}
-  \label{fig:proposal-confirmed-too-late}
+  \caption{An update proposal confirmed too late}
+  \label{fig:up-confirmed-too-late}
 \end{figure}
 
 \clearpage
@@ -1371,16 +1392,12 @@ complex check (which depends on state) to determine if a proposed version can
 follow the current one. By being more lenient on the alternative versions of
 update proposals we can simplify the version checking logic considerably.
 
-\subsubsection{Cleanup}
-\label{sec:up-cleanup}
+\subsubsection{No implicit agreement}
+\label{sec:no-implicit-agreement}
 
-Update proposals that are older than $u$ blocks w.r.t. the current block are
-discarded from the state, along with their associated information. The current
-implementation makes use of the implicit agreement rule and the epoch boundary
-checks: this leads to plenty of different states for a proposal: active,
-adopted, confirmed, competing, never-to-become-adopted, rejected, discarded. If
-the cleanup of proposals can be done in the way specified here we will avoid a
-great deal of cognitive complexity when reasoning about the update system.
+We do not model the implicit agreement rule. If a proposal does not get enough
+votes before the end of the voting period, then we simply discard it. At the
+moment it is not clear whether the implicit agreement rule is needed.
 
 \subsubsection{Adoption threshold}
 \label{sec:adoption-threshold}
@@ -1419,25 +1436,10 @@ Ouroboros-BFT logic in the software.
 It is unclear at this moment whether we need to model the applications names
 and versions, so this aspect is not modeled in the present rules.
 
-\subsubsection{No model of software-version}
-\label{sec:no-model-software-version}
-
-We do not model the
-\href{https://github.com/input-output-hk/cardano-sl/blob/develop/docs/block-processing/us.md#software-version}{application
-  name and the software version} of this application. It remains to be seen
-whether this is part of the scope of this specification.
-
-
-\subsubsection{Protocol-only vs software updates}
-\label{sec:protocol-vs-software-updates}
-
-We do not distinguish between protocol or software updates. The ledger only
-cares about the mechanisms by which the protocol parameters are changed.
-
 \subsubsection{Ignored attributes of proposals}
 
 In Figure~\ref{fig:defs:update-proposals} the types
-$\type{UpdData}$, and $\type{UpdAttr}$ are only needed to model the fact that
+$\type{UpdData}$, and $\type{UpdAttrs}$ are only needed to model the fact that
 an update proposal must sign such data, however, we do not use them for any
 other purpose in this formalization.
 

--- a/specs/ledger/latex/update-mechanism.tex
+++ b/specs/ledger/latex/update-mechanism.tex
@@ -16,6 +16,8 @@
 \newcommand{\BVREnv}{\ensuremath{\type{BVREnv}}}
 \newcommand{\BVRState}{\ensuremath{\type{BVRState}}}
 \newcommand{\BkNr}{\ensuremath{\type{BkNr}}}
+\newcommand{\ApName}{\ensuremath{\type{ApName}}}
+\newcommand{\SWVer}{\ensuremath{\type{SWVer}}}
 
 \newcommand{\upSize}[1]{\ensuremath{\fun{upSize}~\var{#1}}}
 \newcommand{\upPV}[1]{\ensuremath{\fun{upPV}~\var{#1}}}
@@ -24,6 +26,7 @@
 \newcommand{\upSigData}[1]{\ensuremath{\fun{upSigData}~\var{#1}}}
 \newcommand{\upIssuer}[1]{\ensuremath{\fun{upIssuer}~\var{#1}}}
 \newcommand{\upParams}[1]{\ensuremath{\fun{upParams}~\var{#1}}}
+\newcommand{\upSwVer}[1]{\ensuremath{\fun{upSwVer}~\var{#1}}}
 \newcommand{\vCaster}[1]{\ensuremath{\fun{vCaster}~\var{#1}}}
 \newcommand{\vPropId}[1]{\ensuremath{\fun{vPropId}~\var{#1}}}
 \newcommand{\vSig}[1]{\ensuremath{\fun{vSig}~\var{#1}}}
@@ -73,9 +76,9 @@ this specification can be extended to incorporate the research results.
     \begin{array}{r@{~\in~}lr}
       \var{up} & \UProp & \text{(protocol) update proposal}\\
       \var{p} & \ProtPm & \text{protocol parameters}\\
-      \var{swv} & \type{SWVer} & \text{update software version}\\
       \var{upd} & \type{UpdData} & \text{update data}\\
       \var{upa} & \type{UpdAttr} & \text{update attributes}\\
+      \var{an} & \ApName & \text{application name}
     \end{array}
   \end{equation*}
   %
@@ -86,6 +89,9 @@ this specification can be extended to incorporate the research results.
       & (\mathbb{N}, \mathbb{N}, \mathbb{N}) & \text{protocol version}\\
       \var{pps} & \PPMMap & \var{pps} & \ProtPm \mapsto \Value
                                              & \text{protocol parameters map}\\
+      \var{swv} & \SWVer
+      & (\var{an}, \var{av}) & \ApName \times \mathbb{N}
+      & \text{software version}\\
       \var{pb} & \UPropSD
       &
         {\left(\begin{array}{r l}
@@ -119,8 +125,9 @@ this specification can be extended to incorporate the research results.
       \fun{upId} & \UProp \to \UPropId & \text{update proposal id}\\
       \fun{upParams} & \UProp \to \mathbb{\PPMMap}
                                            & \text{new parameters that are proposed}\\
+      \fun{upSwVer} & \UProp \to \SWVer & \text{software version-update proposal}\\
       \fun{upSig} & \UProp \to \Sig & \text{update proposal signature}\\
-      \fun{upSigdata} & \UProp \to \UPropSD & \text{update proposal signed data}
+      \fun{upSigdata} & \UProp \to \UPropSD & \text{update proposal signed data}\\
     \end{array}
   \end{equation*}
   \caption{Update proposals definitions}
@@ -187,11 +194,10 @@ First we model the validity of a proposal.
 
 In Rule~\ref{eq:rule:up-validity} we see that a new proposal:
 \begin{itemize}
-\item must increase one of the (major, minor, or alternative) of the
-  current version in a consistent manner:
+\item if it changes the protocol version, it must do it in a consistent manner:
   \begin{itemize}
-  \item The proposed version must be lexicographically bigger than the current
-    version.
+  \item The proposed version must be lexicographically bigger or equal than the
+    current version.
   \item The major versions of the proposed and current version must differ in
     at most one.
   \item If the proposed major version is equal to the current major
@@ -214,16 +220,20 @@ In Rule~\ref{eq:rule:up-validity} we see that a new proposal:
     implies that a proposal is uniquely determined by the protocol version it
     proposes.
   \end{itemize}
+\item must increase the software version by at most one (see
+  \cref{eq:func:av-can-follow}).
+\item must not contain a software update proposal that was already registered
+  (in $\var{raups}$).
 \item the protocol version and parameters, along with some other data (see the
   definition of $\fun{upSigdata}$), must be signed by the proposal issuer.
 \end{itemize}
 
 \begin{figure}[htb]
   \begin{equation}
-    \label{eq:func:can-follow}
+    \label{eq:func:pv-can-follow}
     \begin{array}{r c l}
-      \fun{canFollow}~(\var{mj_n}, \var{mi_n}, \var{a_n})~(\var{mj_p}, \var{mi_p}, \var{a_p})
-      & = & (\var{mj_p}, \var{mi_p}, \var{a_p}) < (\var{mj_n}, \var{mi_n}, \var{a_n})\\
+      \fun{pvCanFollow}~(\var{mj_n}, \var{mi_n}, \var{a_n})~(\var{mj_p}, \var{mi_p}, \var{a_p})
+      & = & (\var{mj_p}, \var{mi_p}, \var{a_p}) \leq (\var{mj_n}, \var{mi_n}, \var{a_n})\\
       & \wedge & 0 \leq \var{mj_n} - \var{mj_p} \leq 1\\
       & \wedge & (\var{mj_p} = \var{mj_n} \Rightarrow \var{mi_p} + 1 = \var{mi_n}))\\
       & \wedge & (\var{mj_p} + 1 = \var{mj_n} \Rightarrow \var{mi_n} = 0)
@@ -248,11 +258,21 @@ In Rule~\ref{eq:rule:up-validity} we see that a new proposal:
   \end{equation}
   \nextdef
   \begin{equation}
-    \label{eq:func:is-new}
+    \label{eq:func:pv-is-new}
     \begin{array}{r c l}
-      \fun{isNew}~\var{rups}~(\var{pid}, \var{nv})
+      \fun{pvIsNew}~\var{rups}~(\var{pid}, \var{nv})
       & = &  \var{pid} \notin \dom \var{rups}
-            \wedge \var{nv} \notin \dom (\range \var{rups})\\
+            \wedge \var{nv} \notin \dom (\range \var{rups})
+    \end{array}
+  \end{equation}
+  \nextdef
+  \begin{equation}
+    \label{eq:func:av-can-follow}
+    \begin{array}{r c l}
+      \fun{avCanFollow}~\var{avs}~(\var{an}, \var{av}) & =
+      & (\var{an} \mapsto (\var{av_c}, \wcard) \in \var{avs}
+        \Rightarrow 0 \leq \var{av} - \var{av_c} \leq 1)\\
+      & \vee & (\var{an} \notin \dom~\var{avs} \Rightarrow \var{av} = 0)
     \end{array}
   \end{equation}
   \caption{Update validity functions}
@@ -260,17 +280,49 @@ In Rule~\ref{eq:rule:up-validity} we see that a new proposal:
 
 \begin{figure}[htb]
   \begin{equation}
-    \label{eq:rule:up-validity}
+    \label{eq:rule:up-av-validity}
+    \inference
+    {
+      (\var{an}, \var{av}) = \upSwVer{up}
+      & \fun{avCanFollow}~\var{avs}~(\var{an}, \var{av})
+      & (\var{an}, \var{av}) \notin \range~\var{raus}
+    }
+    {
+      {
+        \begin{array}{l}
+          \var{avs}
+        \end{array}
+      }
+      \vdash
+      {
+        \left(
+          \begin{array}{l}
+            \var{raus}
+          \end{array}
+        \right)
+      }
+      \trans{upsvv}{up}
+      {
+        \left(
+          \begin{array}{l}
+            \var{raus} \unionoverride \{ \upId{up} \mapsto (\var{an}, \var{av})\}
+          \end{array}
+        \right)
+      }
+    }
+  \end{equation}
+  \nextdef
+    \begin{equation}
+    \label{eq:rule:up-pv-validity}
     \inference
     {
       \var{vk} = \upIssuer{up}
       & \var{pid} = \upId{up}
       & \var{nv} = \upPV{up}
       & \var{pps_n} = \upParams{up}\\
-      & \fun{canFollow}~\var{nv}~\var{pv}
+      & \fun{pvCanFollow}~\var{nv}~\var{pv}
       & \fun{canUpdate}~\var{pps}~\var{up}
-      & \fun{isNew}~\var{rups}~(\var{pid}, \var{nv})\\
-      \mathcal{V}_{\var{vk}}\serialised{\upSigData{up}}_{(\upSig{up})}
+      & \fun{pvIsNew}~\var{rups}~(\var{pid}, \var{nv})
     }
     {
       {
@@ -287,11 +339,91 @@ In Rule~\ref{eq:rule:up-validity} we see that a new proposal:
           \end{array}
         \right)
       }
-      \trans{upv}{\var{up}}
+      \trans{uppvv}{\var{up}}
       {
         \left(
           \begin{array}{l}
             \var{rups} \unionoverride \{ \var{pid} \mapsto (\var{nv}, \var{pps_n}) \}
+          \end{array}
+        \right)
+      }
+    }
+  \end{equation}
+  \nextdef
+  \begin{equation}
+    \label{eq:rule:up-validity}
+    \inference
+    {
+      {
+        \begin{array}{l}
+          \var{pv}\\
+          \var{pps}
+        \end{array}
+      }
+      \vdash
+      {
+        \left(
+          \begin{array}{l}
+            \var{rups}
+          \end{array}
+        \right)
+      }
+      \trans{uppvv}{\var{up}}
+      {
+        \left(
+          \begin{array}{l}
+            \var{rups'}
+          \end{array}
+        \right)
+      }
+      &
+      {
+        \begin{array}{l}
+          \var{avs}
+        \end{array}
+      }
+      \vdash
+      {
+        \left(
+          \begin{array}{l}
+            \var{raus}
+          \end{array}
+        \right)
+      }
+      \trans{upsvv}{up}
+      {
+        \left(
+          \begin{array}{l}
+            \var{raus'}
+          \end{array}
+        \right)
+      }
+      \\
+      \mathcal{V}_{\var{vk}}\serialised{\upSigData{up}}_{(\upSig{up})}
+    }
+    {
+      {
+        \begin{array}{l}
+          \var{pv}\\
+          \var{pps}\\
+          \var{avs}
+        \end{array}
+      }
+      \vdash
+      {
+        \left(
+          \begin{array}{l}
+            \var{rups}\\
+            \var{raus}
+          \end{array}
+        \right)
+      }
+      \trans{upv}{\var{up}}
+      {
+        \left(
+          \begin{array}{l}
+            \var{rups'}\\
+            \var{raus'}
           \end{array}
         \right)
       }
@@ -796,10 +928,10 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
 
 \clearpage
 
-\subsection{Block protocol version registration}
-\label{sec:block-protocol-version-reg}
+\subsection{Update-proposal endorsement}
+\label{sec:proposal-endorsement}
 
-Figure~\ref{fig:ts-types:up-bv-reg} shows the types of the transition system
+Figure~\ref{fig:ts-types:up-end} shows the types of the transition system
 associated with the registration of candidate protocol versions present in
 blocks. Some clarifications are in order:
 \begin{itemize}
@@ -812,11 +944,11 @@ blocks. Some clarifications are in order:
   width.
 \item For the sake of conciseness, we omit the types associated to the
   transitions $\trans{addbvvk}{}$, since they can be inferred from the types of
-  the $\trans{upbvreg}{}$ transitions.
+  the $\trans{upend}{}$ transitions.
 \end{itemize}
 
 \begin{figure}[htb]
-  \emph{Block protocol version registration environments}
+  \emph{Update-proposal endorsement environments}
   \begin{align*}
     & \BVREnv
       = \left(
@@ -832,7 +964,7 @@ blocks. Some clarifications are in order:
       \end{array}\right)
   \end{align*}
   %
-  \emph{Block protocol version registration states}
+  \emph{Update-proposal endorsement states}
   \begin{align*}
     & \BVRState
       = \left(
@@ -840,28 +972,30 @@ blocks. Some clarifications are in order:
         (\var{pv_c}, \var{pps_c}) & \ProtVer \times \PPMMap
         & \text{candidate protocol}\\
         \var{bvs} & \powerset{(\ProtVer \times \VKeyGen)}
-        & \text{keys ready to adopt versions}
+        & \text{endorsement-key pairs}
       \end{array}\right)
   \end{align*}
   %
-  \emph{Block protocol version registration transitions}
+  \emph{Update-proposal endorsement transitions}
     \begin{equation*}
-    \_ \vdash \_ \trans{upbvreg}{\_} \_ \in
+    \_ \vdash \_ \trans{upend}{\_} \_ \in
     \powerset (\BVREnv \times \BVRState
     \times (\ProtVer \times \VKey) \times \BVRState)
     \end{equation*}
-  \caption{Vote registration transition-system types}
-  \label{fig:ts-types:up-bv-reg}
+  \caption{Update-proposal endorsement transition-system types}
+  \label{fig:ts-types:up-end}
 \end{figure}
 
-Rules in \cref{fig:rules:up-bv-reg} specify what happens when a block issuer
+Rules in \cref{fig:rules:up-end} specify what happens when a block issuer
 signals that it is ready to upgrade to a new protocol version, given in the
 rule by $\var{bv}$:
 \begin{itemize}
-\item The set $\var{bvs}$ that contains which genesis keys are ready to adopt
-  a given protocol version is updated to reflect that all the delegators of the
+\item The set $\var{bvs}$, containing which genesis keys are ready to adopt a
+  given protocol version, is updated to reflect that all the delegators of the
   block issuer (identified by its verifying key, $\var{vk}$) are ready to
-  upgrade to $\var{bv}$.
+  upgrade to $\var{bv}$. Given a pair $(\var{pv}, ~\var{vk_s}) \in \var{bvs}$,
+  we say that (the owner of) key $\var{vk_s}$ endorses the (proposed) protocol
+  version $\var{pv}$.
 \item If the candidate protocol version $\var{bv}$ is greater than the current
   candidate version $\var{pv_c}$, and there is a significant number of blocks
   signed with that version (condition formalized in
@@ -870,10 +1004,16 @@ rule by $\var{bv}$:
   current protocol version $\var{pv}$. If this rule is used in an initial state
   in which $\var{pv} \leq \var{pv_c}$, then this invariant is maintained by
   these rules.
-\item The protocol version $\var{bv}$ must refer to a registered update
+\item Endorsed protocol version $\var{bv}$ must refer to a registered update
   proposal (which are contained in $\var{rups}$), and this update proposal must
   have been confirmed at least $k$ blocks ago, to ensure stability of the
-  confirmation.
+  confirmation. Note that this rule does not guarantee that a confirmed
+  proposal will have $k$ blocks (or $2k$ blocks) before the end of the epoch
+  where nodes can endorse this version. In such case, the proposal can only be
+  adopted in the next epoch. Figure~\ref{fig:proposal-confirmed-too-late} shows
+  an example of a proposal being confirmed too late in an epoch, where it is
+  not possible to get the enough endorsements in the remaining window. In this
+  Figure we take $k = 2$.
 \end{itemize}
 
 \begin{equation}
@@ -969,7 +1109,7 @@ rule by $\var{bv}$:
           \end{array}
         \right)
       }
-      \trans{upbvreg}{(\var{bv}, \var{vk})}
+      \trans{upend}{(\var{bv}, \var{vk})}
       {
         \left(
           \begin{array}{l}
@@ -1034,7 +1174,7 @@ rule by $\var{bv}$:
           \end{array}
         \right)
       }
-      \trans{upbvreg}{(\var{bv}, \var{vk})}
+      \trans{upend}{(\var{bv}, \var{vk})}
       {
         \left(
           \begin{array}{l}
@@ -1100,7 +1240,7 @@ rule by $\var{bv}$:
           \end{array}
         \right)
       }
-      \trans{upbvreg}{(\var{bv}, \var{vk})}
+      \trans{upend}{(\var{bv}, \var{vk})}
       {
         \left(
           \begin{array}{l}
@@ -1111,8 +1251,81 @@ rule by $\var{bv}$:
       }
     }
   \end{equation}
-  \caption{Block protocol version registration rules}
-  \label{fig:rules:up-bv-reg}
+  \caption{Update-proposal endorsement rules}
+  \label{fig:rules:up-end}
+\end{figure}
+
+
+\begin{figure}[htb]
+  \centering
+  \begin{tikzpicture}
+    %%
+    %% Macros used in this picture
+    %%
+    %
+    % Number of slots
+    \pgfmathsetmacro{\nrSlots}{11}
+    % Slot in which the proposal gets confirmed
+    \pgfmathsetmacro{\cSlot}{1}
+    % Our special K.
+    \pgfmathsetmacro{\K}{2}
+    % Epoch end.
+    \pgfmathsetmacro{\eend}{7}
+
+    % Draw the horizontal line
+    \draw[thick, -Triangle] (0,0) -- (\nrSlots,0) node[font=\scriptsize,below left=3pt and -8pt]{slots};
+
+    % % draw vertical lines
+    \foreach \x in {0,1,...,10}
+    \draw (\x cm, 3pt) -- (\x cm, -3pt);
+
+    % Add a label to with the block number in which the proposal got confirmed.
+    \node at (\cSlot, -.7) {$b_j$};
+
+    % Update in cps
+    \node at (\cSlot, -1.5) {$\var{cps'} = \var{cps} \cup \{ \var{pid} \mapsto b_j \}$};
+
+    % The no-endorsements red bar.
+    \draw[red, line width=4pt] (\cSlot, .5) -- +(2*\K, 0);
+
+    % Brace above the no-endorsement window bar.
+    \draw[thick, red, decorate, decoration={brace, amplitude=5pt}]
+    (\cSlot, .7) -- +(2*\K, 0)
+    node[black!20!red, midway, above=4pt, font=\scriptsize] {No-endorsements possible};
+
+    % The endorsements window.
+    \coordinate (ewStart) at (\cSlot + 2*\K, .5);
+    \coordinate (ewEnd) at ($(\eend, .5)$);
+    \draw[green, line width=4pt]
+    (ewStart) -- (ewEnd);
+
+    % Brace above the endorsements window
+    \coordinate (ewStartB) at ($(ewStart) + (0, 0.2)$);
+    \coordinate (ewEndB) at ($(ewEnd) + (0, 0.2)$);
+    \draw[thick, green, decorate, decoration={brace, amplitude=5pt}]
+    (ewStartB) -- (ewEndB)
+    node[black!50!green, midway, above=15pt, font=\scriptsize] {Endorsements window};
+
+    % The 2k before end-of-epoch window.
+    \coordinate (beeStart) at (\eend - 2*\K, -.5);
+    \coordinate (beeEnd) at ($(\eend, -.5)$);
+    \draw[blue, line width=4pt]
+    (beeStart) -- (beeEnd);
+
+    % Brace on above the 2k before end-of-epoch window.
+    \coordinate (beeStartB) at ($(beeStart) - (0, 0.2)$);
+    \coordinate (beeEndB) at ($(beeEnd) - (0, 0.2)$);
+    \draw[thick, blue, decorate, decoration={brace, amplitude=5pt}]
+    (beeEndB) -- (beeStartB)
+    node[black!20!blue, midway, below=5pt, font=\scriptsize] {$2k$ slots before epoch ends};
+
+    \draw[blue, line width=2pt] (\eend, 3pt) -- (\eend, -3pt);
+
+    \draw[->] (\eend, -4pt) -- +(1, -1)
+    node[right, blue, font=\scriptsize] {End of epoch};
+  \end{tikzpicture}
+  \caption{A proposal confirmed too late}
+  \label{fig:proposal-confirmed-too-late}
 \end{figure}
 
 \clearpage
@@ -1192,17 +1405,6 @@ In this specification we only make use of a minimum adoption threshold,
 represented by the protocol parameter $\var{upAdptThd}$ until it becomes clear
 why a dynamic alternative is needed.
 
-\subsubsection{No voting deadlines}
-\label{sec:no-voting-deadlines}
-
-The update proposals have a time-to-live, formalized using the parameter $u$ in
-Figure~\ref{fig:ts-types:upi}. This is the total time a proposal has to enter
-the system and become adopted. Proposals that exceeded this time to live are
-removed from the ledger state. This cleanup takes place at a single place in
-the rules, which simplifies reasoning about the ledger-state size bounds. By
-having a voting deadline, we would still need a time-to-live for confirmed
-proposals that were not adopted, which requires additional logic.
-
 \subsubsection{No checks on unlock-stake-epoch parameter}
 \label{sec:no-unlock-stake-epoch-check}
 
@@ -1234,7 +1436,17 @@ cares about the mechanisms by which the protocol parameters are changed.
 
 \subsubsection{Ignored attributes of proposals}
 
-In Figure~\ref{fig:defs:update-proposals} the types $\type{SWVer}$,
+In Figure~\ref{fig:defs:update-proposals} the types
 $\type{UpdData}$, and $\type{UpdAttr}$ are only needed to model the fact that
 an update proposal must sign such data, however, we do not use them for any
 other purpose in this formalization.
+
+\subsection{Questions}
+\label{sec:up-questions}
+
+This temporary section contains unanswered questions about the formalization of
+update mechanism:
+
+\begin{itemize}
+\item Do we need to model the $\var{scriptVersion}$?
+\end{itemize}

--- a/test/Test/Cardano/Chain/Slotting/Gen.hs
+++ b/test/Test/Cardano/Chain/Slotting/Gen.hs
@@ -90,5 +90,5 @@ genSlottingData = mkSlottingData <$> genSlottingDataMap >>= \case
 feedPMEpochSlots :: (ProtocolMagic -> SlotCount -> Gen a) -> Gen a
 feedPMEpochSlots genA = do
   pm         <- genProtocolMagic
-  epochSlots <- genSlotCount
+  epochSlots <- SlotCount . fromIntegral <$> Gen.word16 Range.constantBounded
   genA pm epochSlots


### PR DESCRIPTION
- Model software version in the ledger rules. Software version is now part of the ledger state.
- Revise the cleanup mechanism for update proposals. Confirmed proposals are not cleaned when the voting period ends, they are removed from the set of confirmed proposals when a new protocol version that has higher version gets adopted.
- Make state diagrams to highlight the differences between protocol updates and software updates.


Closes #160.
Closes #172.
Closes #173.

---
# Consequences

# Retrospective

[nc6] We should think about the best way to review such things, as it's quite dense to "intuit" a whole such system at once!