### PR TITLE
Update version of cardano-prelude for strict Maps

### DIFF
--- a/binary/stack.yaml
+++ b/binary/stack.yaml
@@ -6,7 +6,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 0c3c12ff4b95644c22731f979be0e2e6ebb8fe63
+    commit: 54f2861978a02a2b04f626f47005769bf23b853b
     subdirs:
       - .
       - test

--- a/crypto/stack.yaml
+++ b/crypto/stack.yaml
@@ -6,7 +6,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 0c3c12ff4b95644c22731f979be0e2e6ebb8fe63
+    commit: 54f2861978a02a2b04f626f47005769bf23b853b
     subdirs:
       - .
       - test

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 0c3c12ff4b95644c22731f979be0e2e6ebb8fe63
+    commit: 54f2861978a02a2b04f626f47005769bf23b853b
     subdirs:
       - .
       - test


### PR DESCRIPTION
Hopefully this fixes the space leaks we've been seeing in `cardano-chain` CI