### PR TITLE
Add distributivity assumption for serialization functions

### DIFF
--- a/specs/ledger/latex/crypto-primitives.tex
+++ b/specs/ledger/latex/crypto-primitives.tex
@@ -2,7 +2,10 @@
 \label{sec:crypto-primitives}
 
 Figure~\ref{fig:crypto-defs} introduces the cryptographic abstractions used in
-this document.
+this document. Note that we define a family of serialization functions
+$\serialised{\wcard}_\type{A}$, for all types $\type{A}$ for which such
+serialization function can be defined. When the context is clear, we omit the
+type suffix, and use simply $\serialised{\wcard}$.
 
 \begin{figure}[htb]
   \emph{Abstract types}
@@ -31,6 +34,8 @@ this document.
       %
       \fun{verify} & \VKey \times \Data \times \Sig
       & \text{verification relation}\\
+      \serialised{\wcard}_\type{A} & \type{A} \to \Data
+      & \text{serialization function for values of type $\type{A}$}
     \end{array}
   \end{equation*}
   \emph{Constraints}
@@ -38,12 +43,59 @@ this document.
     & \forall (sk, vk) \in \SkVk,~ m \in \Data,~ \sigma \in \Sig \cdot
       \verify{vk}{m}{\sigma} \iff \sign{sk}{m} = \sigma
   \end{align*}
-  \emph{Notation for serialized and verified data}
+  \emph{Notation}
   \begin{align*}
-    & \serialised{x} & \text{serialised representation of } x\\
-    & \mathcal{V}_{\var{vk}}{\serialised{m}}_{\sigma} = \verify{vk}{m}{\sigma}
+    & \mathcal{V}^\sigma_{\var{vk}}~{d} = \verify{vk}{d}{\sigma}
       & \text{shorthand notation for } \fun{verify}
   \end{align*}
   \caption{Cryptographic definitions}
   \label{fig:crypto-defs}
 \end{figure}
+
+\subsection{A note on serialization}
+\label{sec:a-note-on-serialization}
+
+\begin{definition}[Distributivity over serialization functions]
+  For all types $\type{A}$ and $\type{B}$, given a function
+  $\fun{f} \in \type{A} \to \type{B}$, we say that the serialization function
+  for values of type $\type{A}$, namely $\serialised{ }_\type{A}$ distributes
+  over $\fun{f}$ if there exists a function $\fun{f}_{\serialised{ }}$ such
+  that for all $a \in \type{A}$:
+  \begin{equation}
+    \label{eq:distributivity-serialization}
+    \serialised{\fun{f}~a}_\type{B} = \fun{f}_{\serialised{ }}~\serialised{a}_\type{A}
+  \end{equation}
+\end{definition}
+The equality defined in \cref{eq:distributivity-serialization} means that the
+following diagram commutes:
+
+\[
+  \begin{tikzcd}
+    A \arrow{r}{\fun{f}} \arrow{d}{\serialised{ }_\type{A}}
+    & B \arrow{d}{\serialised{ }_\type{B}} \\
+    \Data \arrow{r}{\fun{f}_{\serialised{ }}} & \Data
+  \end{tikzcd}
+\]
+
+Throughout this specification, whenever we use
+$\serialised{\fun{f}~a}_\type{B}$, for some type $\type{B}$ and function
+$\fun{f} \in \type{A} \to \type{B}$, we assume that $\serialised{ }_\type{A}$
+distributes over $\fun{f}$ (see for example
+Rule~\ref{eq:utxo-witness-inductive}). This property is what allow us to
+extract a component of the serialized data (if it is available) without
+deserializing it in the cases in which the deserialization function
+($\serialised{\wcard}^{-1}_\type{A}$) doesn't behave as an inverse of
+serialization:
+
+\begin{equation*}
+  \serialised{\wcard}^{-1}_\type{A} \cdot \serialised{\wcard}_\type{A} \neq \fun{id}_\type{A}
+\end{equation*}
+
+For the cases in which such an inverse exists, given a function $\fun{f}$, we
+can readily define $\fun{f}_{\serialised{ }}$ as:
+
+\begin{equation*}
+  \fun{f}_{\serialised{ }} \dot{=} \serialised{\wcard}_\type{B}
+                            . \fun{f}
+                            . \serialised{\wcard}^{-1}_\type{A}
+\end{equation*}

--- a/specs/ledger/latex/default.nix
+++ b/specs/ledger/latex/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
                       scheme-small
 
                       # libraries
-                      stmaryrd lm-math amsmath extarrows cleveref semantic xcolor
+                      stmaryrd lm-math amsmath extarrows cleveref semantic tikz-cd xcolor
 
                       # bclogo and dependencies
                       bclogo mdframed xkeyval etoolbox needspace pgf

--- a/specs/ledger/latex/intro.tex
+++ b/specs/ledger/latex/intro.tex
@@ -18,8 +18,8 @@ following aspects:
   the voters, and the participants that can post update proposals.
 \end{description}
 
-The following aspects will not be modeled (since they are not part of the legacy-free
-implementation):
+The following aspects will not be modeled (since they are not part of the Byron
+release):
 \begin{description}
 \item[Stake] staking rights associated to an addresses.
 \end{description}

--- a/specs/ledger/latex/ledger-spec.tex
+++ b/specs/ledger/latex/ledger-spec.tex
@@ -25,6 +25,8 @@
 %% Setup for the semantic package
 \setpremisesspace{20pt}
 
+\usepackage{tikz-cd}
+
 %%
 %% Types
 %%
@@ -107,6 +109,8 @@
 \renewcommand{\textfraction}{0.15}
 \renewcommand{\floatpagefraction}{0.7}
 
+\newtheorem{definition}{Definition}
+
 \begin{document}
 
 \input{frontmatter.tex}
@@ -119,8 +123,6 @@
 \include{notation}
 
 \include{crypto-primitives}
-
-\include{serialisation}
 
 \include{utxo}
 

--- a/specs/ledger/latex/serialisation.tex
+++ b/specs/ledger/latex/serialisation.tex
@@ -1,8 +1,0 @@
-\section{Serialisation}
-\label{sec:serialization}
-
-\begin{todo}
-  Discuss here serialization and
-  \href{https://iohk.myjetbrains.com/youtrack/issue/CDEC-628}{composable
-    serialization}
-\end{todo}

--- a/specs/ledger/latex/utxo.tex
+++ b/specs/ledger/latex/utxo.tex
@@ -211,7 +211,7 @@ different order). The choice here is arbitrary.
     { \var{pc} \vdash \var{utxo} \trans{utxo}{tx} \var{utxo'}\\ ~ \\
       & \forall i \in \txins{tx} \cdot \exists (\var{vk}, \sigma) \in \wits{\var{tx}}
       \cdot
-      \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma}
+      \mathcal{V}^\sigma_{\var{vk}}~{\serialised{\txbody{tx}}}
       \wedge  \fun{addr_h}~{utxo}~i = \hash{vk}\\
     }
     {\var{pc} \vdash \var{utxo} \trans{utxow}{tx} \var{utxo'}}


### PR DESCRIPTION
- Add assumption of distributivity of serialization functions.
- Explain the reason behind the distributivity constraint on the serialization
  functions.

Closes #157.