### PR TITLE
Rewrite STS system

### DIFF
--- a/specs/chain/hs/src/Delegation/Interface.hs
+++ b/specs/chain/hs/src/Delegation/Interface.hs
@@ -37,7 +37,7 @@ initDSIState :: DSIState
 initDSIState = initDSIStateFromKeys initVKeys
 
 -- | Defines when new certificates can be added to the ledger's state
-newCertsRule :: Rule Interf
+newCertsRule :: TransitionRule Interf
 newCertsRule = undefined
 
 -- | Updates the delegation interface state with a set of heavyweight

--- a/specs/semantics/hs/small-steps.cabal
+++ b/specs/semantics/hs/small-steps.cabal
@@ -21,6 +21,8 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:       base >=4.11 && <5
+                     , free
                      , lens
+                     , transformers
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This is a pretty total rewrite of `STS`. It does a few things:

- Rules are now much easier to write, and look much cleaner (much less boilerplate). Standard do notation is used.
- Bindings now work correctly. This means we can easily use results from sub transitions.

The syntax should now be pretty close to what we have in the paper.

Hopefully this new syntax might be a bit more compelling to use!