### PR TITLE
Fixates the number of epoch files for the CI to at most 10

### DIFF
--- a/test/Test/Cardano/Chain/Block/Validation.hs
+++ b/test/Test/Cardano/Chain/Block/Validation.hs
@@ -82,7 +82,7 @@ tests scenario = do
   let
     takeFiles :: [FilePath] -> [FilePath]
     takeFiles = case scenario of
-      ContinuousIntegration -> identity
+      ContinuousIntegration -> take 10
       Development           -> take 15
       QualityAssurance      -> identity
 

--- a/test/Test/Cardano/Chain/Txp/Validation.hs
+++ b/test/Test/Cardano/Chain/Txp/Validation.hs
@@ -59,7 +59,7 @@ tests scenario = do
   let
     takeFiles :: [FilePath] -> [FilePath]
     takeFiles = case scenario of
-      ContinuousIntegration -> identity
+      ContinuousIntegration -> take 10
       Development           -> take 15
       QualityAssurance      -> identity
 


### PR DESCRIPTION
This patch tries to work around the issue of excessive memory usage during continuous integration. It fixates the number of epoch files for the CI to at most 10.