### PR TITLE
Bump to version of cardano-prelude running GHC 8.6.3

### DIFF
--- a/binary/cardano-binary.cabal
+++ b/binary/cardano-binary.cabal
@@ -42,7 +42,7 @@ library
                      , digest
                      , formatting
                      , lens
-                     , micro-recursion-schemes
+                     , recursion-schemes
                      , mtl
                      , safe-exceptions
                      , tagged

--- a/binary/src/Cardano/Binary/Class/Annotated.hs
+++ b/binary/src/Cardano/Binary/Class/Annotated.hs
@@ -21,6 +21,7 @@ import qualified Codec.CBOR.Decoding as D
 import Codec.CBOR.Read (ByteOffset)
 import Data.Aeson (FromJSON(..), ToJSON(..))
 import qualified Data.ByteString.Lazy as BSL
+import Data.Kind (Type)
 
 import Cardano.Binary.Class.Core (Bi(..), DecoderError)
 import Cardano.Binary.Class.Primitive (decodeFullDecoder)
@@ -75,7 +76,7 @@ decodeFullAnnotatedBytes lbl decoder bytes =
     $ decodeFullDecoder lbl decoder bytes
 
 class Decoded t where
-  type BaseType t :: *
+  type BaseType t :: Type
   recoverBytes :: t -> ByteString
 
 instance Decoded (Annotated b ByteString) where

--- a/cardano-chain.cabal
+++ b/cardano-chain.cabal
@@ -107,9 +107,10 @@ library
                        Cardano.Chain.Update.Undo
                        Cardano.Chain.Update.Vote
 
-  build-depends:       base >=4.11 && <4.12
+                       Data.Aeson.Options
+
+  build-depends:       base >=4.11 && <5
                      , aeson
-                     , aeson-options
                      , base16-bytestring
                      , base58-bytestring
                      , base64-bytestring-type

--- a/crypto/src/Cardano/Crypto/HD.hs
+++ b/crypto/src/Cardano/Crypto/HD.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns       #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}

--- a/scripts/nix/nixpkgs-src.json
+++ b/scripts/nix/nixpkgs-src.json
@@ -1,6 +1,6 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "rev": "069bf7aee30faf7b3ed773cfae2154d761b2d6c2",
-  "sha256": "1c44vjb60fw2r8ck8yqwkj1w4288wixi59c6w1vazjixa79mvjvg"
+  "rev": "6054276a8e6e877f8846c79b0779e3310c495a6b",
+  "sha256": "11mv8an4zikh2hybn11znqcbxazqq32byvvvaymy2xkpww2jnkxp"
 }

--- a/scripts/nix/stack-shell.nix
+++ b/scripts/nix/stack-shell.nix
@@ -8,5 +8,5 @@ with pkgs;
 haskell.lib.buildStackProject {
   name = "cardano-chain-env";
   buildInputs = [ zlib openssl git ];
-  ghc = haskell.packages.ghc844.ghc;
+  ghc = haskell.packages.ghc863.ghc;
 }

--- a/src/Data/Aeson/Options.hs
+++ b/src/Data/Aeson/Options.hs
@@ -1,0 +1,46 @@
+module Data.Aeson.Options
+  ( defaultOptions )
+  where
+
+import Control.Category ((.))
+import Data.Char (isLower, isPunctuation, isUpper, toLower)
+import Data.List (drop, dropWhile, filter, findIndex)
+import Data.String (String)
+
+import qualified Data.Aeson as A
+
+import Cardano.Prelude (Int, (-), ($), maybe, not, flip)
+
+headToLower :: String -> String
+headToLower []     = []
+headToLower (x:xs) = toLower x : xs
+
+stripFieldPrefix :: String -> String
+stripFieldPrefix = dropWhile (not . isUpper)
+
+dropPunctuation :: String -> String
+dropPunctuation = filter (not . isPunctuation)
+
+stripConstructorPrefix :: String -> String
+stripConstructorPrefix t =
+    maybe t (flip drop t . decrementSafe) $ findIndex isLower t
+  where
+    decrementSafe :: Int -> Int
+    decrementSafe 0 = 0
+    decrementSafe i = i - 1
+
+-- | These options do the following transformations:
+-- 1. Names of field
+-- records are assumed to be camelCased, `camel` part is removed,
+-- `Cased` part is converted to `cased`. So `camelCased` becomes
+-- `cased`. Also all punctuation symbols are dropped before doing it.
+-- 2. Constructors are assumed to start with some capitalized prefix
+-- (which finished right before the last capital letter). This prefix
+-- is dropped and then the first letter is lowercased.
+defaultOptions :: A.Options
+defaultOptions =
+    A.defaultOptions
+    { A.fieldLabelModifier = headToLower . stripFieldPrefix . dropPunctuation
+    , A.constructorTagModifier = headToLower . stripConstructorPrefix
+    , A.sumEncoding = A.ObjectWithSingleField
+    }

--- a/src/Data/Aeson/Options.hs
+++ b/src/Data/Aeson/Options.hs
@@ -1,6 +1,7 @@
 module Data.Aeson.Options
-  ( defaultOptions )
-  where
+  ( defaultOptions
+  )
+where
 
 import Control.Category ((.))
 import Data.Char (isLower, isPunctuation, isUpper, toLower)
@@ -12,8 +13,8 @@ import qualified Data.Aeson as A
 import Cardano.Prelude (Int, (-), ($), maybe, not, flip)
 
 headToLower :: String -> String
-headToLower []     = []
-headToLower (x:xs) = toLower x : xs
+headToLower []       = []
+headToLower (x : xs) = toLower x : xs
 
 stripFieldPrefix :: String -> String
 stripFieldPrefix = dropWhile (not . isUpper)
@@ -22,12 +23,12 @@ dropPunctuation :: String -> String
 dropPunctuation = filter (not . isPunctuation)
 
 stripConstructorPrefix :: String -> String
-stripConstructorPrefix t =
-    maybe t (flip drop t . decrementSafe) $ findIndex isLower t
-  where
-    decrementSafe :: Int -> Int
-    decrementSafe 0 = 0
-    decrementSafe i = i - 1
+stripConstructorPrefix t = maybe t (flip drop t . decrementSafe)
+  $ findIndex isLower t
+ where
+  decrementSafe :: Int -> Int
+  decrementSafe 0 = 0
+  decrementSafe i = i - 1
 
 -- | These options do the following transformations:
 -- 1. Names of field
@@ -38,9 +39,8 @@ stripConstructorPrefix t =
 -- (which finished right before the last capital letter). This prefix
 -- is dropped and then the first letter is lowercased.
 defaultOptions :: A.Options
-defaultOptions =
-    A.defaultOptions
-    { A.fieldLabelModifier = headToLower . stripFieldPrefix . dropPunctuation
-    , A.constructorTagModifier = headToLower . stripConstructorPrefix
-    , A.sumEncoding = A.ObjectWithSingleField
-    }
+defaultOptions = A.defaultOptions
+  { A.fieldLabelModifier     = headToLower . stripFieldPrefix . dropPunctuation
+  , A.constructorTagModifier = headToLower . stripConstructorPrefix
+  , A.sumEncoding            = A.ObjectWithSingleField
+  }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/85fe2b8094b10e5f669423e0a8af327017cb0771/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/f2802079ba2c07c4d408e3c0aa000fc363792398/snapshot.yaml
 
 packages:
   - .
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 0bc8d7d419994c680f22e8c266652812eccd1f10
+    commit: f2802079ba2c07c4d408e3c0aa000fc363792398
     subdirs:
       - .
       - test

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 54f2861978a02a2b04f626f47005769bf23b853b
+    commit: 0bc8d7d419994c680f22e8c266652812eccd1f10
     subdirs:
       - .
       - test


### PR DESCRIPTION
As per https://input-output-rnd.slack.com/messages/CDXN0D2HG, we are targeting GHC 8.6 for the Shelley release.