### PR TITLE
Add ledger utxo properties and incorporate feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ specs/**/.ghc.environment.x86_64-linux-*
 *.hp
 *.ps
 *.html
+
+# gitinfo2 auxiliary file
+gitHeadLocal.gin

--- a/specs/ledger/latex/Makefile
+++ b/specs/ledger/latex/Makefile
@@ -20,7 +20,6 @@ all: $(DOCNAME).pdf
 ## CUSTOM BUILD RULES
 ##
 
-
 ##
 ## MAIN LATEXMK RULE
 ##

--- a/specs/ledger/latex/crypto-primitives.tex
+++ b/specs/ledger/latex/crypto-primitives.tex
@@ -35,13 +35,15 @@ type suffix, and use simply $\serialised{\wcard}$.
       \fun{verify} & \VKey \times \Data \times \Sig
       & \text{verification relation}\\
       \serialised{\wcard}_\type{A} & \type{A} \to \Data
-      & \text{serialization function for values of type $\type{A}$}
+      & \text{serialization function for values of type $\type{A}$}\\
+      \fun{sign} & \SKey \to \Data \to \Sig
+      & \text{signing function}
     \end{array}
   \end{equation*}
   \emph{Constraints}
   \begin{align*}
     & \forall (sk, vk) \in \SkVk,~ m \in \Data,~ \sigma \in \Sig \cdot
-      \verify{vk}{m}{\sigma} \iff \sign{sk}{m} = \sigma
+      \sign{sk}{m} = \sigma \Rightarrow \verify{vk}{m}{\sigma}
   \end{align*}
   \emph{Notation}
   \begin{align*}

--- a/specs/ledger/latex/default.nix
+++ b/specs/ledger/latex/default.nix
@@ -24,9 +24,9 @@ stdenv.mkDerivation {
 
                       # build tools
                       latexmk
-
                       ;
                   })
+
                 ];
   src = ./.;
   buildPhase = "make";

--- a/specs/ledger/latex/frontmatter.tex
+++ b/specs/ledger/latex/frontmatter.tex
@@ -11,16 +11,28 @@
   urlbordercolor={white}
 }
 
-\title{A Simplified Formal Specification of a UTxO Ledger}
+\title{
+  A Formal Specification of the Cardano Ledger\\
+  \small{(for the Byron release)}
+}
 
-\author{}
+\author{Damian Nadales \\
+  {\small \texttt{damian.nadales@iohk.io}}\\
+}
 
-\date{November 27, 2018}
+\date{\today}
 
 \maketitle
 
 \begin{abstract}
-This documents defines the rules for extending a ledger with transactions. It
-is intended to serve as the specification for random generators of transactions
-which adhere to the rules presented here.
+  This documents defines the rules for extending a ledger with transactions, as
+  implemented in the Byron release of the Cardano Ledger. It is intended to
+  serve as the specification for random generators of transactions which adhere
+  to the rules presented here.
 \end{abstract}
+
+\section*{List of Contributors}
+\label{acknowledgements}
+
+Jared Corduan, Nicholas Clarke, Marko Dimjašević, Duncan Coutts, Ru Horlick,
+Michael Hueschen.

--- a/specs/ledger/latex/gitinfo2.mk
+++ b/specs/ledger/latex/gitinfo2.mk
@@ -1,0 +1,24 @@
+# Get info on current git status for gitinfo2
+# That package recommends creating the appropriate file via git hooks; however,
+# that would require everyone working on the repository to install the hooks.
+# Creating the auxiliary file in the Makefile instead assures that it's always
+# there when the document is compiled.
+FIRSTTAG := $(shell git describe --tags --always --dirty='-*' 2>/dev/null)
+RELTAG := $(shell git describe --tags --long --always --dirty='-*' --match '[0-9]*.*' 2>/dev/null)
+gitHeadLocal.gin:
+	git --no-pager log -1 --date=short --decorate=short --pretty=format:"\usepackage[shash={%h}\
+, lhash={%H}\
+, authname={%an}\
+, authemail={%ae}\
+, authsdate={%ad}\
+, authidate={%ai}\
+, authudate={%at}\
+, commname={%cn}\
+, commemail={%ce}\
+, commsdate={%cd}\
+, commidate={%ci}\
+, commudate={%ct}\
+, refnames={%d}\
+, firsttagdescribe={$(FIRSTTAG)}\
+, reltag={$(RELTAG)}\
+]{gitexinfo} " HEAD > gitHeadLocal.gin

--- a/specs/ledger/latex/ledger-spec.tex
+++ b/specs/ledger/latex/ledger-spec.tex
@@ -26,7 +26,7 @@
 \setpremisesspace{20pt}
 \usepackage{tikz}
 \usetikzlibrary{decorations.pathreplacing, positioning, arrows.meta, calc}
-
+% For drawing simple diagrams involving arrows between LaTeX symbols
 \usepackage{tikz-cd}
 
 %%
@@ -99,6 +99,11 @@
 \newcommand{\bbody}[1]{\fun{bbody}~\var{#1}}
 \newcommand{\bdlgs}[1]{\fun{bdlgs}~\var{#1}}
 
+%% For properties
+\newcommand{\txs}{\ensuremath{\mathcal{T}}}
+\newcommand{\transtar}[2]{\xlongrightarrow[\textsc{#1}]{#2}\negthickspace^{*}}
+\newcommand{\biguo}[1]{\ensuremath{\underset{#1}{\underrightarrow\bigcup}}}
+
 %\includeonly{update-mechanism, delegation, blockchain-interface}
 
 %% Parameters that control floats placement. See https://robjhyndman.com/hyndsight/latex-floats/
@@ -111,6 +116,7 @@
 \renewcommand{\floatpagefraction}{0.7}
 
 \newtheorem{definition}{Definition}
+\newtheorem{prop}{Property}
 
 \begin{document}
 
@@ -132,6 +138,8 @@
 \include{update-mechanism}
 
 \include{blockchain-interface}
+
+\include{properties}
 
 \addcontentsline{toc}{section}{References}
 \bibliographystyle{plainnat}

--- a/specs/ledger/latex/notation.tex
+++ b/specs/ledger/latex/notation.tex
@@ -29,7 +29,7 @@
   are defined in \cref{fig:domain-and-range-ops}. Note that a map $A \mapsto B$
   can be seen as a relation, which means that these operators can be
   applied to maps as well.
-\item[Integer ranges] Given $a, b \in \mathbb{R}$, $[a, b]$ denotes the
+\item[Integer ranges] Given $a, b \in \mathbb{Z}$, $[a, b]$ denotes the
   sequence $[i \mid a \leq i \leq b]$ . Ranges can have open ends: $[.., b]$
   denotes sequence $[i \mid i \leq b]$, whereas $[a, ..]$ denotes sequence
   $[i \mid a \leq i]$. Furthermore, sometimes we use $[a, b]$ to denote a set

--- a/specs/ledger/latex/properties.tex
+++ b/specs/ledger/latex/properties.tex
@@ -1,0 +1,158 @@
+\section{Transition System Properties}
+\label{sec:ts-properties}
+
+
+\subsection{Transition-system traces}
+\label{sec:ts-traces}
+
+This section introduces the notion of traces induced by the transition systems
+described in \cite{small_step_semantics}.
+
+\begin{definition}[Traces]
+  Given a state transition system $L=(S,T,\Sigma, R, \Gamma)$, the set of
+  traces of $L$, denoted as $\fun{traces}_L$ is defined as:
+  $$
+  \{ (e, s, \txs, s') \mid e \in \Gamma,~ s \in S,~ \txs \in \seqof{\Sigma},~ s' \in S\}
+  $$
+
+\end{definition}
+
+
+\begin{definition}[Valid traces]
+  Given a state transition system $L=(S,T,\Sigma, R, \Gamma)$, we define the
+  notion of valid traces inductively:
+
+  \begin{itemize}
+  \item For all $e \in \Gamma$, $s \in S$, $(e, s, \epsilon, s)$ is a valid
+    trace of $L$.
+
+  \item If $(e, s, \txs s')$ is a valid trace, and
+    $e \vdash s' \trans{}{\var{t}} s''$ is a valid transition according to the
+    rules of $L$, then $(e, s, \txs; t, s'')$ is also a valid trace.
+  \end{itemize}
+
+\end{definition}
+
+We denote the set of valid traces of $L$ as $\transtar{L}{}$, and we write
+$e \vdash s \transtar{L}{\txs} s'$ as a shorthand for
+$(e, s, \txs, s') \in \transtar{L}{}$. Furthermore, when the transition system
+name is clear from the context we will omit it from the transition arrow label.
+
+\subsection{Additional notation}
+\label{sec:additional-notation}
+
+We describe next additional notation needed in the properties of the transition
+systems specified in this document.
+
+\subsubsection{Sequence indexing}
+\label{sec:seq-indexing}
+
+Given a sequence $\mathcal{A} \in \seqof{\type{A}}$, and a natural number $i$
+such that $0 \leq i < \size{\mathcal{A}}$, $\mathcal{A}_i$ refers to the
+$i^{\text{th}}$ element of $\mathcal{A}$.
+
+
+Given a sequence $\mathcal{A}$, a quantification symbol $\bigoplus$, e.g.
+$\forall$ or $\exists$, a range predicate $R$, and a quantification term $T$
+(both of which depend on an element of $\mathcal{A}$) we write:
+%
+$$
+\bigoplus \mathcal{A}_i \cdot R~\mathcal{A}_i \cdot T~\mathcal{A}_i
+$$
+%
+as a shorthand notation for:
+%
+$$
+\bigoplus i \cdot 0 \leq i < \size{\mathcal{A}} \wedge R~\mathcal{A}_i \cdot T~\mathcal{A}_i
+$$
+
+For instance:
+%
+$$
+\forall \txs_i \cdot \txins{\txs_i} \neq \emptyset
+$$
+is a shorthand notation for:
+$$
+\forall i \cdot 0 \leq i < \size{\txs} \Rightarrow \txins{\txs_i} \neq \emptyset
+$$
+Remember that the range of a universal quantification can be expressed by an
+implication, and the range of an existential qualification by a conjunction.
+
+\subsubsection{Quantifying over set operations}
+\label{sec:quantifying-over-set-operators}
+
+Given a sequence $\mathcal{A} \in \seqof{A}$, a set $B$, a set operation
+$\bigoplus$, e.g. $\cup$ or $\unionoverride$, and a function
+$\fun{f} \in \type{A} \to \type{B}$, the term:
+%
+$$
+\underset{\fun{f}}{\bigoplus} \mathcal{A}
+$$
+is a shorthand notation for:
+%
+$$
+\underset{0 \leq i < \size{\mathcal{A}}}{\bigoplus} \mathcal{A}_i
+$$
+
+For instance:
+$$
+\bigcup_{\txins{}} \txs
+$$
+denotes the sequence of unions:
+$$
+\bigcup_{0 \leq i < \size{\txs}} \txins{\txs_i}
+$$
+
+In a set operation quantification over a sequence $\mathcal{A}$, the operation
+is applied to the elements the order in which they appear in $\mathcal{A}$.
+This is crucial in the case of non-commutative operations, such as union
+override ($\unionoverride$).
+
+\subsection{UTxO Properties}
+\label{sec:utxo-properties}
+
+Property~\ref{prop:no-double-spending} expresses the fact that transaction
+inputs cannot be used more than once. This property requires that the starting
+UTxO does not contain any future outputs, which is a reasonable constraint.
+
+\begin{prop}[No double spending]\label{prop:no-double-spending}
+  For all
+
+  $$\var{utxo_0} \transtar{UTXO}{\txs} \var{utxo}$$
+
+  such that
+
+  $$
+    \forall \txs_i \cdot \dom~(\txouts{\txs_i}) \cap \dom~(\var{utxo_0}) = \emptyset
+  $$
+
+  we have
+
+  $$
+  \forall \txs_i,~\txs_j \cdot i < j \Rightarrow \txins{\txs_i} \cap \txins{\txs_j} = \emptyset
+  $$
+\end{prop}
+
+Property~\ref{prop:utxo-out-min-in} expresses the fact that all inputs and
+outputs are accounted for, in such a way that we can reconstruct the final
+(UTxO) state by adding all the outputs to the initial state, and removing the
+spent outputs.
+
+\begin{prop}[UTxO is outputs minus inputs]\label{prop:utxo-out-min-in}
+  For all
+
+  $$\var{utxo_0} \transtar{UTXO}{\txs} \var{utxo}$$
+
+  such that
+
+  $$
+    \forall \txs_i \cdot \dom~(\txouts{\txs_i}) \cap \dom~(\var{utxo_0}) = \emptyset
+  $$
+
+  we have:
+
+  $$
+  \bigcup_{\txins{}} \txs \subtractdom (\var{utxo_0} \cup \bigcup_{\txouts{}} \txs) = \var{utxo}
+  $$
+
+\end{prop}

--- a/specs/ledger/latex/references.bib
+++ b/specs/ledger/latex/references.bib
@@ -1,0 +1,6 @@
+@misc{small_step_semantics,
+  author = {Formal Methods Team, IOHK},
+  title  = {Small Step Semantics for Cardano},
+  year   = {2018},
+  url   = {https://hydra.iohk.io/job/Cardano/cardano-chain/semanticsSpec/latest/download/1/small-steps.pdf}
+}

--- a/specs/ledger/latex/utxo.tex
+++ b/specs/ledger/latex/utxo.tex
@@ -1,4 +1,4 @@
-\newcommand{\PPMMap}{\ensuremath{\type{Ppms}}}
+\newcommand{\PPMMap}{\ensuremath{\type{PParams}}}
 \newcommand{\Lmax}{\ensuremath{\mathbb{L}_{\var{max}}}}
 \section{UTxO}
 \label{sec:state-trans-utxo-1}
@@ -10,7 +10,8 @@ protocol parameters as an abstract type, this type is made concrete in
 Section~\ref{sec:update}, where the update mechanism is discussed. Functions on
 these types are defined in Figure~\ref{fig:derived-defs:utxo}. In particular,
 note that in function $\fun{minfee}$ we make use of the fact that the
-$\Lovelace$ type is an alias for the set of natural numbers ($\mathbb{N}$).
+$\Lovelace$ type is an alias for the set of the integers numbers
+($\mathbb{Z}$).
 
 \begin{figure*}[htb]
   \emph{Abstract types}
@@ -28,19 +29,13 @@ $\Lovelace$ type is an alias for the set of natural numbers ($\mathbb{N}$).
       \var{pps} & \PPMMap & \text{protocol parameters}
     \end{array}
   \end{equation*}
-  \emph{Constants}
   %
-  \begin{equation*}
-    \begin{array}{r@{~=~}lr}
-      \Lmax & 45*10^{15} & \text{Lovelace supply cap}\\
-    \end{array}
-  \end{equation*}
   \emph{Derived types}
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}r@{~\in~}lr}
       \ell & \Lovelace
-      & n  & \{ n \mid n \in  \mathbb{N}, 0 \leq n \leq \Lmax \}
+      & n  & \mathbb{Z}
       & \text{currency value}
       \\
       \var{txin}
@@ -57,7 +52,7 @@ $\Lovelace$ type is an alias for the set of natural numbers ($\mathbb{N}$).
       \\
       \var{utxo}
       & \UTxO
-      & \var{txin} \mapsto \var{txout}
+      & m
       & \TxIn \mapsto \TxOut
       & \text{unspent tx outputs}
     \end{array}
@@ -71,15 +66,20 @@ $\Lovelace$ type is an alias for the set of natural numbers ($\mathbb{N}$).
       \fun{txbody} & \Tx \to \powerset{\TxIn} \times (\Ix \mapsto \TxOut)
                                   & \text{transaction body}\\
       %
-      \fun{txfee} & \Tx \to \Lovelace & \text{transaction fee}\\
+      \fun{a} & \PPMMap \to \mathbb{Z} & \text{minumum fee factor}\\
       %
-      \fun{a} & \PPMMap \to \mathbb{N} & \text{minumum fee factor}\\
+      \fun{b} & \PPMMap \to \mathbb{Z} & \text{minumum fee constant}\\
       %
-      \fun{b} & \PPMMap \to \mathbb{N} & \text{minumum fee constant}\\
-      %
-      \fun{txSize} & \Tx \to \mathbb{N} & \text{abstract size of a transaction}
+      \fun{txSize} & \Tx \to \mathbb{Z} & \text{abstract size of a transaction}
     \end{array}
   \end{equation*}
+  %
+  \emph{Constraints}
+  \begin{equation}
+    \label{eq:txid-injective}
+    \forall \var{tx_i}, \var{tx_j} \cdot
+    \txid{\var{tx_i}} = \txid{\var{tx_j}} \Rightarrow \var{tx_i} = \var{tx_j}
+  \end{equation}
   \caption{Definitions used in the UTxO transition system}
   \label{fig:defs:utxo}
 \end{figure*}
@@ -100,12 +100,12 @@ $\Lovelace$ type is an alias for the set of natural numbers ($\mathbb{N}$).
                \end{array}
       \right\}
     \nextdef
-    & \fun{balance} \in \UTxO \to \mathbb{N}
+    & \fun{balance} \in \UTxO \to \mathbb{Z}
     & \text{UTxO balance} \\
     & \fun{balance} ~ utxo = \sum_{(~\wcard ~ \mapsto (\wcard, ~c)) \in \var{utxo}} c\\
    \nextdef
    %
-    & \fun{minfee} \in \PPMMap \to \Tx \to \mathbb{N} & \text{minimum fee}\\
+    & \fun{minfee} \in \PPMMap \to \Tx \to \mathbb{Z} & \text{minimum fee}\\
     & \fun{minfee}~\var{pps}~\var{tx} =
       \fun{a}~\var{pps} * \fun{txSize}~\var{tx} + \fun{b}~\var{pps}
   \end{align*}
@@ -127,10 +127,9 @@ $\Lovelace$ type is an alias for the set of natural numbers ($\mathbb{N}$).
 \begin{figure}
   \begin{equation}\label{eq:utxo-inductive}
     \inference
-    { \txins{tx} \subseteq \dom \var{utxo} & \minfee{pps}{tx} \leq \txfee{tx}
-      & \balance{(\txins{tx} \restrictdom \var{utxo})} \leq \Lmax \\
-      \balance{(\txouts{tx})}  + \txfee{tx} =
-      \balance{(\txins{tx} \restrictdom \var{utxo})}
+    { \txins{tx} \subseteq \dom \var{utxo}
+      & \minfee{pps}{tx} \leq \balance{(\txouts{tx})} - \balance{(\txins{tx} \restrictdom \var{utxo})}\\
+      \txins{tx} \neq \emptyset
     }
     {\var{pps} \vdash \var{utxo} \trans{utxo}{tx}
       (\txins{tx} \subtractdom \var{utxo}) \cup \txouts{tx}
@@ -146,25 +145,15 @@ changes with a transaction:
 \begin{itemize}
 \item Each input spent in the transaction must be in the set of unspent
   outputs.
-\item The transaction fee must be no less than the minimum fee, which depends
-  on the transaction and the protocol parameters.
-\item The balance of the unspent outputs in a transaction (i.e. the total
-  amount paid in a transaction) plus the transaction fees must be equal to the
-  amount of spent inputs, and these cannot exceed the $\Lovelace$ supply cap
-  ($45*10^{15}$).
+\item The minimum fee, which depends on the transaction and the protocol
+  parameters, must be less or equal than the difference between the balance of
+  the unspent outputs in a transaction (i.e. the total amount paid in a
+  transaction) and the amount of spent inputs.
+\item The set of inputs must not be empty.
 \item If the above conditions hold, then the new state will not have the inputs
   spent in transaction $\var{tx}$ and it will have the new outputs in
   $\var{tx}$.
 \end{itemize}
-
-\subsection{Properties}
-\label{sec:utxo-properties}
-
-\begin{todo}
-  Can we prove properties of the transition system of this section? For
-  instance we might like to formalize ``double spending'' and prove that these
-  rules prevent it. Do we want it?
-\end{todo}
 
 \clearpage
 


### PR DESCRIPTION
- Add two ledger UTxO properties: no double spending and utxo is outputs minus inputs.
- Incorporate feedback received from @dcoutts and @jcmincke, and part of the feedback received during the Berlin workshop.
- Add injectivity constraint to `txid`.
- Replace `N` by `Z` as an alias for `Lovelace` and remove `Lovelace` cap and explicit fees.
- Make protocol parameters consistent with Shelley spec.
- Add author field, list of contributors, and git revision.

Close #219, close #233, close #234, close #232, close #231.