### PR TITLE
Add support for building with Cabal at the top level

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,7 @@ packages: specs/semantics/hs
           specs/chain/hs
 	  binary
 	  crypto
-	  .
+	  ./
 
 source-repository-package
   type: git
@@ -20,3 +20,8 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-crypto
   tag: f5cecb6e424cc84f85b6a3e1f803517bb7b4cfb1
+
+source-repository-package
+  type: git
+  location: https://github.com/avieth/plutus-prototype
+  tag: d094be301195fcd8ab864d793f114970426a4478

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,22 @@
+packages: specs/semantics/hs
+          specs/ledger/hs
+          specs/chain/hs
+	  binary
+	  crypto
+	  .
+
+source-repository-package
+  type: git
+  location: https://github.com/well-typed/cborg
+  tag: 80fbe0ee5e67a5622e2cb9eaa9d8594a2214322d
+  subdir: cborg
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-prelude
+  tag: 3c5b1f78bb07d361ff8a1d20bf0350d0c5b115b9
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-crypto
+  tag: f5cecb6e424cc84f85b6a3e1f803517bb7b4cfb1


### PR DESCRIPTION
This patch adds support for building with Cabal only at the top level.

Closes #269.