### PR TITLE
Replace git-lfs with cardano-mainnet-mirror Haskell package

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,9 +11,6 @@ steps:
       - "rm -rf /build/cardano-chain"
       - "cp -R . /build/cardano-chain"
       - "cd /build/cardano-chain"
-      - "git lfs install"
-      - "git lfs pull"
-      - "ls -lh test/resources/epochs/"
       - "nix-build scripts/buildkite -o stack-rebuild"
       - "./stack-rebuild"
     agents:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.epoch filter=lfs diff=lfs merge=lfs -text
-*.index filter=lfs diff=lfs merge=lfs -text

--- a/cardano-chain.cabal
+++ b/cardano-chain.cabal
@@ -204,6 +204,7 @@ test-suite cardano-chain-test
                      , cardano-crypto
                      , cardano-crypto-test
                      , cardano-crypto-wrapper
+                     , cardano-mainnet-mirror
                      , cardano-prelude
                      , cardano-prelude-test
                      , containers

--- a/scripts/buildkite/rebuild.hs
+++ b/scripts/buildkite/rebuild.hs
@@ -37,15 +37,16 @@ main = do
 buildStep :: IO ExitCode
 buildStep = do
   echo "+++ Build and test"
-  build .&&. test
+  test "cardano-binary" .&&. test "cardano-crypto-wrapper" .&&. test
+    "cardano-chain"
  where
   cfg = ["--dump-logs", "--color", "always"]
   stackBuild args = run "stack" $ cfg ++ ["build", "--fast"] ++ args
   buildArgs    = ["--bench", "--no-run-benchmarks", "--no-haddock-deps"]
   buildAndTest = stackBuild $ ["--tests"] ++ buildArgs
   build        = stackBuild $ ["--no-run-tests"] ++ buildArgs
-  test         = stackBuild
-    ["--test", "--jobs", "1", "--ta", "--scenario=ContinuousIntegration"]
+  test pkg = stackBuild
+    [pkg, "--test", "--jobs", "1", "--ta", "--scenario=ContinuousIntegration"]
 
 -- buildkite agents have S3 creds installed, but under different names
 awsCreds :: IO ()

--- a/scripts/nix/stack-shell.nix
+++ b/scripts/nix/stack-shell.nix
@@ -7,6 +7,7 @@ with pkgs;
 
 haskell.lib.buildStackProject {
   name = "cardano-chain-env";
-  buildInputs = [ zlib openssl git ];
+  buildInputs = [ zlib openssl git git-lfs ];
   ghc = haskell.packages.ghc863.ghc;
+  GIT_LFS_SKIP_SMUDGE = "1";
 }

--- a/scripts/nix/stack-shell.nix
+++ b/scripts/nix/stack-shell.nix
@@ -7,7 +7,6 @@ with pkgs;
 
 haskell.lib.buildStackProject {
   name = "cardano-chain-env";
-  buildInputs = [ zlib openssl git git-lfs ];
+  buildInputs = [ zlib openssl git ];
   ghc = haskell.packages.ghc863.ghc;
-  GIT_LFS_SKIP_SMUDGE = "1";
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,10 +3,6 @@ resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/f280
 packages:
   - .
   - test
-  - binary
-  - binary/test
-  - crypto
-  - crypto/test
   - specs/ledger/hs
   - specs/semantics/hs
 
@@ -16,6 +12,19 @@ extra-deps:
     subdirs:
       - .
       - test
+
+  - git: https://github.com/input-output-hk/cardano-chain
+    commit: c14a65370cfd70c2c9a77003072e20113894f6c9
+    subdirs:
+      - binary
+      - binary/test
+
+  - git: https://github.com/input-output-hk/cardano-chain
+    commit: c14a65370cfd70c2c9a77003072e20113894f6c9
+    subdirs:
+      - crypto
+      - crypto/test
+
   - sequence-0.9.8
 
 nix:

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,10 @@ resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/f280
 packages:
   - .
   - test
+  - binary
+  - binary/test
+  - crypto
+  - crypto/test
   - specs/ledger/hs
   - specs/semantics/hs
 
@@ -13,17 +17,20 @@ extra-deps:
       - .
       - test
 
-  - git: https://github.com/input-output-hk/cardano-chain
-    commit: c14a65370cfd70c2c9a77003072e20113894f6c9
-    subdirs:
-      - binary
-      - binary/test
+  # - git: https://github.com/input-output-hk/cardano-chain
+  #   commit: c14a65370cfd70c2c9a77003072e20113894f6c9
+  #   subdirs:
+  #     - binary
+  #     - binary/test
 
-  - git: https://github.com/input-output-hk/cardano-chain
-    commit: c14a65370cfd70c2c9a77003072e20113894f6c9
-    subdirs:
-      - crypto
-      - crypto/test
+  # - git: https://github.com/input-output-hk/cardano-chain
+  #   commit: c14a65370cfd70c2c9a77003072e20113894f6c9
+  #   subdirs:
+  #     - crypto
+  #     - crypto/test
+
+  - git: https://github.com/input-output-hk/cardano-mainnet-mirror
+    commit: 74ca63f8ad6b47beba2f565c73592cede63ce4b5
 
   - sequence-0.9.8
 

--- a/test/Test/Cardano/Chain/Txp/Validation.hs
+++ b/test/Test/Cardano/Chain/Txp/Validation.hs
@@ -32,9 +32,9 @@ import Cardano.Chain.Slotting (SlotId)
 import Cardano.Chain.Txp
   (UTxO, UTxOValidationError, aUnTxPayload, genesisUtxo, updateUTxOWitness)
 import Cardano.Crypto (ProtocolMagicId, getProtocolMagicId)
+import Cardano.Mirror (mainnetEpochFiles)
 
 import Test.Options (TestScenario(..))
-import Test.Cardano.Chain.Epoch.File (getEpochFiles)
 
 
 -- | These tests perform transaction validation over mainnet epoch files
@@ -64,7 +64,7 @@ tests scenario = do
       QualityAssurance      -> identity
 
   -- Get a list of epoch files to perform validation on
-  files <- takeFiles <$> getEpochFiles
+  files <- takeFiles <$> mainnetEpochFiles
 
   -- Validate the transactions of each epoch file in a single 'Property' and
   -- check them all sequentially

--- a/test/resources/epochs/00000.epoch
+++ b/test/resources/epochs/00000.epoch
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b51800662e3f5bf773dbe39db463a681d201026c92d2c76bab4ee3d25b8d997c
-size 14892108

--- a/test/resources/epochs/00000.index
+++ b/test/resources/epochs/00000.index
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bba709f7935674572ba59ce09f0954f07e63e197991845c6bd4f058981679e6c
-size 172816

--- a/test/resources/epochs/00001.epoch
+++ b/test/resources/epochs/00001.epoch
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d4a13a0adc2237d840426031ff65b9b296106e326e03cab75e75a7925624c5e
-size 19911677

--- a/test/resources/epochs/00001.index
+++ b/test/resources/epochs/00001.index
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80b06e67a571811ffb776762bce383814db4ecfb1633fee825ce2e47fa14044a
-size 172816


### PR DESCRIPTION
This allows us to make changes to the cardano-binary or cardano-crypto repos without propagating the changes all the way up the codebase. That allows us to have smaller PRs and is a stepping stone to splitting those packages into their own repos.