### PR TITLE
Implement several class instances for cs-blockchain

### DIFF
--- a/specs/chain/hs/src/Data/Queue.hs
+++ b/specs/chain/hs/src/Data/Queue.hs
@@ -12,6 +12,10 @@ where
 
 data Queue a = MkQueue { inbox :: [a], outbox :: [a] }
 
+instance Show a => Show (Queue a) where
+  show (MkQueue i o) = (show $ o ++ reverse i)
+
+
 -- | Creates a new empty 'Queue'
 newQueue :: Queue a
 newQueue = MkQueue [] []

--- a/specs/chain/hs/src/Types.hs
+++ b/specs/chain/hs/src/Types.hs
@@ -18,7 +18,7 @@ import Ledger.Signatures (Hash)
 -- | Phantom type for the blockchain extension transition system
 data BC
 
-newtype BlockIx = MkBlockIx Natural deriving (Eq, Ord)
+newtype BlockIx = MkBlockIx Natural deriving (Eq, Ord, Show)
 
 data ProtParams = MkProtParams
   { maxBlockSize  :: !Natural
@@ -50,4 +50,4 @@ data Block
     , rbIsEBB  :: Bool -- ^ Indicates if this is an epoch boundary block
     , rbSize   :: Natural -- ^ Size of the block
     , rbHeaderSize :: Natural -- ^ Size of the header of the block
-    }
+    } deriving (Eq, Show)


### PR DESCRIPTION
This patch implements several missing classes for types in `cs-blockchain` to allow for integration with the consensus layer.

Closes #281.