### PR TITLE
Expose the Data.Queue module in cs-blockchain

### DIFF
--- a/specs/chain/hs/cs-blockchain.cabal
+++ b/specs/chain/hs/cs-blockchain.cabal
@@ -19,8 +19,8 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Chain.Blockchain
                        Chain.GenesisBlock
+                       Data.Queue
                        Types
-  other-modules:       Data.Queue
   -- other-extensions:
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This patch exposes the `Data.Queue` module in `cs-blockchain`. It is a dependency for https://github.com/input-output-hk/ouroboros-network/issues/168.

Closes #288.