### PR TITLE
Change protocol-version confirmation and adoption criteria

### DIFF
--- a/specs/ledger/latex/blockchain-interface.tex
+++ b/specs/ledger/latex/blockchain-interface.tex
@@ -190,8 +190,8 @@ labels have the following meaning:
         \var{e_p} & \Epoch & \text{previously seen epoch}\\
         (\var{pv}, \var{pps}) & \ProtVer \times \PPMMap
         & \text{current protocol information}\\
-        (\var{pv_c}, \var{pps_c}) & \ProtVer \times \PPMMap
-        & \text{candidate protocol information}\\
+        \var{fads} & \seqof{(\Slot \times (\ProtVer \times \PPMMap))}
+        & \text{future protocol version adoptions}\\
         \var{avs} & \ApName \mapsto (\ApVer \times \Slot)
         & \text{application versions}\\
         \var{rpus} & \UPropId \mapsto (\ProtVer \times \PPMMap)
@@ -272,7 +272,7 @@ labels have the following meaning:
           \begin{array}{l}
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
-            (\var{pv_c}, \var{pps_c})\\
+            \var{fads}\\
             \var{avs}\\
             \var{rpus}\\
             \var{raus}\\
@@ -289,7 +289,7 @@ labels have the following meaning:
           \begin{array}{l}
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
-            (\var{pv_c}, \var{pps_c})\\
+            \var{fads}\\
             \var{avs}\\
             \var{rpus'}\\
             \var{raus'}\\
@@ -369,7 +369,7 @@ updated.
           \begin{array}{l}
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
-            (\var{pv_c}, \var{pps_c})\\
+            \var{fads}\\
             \var{avs}\\
             \var{rpus}\\
             \var{raus}\\
@@ -386,7 +386,7 @@ updated.
           \begin{array}{l}
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
-            (\var{pv_c}, \var{pps_c})\\
+            \var{fads}\\
             \var{avs} \unionoverride \var{avs_{new}}\\
             \var{rpus}\\
             \dom~ \var{cps} \subtractdom \var{raus}\\
@@ -484,7 +484,6 @@ the end on an epoch.
           k\\
           s_n\\
           (\var{pv}, \var{pps})\\
-          \var{dms}\\
           \var{cps}\\
           \var{rpus}
         \end{array}
@@ -493,7 +492,7 @@ the end on an epoch.
       {
         \left(
           \begin{array}{l}
-            (\var{pv_c}, \var{pps_c})\\
+            \var{fads}\\
             \var{bvs}
           \end{array}
         \right)
@@ -502,12 +501,12 @@ the end on an epoch.
       {
         \left(
           \begin{array}{l}
-            (\var{pv_c'}, \var{pps_c'})\\
+            \var{fads'}\\
             \var{bvs'}
           \end{array}
         \right)
       }\\
-      \var{chainStabilityParameter} \mapsto k \in  \var{pps} &
+      \var{chainStability} \mapsto k \in  \var{pps} &
       \var{upropTTL} \mapsto u \in \var{pps} \\
       {
         \begin{array}{r@{~=~}l}
@@ -531,7 +530,7 @@ the end on an epoch.
           \begin{array}{l}
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
-            (\var{pv_c}, \var{pps_c})\\
+            \var{fads}\\
             \var{avs}\\
             \var{rpus}\\
             \var{raus}\\
@@ -548,7 +547,7 @@ the end on an epoch.
           \begin{array}{l}
             \var{e_p}\\
             (\var{pv}, \var{pps})\\
-            (\var{pv_c'}, \var{pps_c'})\\
+            \var{fads'}\\
             \var{avs}\\
             \var{rpus'}\\
             \var{pids_{keep}} \restrictdom \var{raus}\\
@@ -567,15 +566,25 @@ the end on an epoch.
 
 \clearpage
 
-Rule~\ref{eq:rule:upi-ec} models how the protocol version and its parameters
-are changed depending on the epoch in the signal ($e_n$ in this case). A change
-only occurs if the new epoch is greater than the previously seen epoch ($e_p$).
-In such case, the current epoch is also updated accordingly. The candidate
-versions and parameters map $(\var{pv_c}, \var{pps_c})$ remain constant in this
-transition, even if they become adopted. Note that, in the final state, we use
-union override to define the updated parameters
-($\var{pps} \unionoverride \var{pps'}$). This is because candidate proposal
-might only update some parameters of the protocol.
+Rule~\ref{eq:rule:upi-ec} models how the epoch, protocol-version and its
+parameters are changed depending on the epoch in the signal ($e_n$ in this
+case). A change in the epoch only occurs if the new epoch is greater than the
+previously seen epoch ($e_p$).
+%
+On an epoch change, this rule will pick a candidate that gathered enough
+endorsements at least $2 \cdot k$ slots ago. If a protocol-version candidate
+cannot gather enough endorsements $2 \cdot k$ slots before the end of an
+epoch, the proposal can only be adopted in the next epoch.
+%
+Figure~\ref{fig:up-confirmed-too-late} shows an example of a proposal being
+confirmed too late in an epoch, where it is not possible to get enough
+endorsements in the remaining window. In this Figure we take $k = 2$, and we
+assume $5$ endorsements are needed to consider a proposal as candidate for
+adoption.
+%
+Note that, in the final state, we use union override to define the updated
+parameters ($\var{pps} \unionoverride \var{pps'}$). This is because candidate
+proposal might only update some parameters of the protocol.
 
 Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
 \begin{itemize}
@@ -586,6 +595,8 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
   proposes to upgrade to an older version of the protocol).
 \item The registered software-update proposals need not be cleaned here, since
   this is done either when a proposal gets confirmed or when it expires.
+\item Rule~\ref{eq:rule:pvbump-change} keeps only those candidates that can be
+  adopted in future epochs.
 \end{itemize}
 
 \begin{figure}[htb]
@@ -596,13 +607,17 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
       e_n \leq e_p
     }
     {
-      (\var{pv_c}, \var{pps_c})
+      {\begin{array}{l}
+         k\\
+         s_n
+       \end{array}}
       \vdash
       {
         \left(
           \begin{array}{l}
             \var{e_p}\\
             \var{(\var{pv}, \var{pps})}\\
+            \var{fads}
           \end{array}
         \right)
       }
@@ -612,6 +627,41 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
           \begin{array}{l}
             \var{e_p}\\
             \var{(\var{pv}, \var{pps})}\\
+            \var{fads}
+          \end{array}
+        \right)
+      }
+    }
+  \end{equation}
+  \nextdef
+  \begin{equation}
+    \label{eq:rule:pvbump-change-epoch-only}
+    \inference
+    {
+      [.., s_n - 2 \cdot k] \restrictdom \var{fads} = \epsilon &  e_p < e_n
+    }
+    {
+      {\begin{array}{l}
+         k\\
+         s_n
+       \end{array}}
+      \vdash
+      {
+        \left(
+          \begin{array}{l}
+            \var{e_p}\\
+            \var{(\var{pv}, \var{pps})}\\
+            \var{fads}
+          \end{array}
+        \right)
+      }
+      \trans{pvbump}{\var{e_n}}
+      {
+        \left(
+          \begin{array}{l}
+            \var{e_n}\\
+            \var{(\var{pv}, \var{pps})}\\
+            \var{fads}
           \end{array}
         \right)
       }
@@ -622,16 +672,21 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
     \label{eq:rule:pvbump-change}
     \inference
     {
-      e_p < e_n
+      \wcard ; (\wcard , (\var{pv_c}, \var{pps_c})) \leteq [.., s_n - 2 \cdot k] \restrictdom \var{fads}
+      & e_p < e_n
     }
     {
-      (\var{pv_c}, \var{pps_c})
+      {\begin{array}{l}
+         k\\
+         s_n
+       \end{array}}
       \vdash
       {
         \left(
           \begin{array}{l}
             \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}
+            \var{(\var{pv}, \var{pps})}\\
+            \var{fads}
           \end{array}
         \right)
       }
@@ -640,7 +695,8 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
         \left(
           \begin{array}{l}
             \var{e_n}\\
-            \var{(\var{pv_c}, \var{pps_c})}
+            \var{(\var{pv_c}, \var{pps_c})}\\
+            {[s_n - 2 \cdot k + 1, ..]} \restrictdom fads
           \end{array}
         \right)
       }
@@ -651,13 +707,18 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
     \label{eq:rule:upi-ec}
     \inference
     {
-      (\var{pv_c}, \var{pps_c})
+      \var{chainStability} \mapsto k \in  \var{pps} &
+      {\begin{array}{l}
+         k\\
+         s_n
+       \end{array}}
       \vdash
       {
         \left(
           \begin{array}{l}
             \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}
+            \var{(\var{pv}, \var{pps})}\\
+            \var{fads}
           \end{array}
         \right)
       }
@@ -667,6 +728,7 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
           \begin{array}{l}
             \var{e'}\\
             \var{(\var{pv'}, \var{pps'})}\\
+            \var{fads'}
           \end{array}
         \right)
       }\\ ~ \\
@@ -688,7 +750,7 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
           \begin{array}{l}
             \var{e_p}\\
             \var{(\var{pv}, \var{pps})}\\
-            \var{(\var{pv_c}, \var{pps_c})}\\
+            \var{fads}\\
             \var{avs}\\
             \var{rpus}\\
             \var{raus}\\
@@ -705,7 +767,7 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
           \begin{array}{l}
             \var{e'}\\
             \var{(\var{pv'}, \var{pps} \unionoverride \var{pps'})}\\
-            \var{(\var{pv_c}, \var{pps_c})}\\
+            \var{fads'}\\
             \var{avs}\\
             \var{pids_{keep}} \restrictdom \var{rpus}\\
             \var{raus}\\
@@ -720,6 +782,99 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
   \end{equation}
   \caption{Block version adoption on epoch change rules}
   \label{fig:rules:upi-ec}
+\end{figure}
+
+\begin{figure}[htb]
+  \centering
+  \begin{tikzpicture}
+    %%
+    %% Macros used in this picture
+    %%
+    %
+    % Number of slots
+    \pgfmathsetmacro{\nrSlots}{12}
+    % Slot in which the proposal gets confirmed
+    \pgfmathsetmacro{\cSlot}{1}
+    % Our special K.
+    \pgfmathsetmacro{\K}{4}
+    % Epoch end.
+    \pgfmathsetmacro{\eend}{11}
+    % Number of positive votes needed
+    \pgfmathsetmacro{\votes}{5}
+
+    % Draw the horizontal line
+    \draw[thick, -Triangle] (0,0) -- (\nrSlots,0)
+    node[font=\scriptsize,below left=3pt and -8pt]{slots};
+
+    % % draw vertical lines
+    \foreach \x in {0,1,...,\nrSlots}
+    \draw (\x cm, 3pt) -- (\x cm, -3pt);
+
+    % Add a label to with the block number in which the proposal got confirmed.
+    \node at (\cSlot, -.7) {$b_j$};
+
+    % Update in cps
+    \node at (\cSlot, -1.5) {$\var{cps'} = \var{cps} \cup \{ \var{pid} \mapsto b_j \}$};
+
+    % The no-endorsements red bar.
+    \draw[red, line width=4pt] (\cSlot, .5) -- +(\K, 0);
+
+    % Brace above the no-endorsement window bar.
+    \draw[thick, red, decorate, decoration={brace, amplitude=5pt}]
+    (\cSlot, .7) -- +(\K, 0)
+    node[black!20!red, midway, above=4pt, font=\scriptsize] {No endorsements possible};
+
+    % The endorsements window.
+    \coordinate (ewStart) at (\cSlot + \K, .5);
+    \coordinate (ewEnd) at ($(\eend - \K, .5)$);
+    \draw[green, line width=4pt]
+    (ewStart) -- (ewEnd);
+
+    % Brace above the endorsements window
+    \coordinate (ewStartB) at ($(ewStart) + (0, 0.2)$);
+    \coordinate (ewEndB) at ($(ewEnd) + (0, 0.2)$);
+    \draw[thick, green, decorate, decoration={brace, amplitude=5pt}]
+    (ewStartB) -- (ewEndB)
+    node[black!50!green, midway, above=18pt, font=\scriptsize] {Endorsements window};
+
+    % The no-candidates change window.
+    \coordinate (nccStart) at (\eend - \K, .5);
+    \coordinate (nccEnd) at ($(\eend, .5)$);
+    \draw[gray, line width=4pt]
+    (nccStart) -- (nccEnd);
+
+    % Brace above the no-candidates change window.
+    \coordinate (nccStartB) at ($(nccStart) + (0, 0.2)$);
+    \coordinate (nccEndB) at ($(nccEnd) + (0, 0.2)$);
+    \draw[thick, gray, decorate, decoration={brace, amplitude=5pt}]
+    (nccStartB) -- (nccEndB)
+    node[gray, midway, above=5pt, font=\scriptsize] {No candidates change for current epoch};
+
+
+    % The 2k before end-of-epoch window.
+    \coordinate (beeStart) at (\cSlot + \K, -.5);
+    \coordinate (beeEnd) at ($(\cSlot + \K + \votes, -.5)$);
+    \draw[blue, line width=4pt]
+    (beeStart) -- (beeEnd);
+
+    % Brace on above the 2k before end-of-epoch window.
+    \coordinate (beeStartB) at ($(beeStart) - (0, 0.2)$);
+    \coordinate (beeEndB) at ($(beeEnd) - (0, 0.2)$);
+    \draw[thick, blue, decorate, decoration={brace, amplitude=5pt}]
+    (beeEndB) -- (beeStartB)
+    node[black!20!blue, midway, below=5pt, font=\scriptsize] {$\votes$ endorsements needed};
+
+    \draw[blue, line width=2pt] (\eend, 3pt) -- (\eend, -3pt);
+
+    \draw[<-] (\cSlot, 4pt) -- +(-1, 1)
+    node [above=2pt, black, font=\scriptsize]
+    {Proposal with id $\var{pid}$ gets confirmed};
+
+    \draw[->] (\eend, -4pt) -- +(1, -1)
+    node[right, blue, font=\scriptsize] {End of epoch};
+  \end{tikzpicture}
+  \caption{An update proposal confirmed too late}
+  \label{fig:up-confirmed-too-late}
 \end{figure}
 
 Figure~\ref{fig:st-diagram-pt-up} shows the different states a protocol-update
@@ -760,8 +915,8 @@ proposal can be in, and what causes the transitions between them.
   (rejected);
 
   \draw[->] (confirmed)
-  edge node [right]
-  {Proposal gets enough endorsements}
+  edge node [right, text width=8em]
+  {Proposal gets enough endorsements $2 \cdot k$ slots before the end of an epoch}
   (adopted);
 
   \end{tikzpicture}

--- a/specs/ledger/latex/notation.tex
+++ b/specs/ledger/latex/notation.tex
@@ -51,6 +51,13 @@
 \item[Implicit existential quantifications] Given a predicate
   $P \in X \to Bool$, we use $P \wcard$ as a shorthand notation for
   $\exists x \cdot P~x$.
+% TODO: use leteq
+\item[Pattern matching in premises] In the inference-rules premises use
+  $\var{patt} = \var{exp}$ to pattern-match an expression $\var{exp} $ with a
+  certain pattern $\var{patt}$. For instance, we use $\Lambda'; x = \Lambda$ to
+  be able to deconstruct a sequence $\Lambda$ in its last element, and prefix.
+  If an expression does not match the given pattern, then the premise does not
+  hold, and the rule cannot trigger.
 \end{description}
 
 \begin{figure}[htb]

--- a/specs/ledger/latex/update-mechanism.tex
+++ b/specs/ledger/latex/update-mechanism.tex
@@ -148,7 +148,8 @@ correspond with fields of the current `BlockVersionData` structure:
 \item Transaction fee policy: $\var{txFeePolicy}$
 \item Script version: $\var{scriptVersion}$
 \item Update adoption threshold: $\var{upAdptThd}$. This would correspond with
-  `srInitThd` in `SoftForkRule`.
+  `srInitThd` in `SoftForkRule`, if we set `srMinThd` to `srInitThd` and
+  `srThdDecrement` to $0$.
 \item Chain stability parameter: $\var{chainStabilityParameter}$.
 \item Update proposal time-to-live: $\var{upropTTL}$.
 \item Certificate liveness: $\var{certificateLiveness}$.
@@ -966,9 +967,9 @@ blocks. Some clarifications are in order:
 \begin{itemize}
 \item The $k$ parameter is used to determined when a confirmed proposal is
   stable. Given we are in a current slot $s_n$, all update proposals confirmed
-  at or before slot $s_n - k$ are deemed stable.
+  at or before slot $s_n - 2 \cdot k$ are deemed stable.
 \item For the sake of conciseness, we omit the types associated to the
-  transitions $\trans{addbvvk}{}$, since they can be inferred from the types of
+  transitions $\trans{fads}{}$, since they can be inferred from the types of
   the $\trans{upend}{}$ transitions.
 \end{itemize}
 
@@ -982,7 +983,6 @@ blocks. Some clarifications are in order:
         \var{s_n} & \Slot & \text{current block number}\\
         (\var{pv}, \var{pps}) & \ProtVer \times \PPMMap
                              & \text{current protocol parameters map}\\
-        \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
         \var{cps} & \UPropId \mapsto \Slot & \text{confirmed proposals}\\
         \var{rpus} & \UPropId \mapsto (\ProtVer \times \PPMMap)
                              & \text{registered update proposals}\\
@@ -994,8 +994,8 @@ blocks. Some clarifications are in order:
     & \BVRState
       = \left(
       \begin{array}{r@{~\in~}lr}
-        (\var{pv_c}, \var{pps_c}) & \ProtVer \times \PPMMap
-        & \text{candidate protocol}\\
+        \var{fads} & \seqof{(\Slot \times (\ProtVer \times \PPMMap))}
+        & \text{future protocol-version adoptions}\\
         \var{bvs} & \powerset{(\ProtVer \times \VKeyGen)}
         & \text{endorsement-key pairs}
       \end{array}\right)
@@ -1015,30 +1015,34 @@ Rules in \cref{fig:rules:up-end} specify what happens when a block issuer
 signals that it is ready to upgrade to a new protocol version, given in the
 rule by $\var{bv}$:
 \begin{itemize}
-\item The set $\var{bvs}$, containing which genesis keys are ready to adopt a
-  given protocol version, is updated to reflect that all the delegators of the
-  block issuer (identified by its verifying key, $\var{vk}$) are ready to
-  upgrade to $\var{bv}$. Given a pair $(\var{pv}, ~\var{vk_s}) \in \var{bvs}$,
-  we say that (the owner of) key $\var{vk_s}$ endorses the (proposed) protocol
-  version $\var{pv}$.
-\item If the candidate protocol version $\var{bv}$ is greater than the current
-  candidate version $\var{pv_c}$, and there is a significant number of blocks
-  signed with that version (condition formalized in
-  \cref{eq:predicate:canadopt}), then the new candidate version becomes
-  $\var{bv}$. Note that we only compare candidates block versions, and not the
-  current protocol version $\var{pv}$. If this rule is used in an initial state
-  in which $\var{pv} \leq \var{pv_c}$, then this invariant is maintained by
-  these rules.
-\item Endorsed protocol version $\var{bv}$ must refer to a registered update
-  proposal (which are contained in $\var{rpus}$), and this update proposal must
-  have been confirmed at least $k$ blocks ago, to ensure stability of the
-  confirmation. Note that this rule does not guarantee that a confirmed
-  proposal will have enough blocks before the end of the epoch where nodes can
-  endorse this version. In such case, the proposal can only be adopted in the
-  next epoch. Figure~\ref{fig:up-confirmed-too-late} shows an example of a
-  proposal being confirmed too late in an epoch, where it is not possible to
-  get the enough endorsements (4 out of 7) in the remaining window. In this
-  Figure we take $k = 4$.
+\item The set $\var{bvs}$, containing which block issuers are ready to adopt a
+  given protocol version, is updated to reflect that the block issuer
+  (identified by its verifying key $\var{vk}$) is ready to upgrade to
+  $\var{bv}$. Given a pair $(\var{pv}, ~\var{vk}) \in \var{bvs}$, we say that
+  (the owner of) key $\var{vk}$ endorses the (proposed) protocol version
+  $\var{pv}$.
+\item If there are a significant number of blocks signed with $\var{bv}$
+  (condition formalized in \cref{eq:predicate:canadopt}), there is a registered
+  proposal (which are contained in $\var{rpus}$) which proposes to upgrade the
+  protocol to version $\var{bv}$, and this update proposal was confirmed at
+  least $2 \cdot k$ slots ago (to ensure stability of the confirmation), then
+  we update the sequence of future protocol-version adoptions ($\var{fads}$).
+\item An element $(s_c, (\var{pv_c}, \var{pps_c})$ of $\var{fads}$ represents
+  the fact that protocol version $\var{pv_c}$ got enough endorsements at slot
+  $s_c$. An invariant that this sequence should maintain is that it is sorted
+  in ascending order on slots and on protocol versions. This means that if we
+  want to know what is the next candidate to adopt at a slot $s_k$ we only need
+  to look at the last element of $[.., s_k] \restrictdom \var{fads}$. Since the
+  list is sorted in ascending order on protocol versions, we know that this
+  last element will contain the highest version to be adopted in the slot range
+  $[.., s_k]$. The $\trans{fads}{}$ transition rules take care of maintaining
+  the aforementioned invariant. If a given protocol-version $\var{bv}$ got
+  enough endorsements, but there is an adoption candidate as last element of
+  $\var{fads}$ with a higher version, we simply discard $\var{bv}$.
+\item If a registered proposal cannot be adopted, we only register the
+  endorsement.
+\item If a block version does not correspond to a registered or confirmed
+  proposal, we just ignore the endorsement.
 \end{itemize}
 
 \begin{figure}[htb]
@@ -1056,31 +1060,25 @@ rule by $\var{bv}$:
 
 \begin{figure}[htb]
   \begin{equation}
-    \label{eq:rule:addbvvk}
+    \label{eq:rule:fads-add}
     \inference
     {
-      \var{bvs'} = \var{bvs} \cup
-      \{ (\var{bv}, \var{vk_s}) \mid \var{vk_s} \mapsto \var{vk} \in \var{dms} \}
+      (\wcard ; (s_c, (\var{pv_c}, \wcard)) \leteq \var{fads}
+      \wedge \var{pv_c} < bv) \vee \epsilon = fads
     }
     {
       {
-        \begin{array}{l}
-          \var{dms}
-        \end{array}
-      }
-      \vdash
-      {
         \left(
           \begin{array}{l}
-            bvs
+            \var{fads}
           \end{array}
         \right)
       }
-      \trans{addbvvk}{(\var{bv}, \var{vk})}
+      \trans{fads}{(s_n, (\var{bv}, \var{pps_c}))}
       {
         \left(
           \begin{array}{l}
-            \var{bvs'}
+            \var{fads}; (s_n, (\var{bv}, \var{pps_c}))
           \end{array}
         \right)
       }
@@ -1088,34 +1086,37 @@ rule by $\var{bv}$:
   \end{equation}
   %
   \nextdef
-  %
   \begin{equation}
-    \label{eq:rule:up-adopted}
+    \label{eq:rule:fads-noop}
     \inference
     {
-      (\var{bv} \leq \var{pv_c} \vee \var{pid} \notin \dom~(\var{cps} \restrictrange [.., s_n - k]))
-      &
-      {
-        \begin{array}{l}
-          \var{dms}
-        \end{array}
-      }
-      \vdash
+      \wcard ; (\wcard, (\var{pv_c}, \wcard)) \leteq \var{fads} & \var{bv} \leq \var{pv_c}
+    }
+    {
       {
         \left(
           \begin{array}{l}
-            bvs
+            \var{fads}
           \end{array}
         \right)
       }
-      \trans{addbvvk}{(\var{bv}, \var{vk})}
+      \trans{fads}{(s_n, (\var{bv}, \var{pps_c}))}
       {
         \left(
           \begin{array}{l}
-            bvs'
+            \var{fads}
           \end{array}
         \right)
       }
+    }
+  \end{equation}
+  \nextdef
+    \begin{equation}
+    \label{eq:rule:up-up-invalid}
+    \inference
+    {
+      \var{pid} \mapsto (\var{bv}, \wcard) \notin \var{rpus}
+      \vee \var{pid} \notin \dom~(\var{cps} \restrictrange [.., s_n - 2 \cdot k])
     }
     {
       {
@@ -1123,7 +1124,6 @@ rule by $\var{bv}$:
           k\\
           s_n\\
           (\var{pv}, \var{pps})\\
-          \var{dms}\\
           \var{cps}\\
           \var{rpus}
         \end{array}
@@ -1132,7 +1132,7 @@ rule by $\var{bv}$:
       {
         \left(
           \begin{array}{l}
-            (\var{pv_c}, \var{pps_c})\\
+            \var{fads}\\
             \var{bvs}
           \end{array}
         \right)
@@ -1141,46 +1141,23 @@ rule by $\var{bv}$:
       {
         \left(
           \begin{array}{l}
-            (\var{pv_c}, \var{pps_c})\\
-            \var{bvs'}
+            \var{fads}\\
+            \var{bvs}
           \end{array}
         \right)
       }
     }
   \end{equation}
-  %
   \nextdef
   %
   \begin{equation}
-    \label{eq:rule:up-no-adoption}
+    \label{eq:rule:up-cant-adopt}
     \inference
     {
-      \var{pv_c} < \var{bv}
-      &
-      {
-        \begin{array}{l}
-          \var{dms}
-        \end{array}
-      }
-      \vdash
-      {
-        \left(
-          \begin{array}{l}
-            bvs
-          \end{array}
-        \right)
-      }
-      \trans{addbvvk}{(\var{bv}, \var{vk})}
-      {
-        \left(
-          \begin{array}{l}
-            bvs'
-          \end{array}
-        \right)
-      }
-      & \neg (\fun{canAdopt}~\var{pps}~\var{bvs'}~\var{bv})\\
+      \var{bvs'} \leteq \var{bvs} \cup \{(\var{bv}, \var{vk})\}
+      & \neg (\fun{canAdopt}~\var{pps}~\var{bvs'}~\var{bv}) \\
       \var{pid} \mapsto (\var{bv}, \wcard) \in \var{rpus}
-      & \var{pid} \in \dom~(\var{cps} \restrictrange [.., s_n - k])
+      & \var{pid} \in \dom~(\var{cps} \restrictrange [.., s_n - 2 \cdot k])
     }
     {
       {
@@ -1188,7 +1165,6 @@ rule by $\var{bv}$:
           k\\
           s_n\\
           (\var{pv}, \var{pps})\\
-          \var{dms}\\
           \var{cps}\\
           \var{rpus}
         \end{array}
@@ -1197,7 +1173,7 @@ rule by $\var{bv}$:
       {
         \left(
           \begin{array}{l}
-            (\var{pv_c}, \var{pps_c})\\
+            \var{fads}\\
             \var{bvs}
           \end{array}
         \right)
@@ -1206,7 +1182,7 @@ rule by $\var{bv}$:
       {
         \left(
           \begin{array}{l}
-            (\var{pv_c}, \var{pps_c})\\
+            \var{fads}\\
             \var{bvs'}
           \end{array}
         \right)
@@ -1217,36 +1193,14 @@ rule by $\var{bv}$:
   \nextdef
   %
   \begin{equation}
-    \label{eq:rule:up-adoption}
+    \label{eq:rule:up-canadopt}
     \inference
     {
-      \var{pv_c} < \var{bv}
-      &
-      {
-        \begin{array}{l}
-          \var{dms}
-        \end{array}
-      }
-      \vdash
-      {
-        \left(
-          \begin{array}{l}
-            bvs
-          \end{array}
-        \right)
-      }
-      \trans{addbvvk}{(\var{bv}, \var{vk})}
-      {
-        \left(
-          \begin{array}{l}
-            bvs'
-          \end{array}
-        \right)
-      }
-      &
-      \fun{canAdopt}~\var{pps}~\var{bvs'}~\var{bv}\\
-      \var{pid} \mapsto (\var{bv}, \var{pps_c'}) \in \var{rpus}
-      & \var{pid} \in \dom~(\var{cps} \restrictrange [.., s_n - k])\\
+      \var{bvs'} = \var{bvs} \cup \{(\var{bv}, \var{vk})\}
+      & \fun{canAdopt}~\var{pps}~\var{bvs'}~\var{bv} \\
+      \var{pid} \mapsto (\var{bv}, \var{pps_c}) \in \var{rpus}
+      & \var{pid} \in \dom~(\var{cps} \restrictrange [.., s_n - 2 \cdot k])\\
+      (\var{fads}) \trans{fads}{(s_n, (\var{bv}, \var{pps_c}))} (\var{fads'})
     }
     {
       {
@@ -1263,7 +1217,7 @@ rule by $\var{bv}$:
       {
         \left(
           \begin{array}{l}
-            (\var{pv_c}, \var{pps_c})\\
+            \var{fads}\\
             \var{bvs}
           \end{array}
         \right)
@@ -1272,7 +1226,7 @@ rule by $\var{bv}$:
       {
         \left(
           \begin{array}{l}
-            (\var{bv}, \var{pps_c'})\\
+            \var{fads'}\\
             \var{bvs'}
           \end{array}
         \right)
@@ -1281,86 +1235,6 @@ rule by $\var{bv}$:
   \end{equation}
   \caption{Update-proposal endorsement rules}
   \label{fig:rules:up-end}
-\end{figure}
-
-
-\begin{figure}[htb]
-  \centering
-  \begin{tikzpicture}
-    %%
-    %% Macros used in this picture
-    %%
-    %
-    % Number of slots
-    \pgfmathsetmacro{\nrSlots}{11}
-    % Slot in which the proposal gets confirmed
-    \pgfmathsetmacro{\cSlot}{1}
-    % Our special K.
-    \pgfmathsetmacro{\K}{4}
-    % Epoch end.
-    \pgfmathsetmacro{\eend}{7}
-    % Number of positive votes needed
-    \pgfmathsetmacro{\votes}{4}
-
-    % Draw the horizontal line
-    \draw[thick, -Triangle] (0,0) -- (\nrSlots,0)
-    node[font=\scriptsize,below left=3pt and -8pt]{slots};
-
-    % % draw vertical lines
-    \foreach \x in {0,1,...,10}
-    \draw (\x cm, 3pt) -- (\x cm, -3pt);
-
-    % Add a label to with the block number in which the proposal got confirmed.
-    \node at (\cSlot, -.7) {$b_j$};
-
-    % Update in cps
-    \node at (\cSlot, -1.5) {$\var{cps'} = \var{cps} \cup \{ \var{pid} \mapsto b_j \}$};
-
-    % The no-endorsements red bar.
-    \draw[red, line width=4pt] (\cSlot, .5) -- +(\K, 0);
-
-    % Brace above the no-endorsement window bar.
-    \draw[thick, red, decorate, decoration={brace, amplitude=5pt}]
-    (\cSlot, .7) -- +(\K, 0)
-    node[black!20!red, midway, above=4pt, font=\scriptsize] {No-endorsements possible};
-
-    % The endorsements window.
-    \coordinate (ewStart) at (\cSlot + \K, .5);
-    \coordinate (ewEnd) at ($(\eend, .5)$);
-    \draw[green, line width=4pt]
-    (ewStart) -- (ewEnd);
-
-    % Brace above the endorsements window
-    \coordinate (ewStartB) at ($(ewStart) + (0, 0.2)$);
-    \coordinate (ewEndB) at ($(ewEnd) + (0, 0.2)$);
-    \draw[thick, green, decorate, decoration={brace, amplitude=5pt}]
-    (ewStartB) -- (ewEndB)
-    node[black!50!green, midway, above=15pt, font=\scriptsize] {Endorsements window};
-
-    % The 2k before end-of-epoch window.
-    \coordinate (beeStart) at (\eend - \votes + 1, -.5);
-    \coordinate (beeEnd) at ($(\eend, -.5)$);
-    \draw[blue, line width=4pt]
-    (beeStart) -- (beeEnd);
-
-    % Brace on above the 2k before end-of-epoch window.
-    \coordinate (beeStartB) at ($(beeStart) - (0, 0.2)$);
-    \coordinate (beeEndB) at ($(beeEnd) - (0, 0.2)$);
-    \draw[thick, blue, decorate, decoration={brace, amplitude=5pt}]
-    (beeEndB) -- (beeStartB)
-    node[black!20!blue, midway, below=5pt, font=\scriptsize] {$\votes$ votes needed};
-
-    \draw[blue, line width=2pt] (\eend, 3pt) -- (\eend, -3pt);
-
-    \draw[<-] (\cSlot, 4pt) -- +(-1, 1)
-    node [above=2pt, black, font=\scriptsize]
-    {Proposal with id $\var{pid}$ gets confirmed};
-
-    \draw[->] (\eend, -4pt) -- +(1, -1)
-    node[right, blue, font=\scriptsize] {End of epoch};
-  \end{tikzpicture}
-  \caption{An update proposal confirmed too late}
-  \label{fig:up-confirmed-too-late}
 \end{figure}
 
 \clearpage
@@ -1493,18 +1367,6 @@ A consequence of enforcing the update rules in \cref{fig:rules:up-end} is that
 a block that is endorsing an unconfirmed proposal gets accepted, although it
 will not have any effect on the update mechanism. It is not clear at this stage
 whether such block should be rejected, therefore we have chosen to be lenient.
-
-\subsubsection{Proposal require a majority of endorsements to be adopted}
-\label{sec:up-adoption-with-majority}
-
-Instead of considering the endorsements for an update proposal in $2*k$ slots
-before the end of the current epoch, we only require a majority of endorsements
-in the current epoch. This makes the specification and the rules simpler and
-gives a bigger window to accept updates before the end of an epoch, however,
-before the handover phase to Shelley, we must make sure that this will not lead
-to a situation in which an update proposal would be adopted by the new rules,
-but was rejected by the old ones due to its endorsements not arriving $2*k$
-slots before the end of the epoch.
 
 \subsection{Questions}
 \label{sec:up-questions}


### PR DESCRIPTION
Change `k` by `2k` slots when talking about chain stability:

![image](https://user-images.githubusercontent.com/175315/52281919-6edb2b80-295f-11e9-8639-38b950268097.png)

Introduce a sequence of candidate versions to be adopted, so that at the end of an epoch we can determine whether we can adopt a new protocol-version:

![image](https://user-images.githubusercontent.com/175315/52283617-160d9200-2963-11e9-8ca9-78af83adf425.png)

`fads` has the following meaning:

![image](https://user-images.githubusercontent.com/175315/52283654-2aea2580-2963-11e9-95ed-256eb0b15de3.png)

The endorsement rules where changed, so that the `fads` sequence is updated when new endorsements are registered (and satisfy certain conditions):

![image](https://user-images.githubusercontent.com/175315/52283761-61c03b80-2963-11e9-9217-d8f06d8184cf.png)

This had also a minor impact on the chain interface rules for endorsement:

![image](https://user-images.githubusercontent.com/175315/52283870-9d5b0580-2963-11e9-8fc0-321a2d196fa4.png)

And the protocol-adoption rule on epoch change now looks at the last element of `fads` restricted to slots not newer that `2k`:

![image](https://user-images.githubusercontent.com/175315/52283977-d4c9b200-2963-11e9-806e-36d35586c6b9.png)

The timeline that exemplifies an update-proposal confirmed too late was adapted accordingly:

![image](https://user-images.githubusercontent.com/175315/52284036-f4f97100-2963-11e9-8658-064a389ccf69.png)

And as required by #297, we now count the endorsements per-node, instead of per-genesis key:

![image](https://user-images.githubusercontent.com/175315/52284193-3722b280-2964-11e9-8b95-5512f4253c02.png)

# Other changes:

Clarify what `upAdptThd` should relate to existing protocol parameters (@ruhatch we have to check this):

![image](https://user-images.githubusercontent.com/175315/52281522-9b427800-295e-11e9-8fa8-c82c92aa2426.png)




Closes #297.
Closes #298.