### PR TITLE
Add `cardano-prelude` as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cardano-mainnet-mirror"]
 	path = cardano-mainnet-mirror
 	url = https://github.com/input-output-hk/cardano-mainnet-mirror.git
+[submodule "submodules/cardano-prelude"]
+	path = submodules/cardano-prelude
+	url = git@github.com:input-output-hk/cardano-prelude.git

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,12 +7,6 @@ packages:
   - specs/semantics/hs
 
 extra-deps:
-  - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 7f8544ae9e162b6664f07093227edb148f1c8a5b
-    subdirs:
-      - .
-      - test
-
   - git: https://github.com/input-output-hk/cardano-chain
     commit: 4d9eec080374179bf15bf9c4fca09cc7d73e5f53
     subdirs:


### PR DESCRIPTION
This is an alternative to `stack.yaml` commit pinning.  I've found
it to be smoother for development. The pain point this addresses is
making and testing local changes (e.g. changes in `cardano-prelude`
which are used/tested from `cardano-chain`) - with the `stack.yaml`
-pinning style, changes must be pushed to a remote or done through
an include of a local git repo. The submodules style lets you make
local modifications, test that they work, then commit and push to
the submodule remote (`cardano-prelude` in this case) before bumping
the submodule tracking hash from the parent (`cardano-chain` in this
case), committing that, and pushing it to the parent's remote.