### PR TITLE
Update cabal.project to cover building tests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,10 +1,9 @@
 packages:
-  binary
-  binary/test
-  crypto
-  crypto/test
-  ./
-  test
+  crypto crypto/test
+  ./     ./test
+
+package cardano-chain
+  tests: True
 
 source-repository-package
   type: git
@@ -15,12 +14,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 2256fd727c5f92e6218afdcf8cddf6e01c4a9dcd
+  tag: ff5fd5f33849be8a826506c34e5b0278f267f804
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 2256fd727c5f92e6218afdcf8cddf6e01c4a9dcd
+  tag: ff5fd5f33849be8a826506c34e5b0278f267f804
   subdir: test
 
 source-repository-package
@@ -31,19 +30,19 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: bf059d1d593e7ef9f3b983a0c904e7bb81362af9
+  tag: 965b32be3361b2ed404e1e58a6fb3cf525d3a26c
   subdir: specs/semantics/hs
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: bf059d1d593e7ef9f3b983a0c904e7bb81362af9
+  tag: 965b32be3361b2ed404e1e58a6fb3cf525d3a26c
   subdir: specs/ledger/hs
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: bf059d1d593e7ef9f3b983a0c904e7bb81362af9
+  tag: 965b32be3361b2ed404e1e58a6fb3cf525d3a26c
   subdir: specs/chain/hs
 
 source-repository-package
@@ -51,3 +50,8 @@ source-repository-package
   location: https://github.com/hedgehogqa/haskell-hedgehog
   tag: 2505055760d06ba6343f803783ed023fb0ed6c48
   subdir: hedgehog
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-mainnet-mirror
+  tag: 0232971dddd5cd235c5a0c18d7b4f342a887276f

--- a/cabal.project
+++ b/cabal.project
@@ -24,6 +24,17 @@ source-repository-package
 
 source-repository-package
   type: git
+  location: https://github.com/input-output-hk/cardano-base
+  tag: bd978263ab884c4b27c940fcfe2d1ee8604afc5f
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-base
+  tag: bd978263ab884c4b27c940fcfe2d1ee8604afc5f
+  subdir: test
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/cardano-crypto
   tag: f5cecb6e424cc84f85b6a3e1f803517bb7b4cfb1
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -31,7 +31,7 @@ extra-deps:
       - specs/chain/hs
 
   - git: https://github.com/input-output-hk/cardano-mainnet-mirror
-    commit: 74ca63f8ad6b47beba2f565c73592cede63ce4b5
+    commit: 0232971dddd5cd235c5a0c18d7b4f342a887276f
 
   - sequence-0.9.8
   - tasty-hedgehog-0.2.0.0


### PR DESCRIPTION
So building with `cabal new-build` works and covers tests.

Depends on https://github.com/input-output-hk/cardano-mainnet-mirror/pull/3

Not all tests build yet: it's not quite clear if we're using the right version of the fm-ledger-rules repo, as `test/Test/Cardano/Chain/Elaboration/Block.hs` fails to build for me, but it's the same one as used in the `stack.yaml` file, so I'm not sure. Suggestions welcome.