### PR TITLE
Remove plutus-protoype from build

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ organization, whose versions are pinned in the `stack.yaml` file, e.g.:
 ```yaml
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 7f8544ae9e162b6664f07093227edb148f1c8a5b
+    commit: ff5fd5f33849be8a826506c34e5b0278f267f804
     subdirs:
       - .
       - test

--- a/binary/stack.yaml
+++ b/binary/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/7f8544ae9e162b6664f07093227edb148f1c8a5b/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/ff5fd5f33849be8a826506c34e5b0278f267f804/snapshot.yaml
 
 packages:
   - .
@@ -6,7 +6,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 7f8544ae9e162b6664f07093227edb148f1c8a5b
+    commit: ff5fd5f33849be8a826506c34e5b0278f267f804
     subdirs:
       - .
       - test

--- a/cardano-chain.cabal
+++ b/cardano-chain.cabal
@@ -132,7 +132,6 @@ library
                      , lens
                      , memory
                      , mtl
-                     , plutus-prototype
                      , resourcet
                      , servant
                      , streaming

--- a/crypto/stack.yaml
+++ b/crypto/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/7f8544ae9e162b6664f07093227edb148f1c8a5b/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/ff5fd5f33849be8a826506c34e5b0278f267f804/snapshot.yaml
 
 packages:
   - .
@@ -6,7 +6,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 7f8544ae9e162b6664f07093227edb148f1c8a5b
+    commit: ff5fd5f33849be8a826506c34e5b0278f267f804
     subdirs:
       - .
       - test

--- a/src/Cardano/Chain/Common/Script.hs
+++ b/src/Cardano/Chain/Common/Script.hs
@@ -6,7 +6,6 @@
 module Cardano.Chain.Common.Script
   ( Script(..)
   , ScriptVersion
-  , Script_v0
   )
 where
 
@@ -16,7 +15,6 @@ import Data.Aeson (FromJSON(..), ToJSON(toJSON), object, withObject, (.:), (.=))
 import Data.ByteString.Base64.Type (getByteString64, makeByteString64)
 import Formatting (bprint, int)
 import qualified Formatting.Buildable as B
-import qualified PlutusCore.Program as PLCore
 
 import Cardano.Binary.Class (Bi(..), encodeListLen, enforceSize)
 
@@ -52,6 +50,3 @@ instance Bi Script where
     decode = do
         enforceSize "Script" 2
         Script <$> decode <*> decode
-
--- | Deserialized script (i.e. an AST), version 0.
-type Script_v0 = PLCore.Program

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/7f8544ae9e162b6664f07093227edb148f1c8a5b/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/ff5fd5f33849be8a826506c34e5b0278f267f804/snapshot.yaml
 
 packages:
   - .
@@ -6,7 +6,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: d71ddaacf474bfc9b96f96ce1b7c0e81a156d719
+    commit: ff5fd5f33849be8a826506c34e5b0278f267f804
     subdirs:
       - .
       - test


### PR DESCRIPTION
The Plutus protoype code was never used on mainnet and is going to
be replaced by a new version at some later date.