### PR TITLE
Set main branch for Buildkite ci-cache

### DIFF
--- a/scripts/buildkite/rebuild.hs
+++ b/scripts/buildkite/rebuild.hs
@@ -122,6 +122,10 @@ saveCICache cfg = do
   -- cacheS3 cfg Nothing "save stack"
   cacheS3 cfg Nothing "save stack work"
 
+-- Deletes the files from S3 that would have been put with "cache-s3 save".
+clearCICache :: CICacheConfig -> IO ()
+clearCICache cfg = cacheS3 cfg Nothing "clear"
+
 cacheS3 :: CICacheConfig -> Maybe Text -> Text -> IO ()
 cacheS3 CICacheConfig {..} baseBranch cmd = void $ run "cache-s3" args
  where

--- a/scripts/buildkite/rebuild.hs
+++ b/scripts/buildkite/rebuild.hs
@@ -25,6 +25,9 @@ data CICacheConfig = CICacheConfig
   , ccBranch  :: Text
   } deriving (Show)
 
+mainlineBranch :: Text
+mainlineBranch = "master"
+
 main :: IO ()
 main = do
   awsCreds
@@ -111,8 +114,8 @@ cacheUploadStep cacheConfig = do
 
 restoreCICache :: CICacheConfig -> IO ()
 restoreCICache cfg = do
-  -- cacheS3 cfg (Just "develop") "restore stack"
-  cacheS3 cfg (Just "develop") "restore stack work"
+  -- cacheS3 cfg (Just mainlineBranch) "restore stack"
+  cacheS3 cfg (Just mainlineBranch) "restore stack work"
 
 saveCICache :: CICacheConfig -> IO ()
 saveCICache cfg = do


### PR DESCRIPTION
This will make Buildkite branch builds faster because they can start with the `.stack-work` cache from `master`.
