### PR TITLE
Add coveralls to buildkite steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The formal specifications and associated executable specifications can be found
 in the [`specs`](specs/) directory.
 
 [![Build status](https://badge.buildkite.com/92690086997996d4f9703ef752c0e918a02bb389b44d0659a0.svg?branch=master)](https://buildkite.com/input-output-hk/cardano-chain)
+[![Coverage Status](https://coveralls.io/repos/github/input-output-hk/cardano-chain/badge.svg?branch=master)](https://coveralls.io/github/input-output-hk/cardano-chain?branch=master)
 
 ## Developing
 

--- a/scripts/buildkite/default.nix
+++ b/scripts/buildkite/default.nix
@@ -10,6 +10,9 @@ with pkgs;
 let
   cache-s3 = callPackage ./cache-s3.nix {};
 
+  stack-hpc-coveralls = pkgs.haskell.lib.dontCheck
+    (haskell.packages.ghc844.callPackage ./stack-hpc-coveralls.nix {});
+
   stackRebuild = runCommand "stack-rebuild" {} ''
     ${haskellPackages.ghcWithPackages (ps: [ps.turtle ps.safe ps.transformers])}/bin/ghc -o $out ${./rebuild.hs}
   '';
@@ -17,6 +20,6 @@ let
 in
   writeScript "stack-rebuild-wrapped" ''
     #!${stdenv.shell}
-    export PATH=${lib.makeBinPath ([ cache-s3 stack gnused coreutils ] ++ buildTools)}
+    export PATH=${lib.makeBinPath ([ cache-s3 stack gnused coreutils stack-hpc-coveralls ] ++ buildTools)}
     exec ${stackRebuild} "$@"
   ''

--- a/scripts/buildkite/stack-hpc-coveralls.nix
+++ b/scripts/buildkite/stack-hpc-coveralls.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, aeson, base, bytestring, containers, deepseq
+, directory, docopt, fetchgit, filepath, hlint, hpc, hspec
+, hspec-contrib, http-client, HUnit, lens, lens-aeson, process
+, pureMD5, stdenv, text, time, unordered-containers, utf8-string
+, wreq, yaml
+}:
+mkDerivation {
+  pname = "stack-hpc-coveralls";
+  version = "0.0.4.0";
+  src = fetchgit {
+    url = "https://github.com/input-output-hk/stack-hpc-coveralls";
+    rev = "347159869bc9af2de6c6fa16e247ae060e82b954";
+    sha256 = "0qsfxddbzvw3lkyvr0876vnlsm1901gy2mksbghg709wpip4xksp";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson base bytestring containers directory filepath hpc http-client
+    lens lens-aeson process pureMD5 text unordered-containers
+    utf8-string wreq yaml
+  ];
+  executableHaskellDepends = [ aeson base bytestring docopt ];
+  testHaskellDepends = [
+    aeson base containers deepseq hlint hpc hspec hspec-contrib HUnit
+    time
+  ];
+  homepage = "http://github.com/rubik/stack-hpc-coveralls";
+  description = "Initial project template from stack";
+  license = stdenv.lib.licenses.isc;
+}


### PR DESCRIPTION
This generates coverage information for `cardano-chain` (not binary or crypto yet) and uploads it to coveralls

Closes #262