### PR TITLE
Remove cardano-chain-test.x86_64-darwin from required hydra jobs

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -51,7 +51,6 @@ localLib.pkgs.lib.mapAttrsRecursiveCond
 
     jobs.nix-tools.libs.cardano-chain.x86_64-darwin
     jobs.nix-tools.libs.cardano-chain.x86_64-linux
-    jobs.nix-tools.tests.cardano-chain.cardano-chain-test.x86_64-darwin
     jobs.nix-tools.tests.cardano-chain.cardano-chain-test.x86_64-linux
 
     # windows cross compilation targets


### PR DESCRIPTION
 this job is not built by hydra and should have been removed from
 the required aggregate job in #354, otherwise the required
 job never finish.
Other PRs need to be rebased on master once this is merged.