### PR TITLE
 Prepare for integration with ouroboros-network

### DIFF
--- a/src/Cardano/Chain/Block/Block.hs
+++ b/src/Cardano/Chain/Block/Block.hs
@@ -103,7 +103,7 @@ import Cardano.Chain.Block.Header
   , wrapHeaderBytes
   )
 import Cardano.Chain.Block.Proof (Proof(..))
-import Cardano.Chain.Common (Attributes, ChainDifficulty, mkAttributes)
+import Cardano.Chain.Common (Attributes, ChainDifficulty (..), mkAttributes)
 import qualified Cardano.Chain.Delegation as Delegation
 import Cardano.Chain.Genesis.Hash (GenesisHash(..))
 import Cardano.Chain.Slotting (SlotId(..))
@@ -247,7 +247,7 @@ mkBlock
 mkBlock pm bv sv prevHeader = mkBlockExplicit pm bv sv prevHash difficulty
  where
   prevHash   = either genesisHeaderHash hashHeader prevHeader
-  difficulty = either (const 0) (succ . headerDifficulty) prevHeader
+  difficulty = either (const $ ChainDifficulty 0) (succ . headerDifficulty) prevHeader
 
 -- | Smart constructor for 'Block', without requiring the entire previous
 --   'Header'. Instead, you give its hash and the difficulty of this block.

--- a/src/Cardano/Chain/Block/Header.hs
+++ b/src/Cardano/Chain/Block/Header.hs
@@ -85,7 +85,7 @@ import Cardano.Chain.Block.ExtraBodyData (ExtraBodyData)
 import Cardano.Chain.Block.ExtraHeaderData
   (ExtraHeaderData(..), ExtraHeaderDataError, verifyExtraHeaderData)
 import Cardano.Chain.Block.Proof (Proof(..), mkProof)
-import Cardano.Chain.Common (Attributes, ChainDifficulty)
+import Cardano.Chain.Common (Attributes, ChainDifficulty (..))
 import qualified Cardano.Chain.Delegation.Certificate as Delegation
 import Cardano.Chain.Genesis.Hash (GenesisHash(..))
 import Cardano.Chain.Slotting (EpochIndex, SlotId(..), slotIdF)
@@ -154,7 +154,7 @@ instance B.Buildable Header where
     headerHash
     (headerPrevHash header)
     (consensusSlot consensus)
-    (consensusDifficulty consensus)
+    (unChainDifficulty $ consensusDifficulty consensus)
     (consensusLeaderKey consensus)
     (consensusSignature consensus)
     (headerExtraData header)
@@ -209,7 +209,7 @@ mkHeader pm prevHeader = mkHeaderExplicit pm prevHash difficulty
  where
   prevHash   = either genesisHeaderHash hashHeader prevHeader
   difficulty = either
-    (const 0)
+    (const $ ChainDifficulty 0)
     (succ . consensusDifficulty . headerConsensusData)
     prevHeader
 

--- a/src/Cardano/Chain/Common/BlockCount.hs
+++ b/src/Cardano/Chain/Common/BlockCount.hs
@@ -15,23 +15,12 @@ import Formatting.Buildable (Buildable)
 import Cardano.Binary.Class (Bi(..))
 
 newtype BlockCount = BlockCount
-    { getBlockCount :: Word64
-    } deriving ( Eq
-              , Ord
-              , Num
-              , Real
-              , Integral
-              , Enum
-              , Read
-              , Show
-              , Buildable
-              , Generic
-              , NFData
-              )
+    { unBlockCount :: Word64
+    } deriving ( Eq, Ord, Enum, Read, Show, Buildable, Generic, NFData)
 
 instance Bi BlockCount where
-    encode = encode . getBlockCount
+    encode = encode . unBlockCount
     decode = BlockCount <$> decode
-    encodedSizeExpr size pxy = size (getBlockCount <$> pxy)
+    encodedSizeExpr size pxy = size (unBlockCount <$> pxy)
 
 deriveJSON defaultOptions ''BlockCount

--- a/src/Cardano/Chain/Common/ChainDifficulty.hs
+++ b/src/Cardano/Chain/Common/ChainDifficulty.hs
@@ -16,26 +16,15 @@ import Formatting.Buildable (Buildable)
 
 import Cardano.Binary.Class
   (Bi(..), Dropper, dropWord64, encodeListLen, enforceSize)
-import Cardano.Chain.Common.BlockCount (BlockCount)
 
 -- | Chain difficulty represents necessary effort to generate a
 -- chain. In the simplest case it can be number of blocks in chain.
 newtype ChainDifficulty = ChainDifficulty
-  { getChainDifficulty :: BlockCount
-  } deriving ( Show
-             , Eq
-             , Ord
-             , Num
-             , Enum
-             , Real
-             , Integral
-             , Generic
-             , Buildable
-             , NFData
-             )
+  { unChainDifficulty :: Word64
+  } deriving ( Show, Eq, Ord, Enum, Generic, Buildable, NFData)
 
 instance Bi ChainDifficulty where
-    encode cd = encodeListLen 1 <> encode (getChainDifficulty cd)
+    encode cd = encodeListLen 1 <> encode (unChainDifficulty cd)
     decode = do
         enforceSize "ChainDifficulty" 1
         ChainDifficulty <$> decode

--- a/src/Cardano/Chain/Genesis/Data.hs
+++ b/src/Cardano/Chain/Genesis/Data.hs
@@ -35,7 +35,7 @@ import Text.JSON.Canonical
   , parseCanonicalJSON
   )
 
-import Cardano.Chain.Common (BlockCount)
+import Cardano.Chain.Common (BlockCount (..))
 import Cardano.Chain.Genesis.AvvmBalances (GenesisAvvmBalances)
 import Cardano.Chain.Genesis.Delegation (GenesisDelegation)
 import Cardano.Chain.Genesis.Hash (GenesisHash(..))
@@ -75,7 +75,7 @@ instance Monad m => ToJSON m GenesisData where
     --  mainnet genesis block
     , ( "protocolConsts"
       , mkObject
-        [ ("k"            , pure . JSNum . fromIntegral $ gdK gd)
+        [ ("k"            , pure . JSNum . fromIntegral . unBlockCount $ gdK gd)
         , ("protocolMagic", toJSON . getProtocolMagic $ gdProtocolMagic gd)
         ]
       )
@@ -97,7 +97,7 @@ instance MonadError SchemaError m => FromJSON m GenesisData where
       <*> fromJSField obj "blockVersionData"
       -- The above is called blockVersionData for backwards compatibility with
       -- mainnet genesis block
-      <*> (fromIntegral @Int54 <$> fromJSField protocolConsts "k")
+      <*> (BlockCount . (fromIntegral @Int54) <$> fromJSField protocolConsts "k")
       <*> (ProtocolMagic . ProtocolMagicId <$> (fromJSField protocolConsts "protocolMagic") <*> pure RequiresMagic)
       <*> fromJSField obj "avvmDistr"
 

--- a/src/Cardano/Chain/ProtocolConstants.hs
+++ b/src/Cardano/Chain/ProtocolConstants.hs
@@ -18,15 +18,14 @@ import Cardano.Chain.Slotting.EpochSlots (EpochSlots(..))
 -- | Security parameter expressed in number of slots. It uses chain quality
 --   property. It's basically @blkSecurityParam / chainQualityThreshold@.
 kSlotSecurityParam :: BlockCount -> EpochSlots
-kSlotSecurityParam = EpochSlots . (*) 2 . getBlockCount
+kSlotSecurityParam = EpochSlots . (*) 2 . unBlockCount
 
 -- | Minimal chain quality (number of blocks divided by number of
 --   slots) necessary for security of the system.
 kChainQualityThreshold :: Fractional f => BlockCount -> f
-kChainQualityThreshold k =
-  realToFrac k / fromIntegral (unEpochSlots $ kSlotSecurityParam k)
+kChainQualityThreshold k = realToFrac (unBlockCount k) / fromIntegral (unEpochSlots $ kSlotSecurityParam k)
 
 -- | Number of slots inside one epoch
 kEpochSlots :: BlockCount -> EpochSlots
-kEpochSlots = EpochSlots . (*) 10 . getBlockCount
+kEpochSlots = EpochSlots . (*) 10 . unBlockCount
 

--- a/src/Cardano/Chain/Update/Validation/Endorsement.hs
+++ b/src/Cardano/Chain/Update/Validation/Endorsement.hs
@@ -107,7 +107,7 @@ registerEndorsement env st endorsement =
    where
       -- Stable and confirmed proposals.
     scps     = M.filter (stableAt <=) confirmedProposals
-    stableAt = currentSlot - FlatSlotId (2 * getBlockCount k)
+    stableAt = currentSlot - FlatSlotId (2 * unBlockCount k)
 
   pps = adoptedProtocolParameters env
   pv  = endorsementProtocolVersion endorsement

--- a/test/Test/Cardano/Chain/Block/Validation.hs
+++ b/test/Test/Cardano/Chain/Block/Validation.hs
@@ -165,12 +165,12 @@ prop_signingHistoryUpdatesPreserveInvariants =
           initialSigningHistory = SigningHistory
             { shK = k
             , shSigningQueue = Seq.Empty
-            , shStakeholderCounts = M.fromList $ fmap (, 0) stakeholders
+            , shStakeholderCounts = M.fromList $ fmap (, BlockCount 0) stakeholders
             }
 
         -- Generate a list of signers with which to update the 'SigningHistory'
         signers <- forAll $ Gen.list
-          (Range.constant 0 (2 * fromIntegral k))
+          (Range.constant 0 (fromIntegral $ 2 * unBlockCount k))
           (Gen.element publicKeys)
 
         let
@@ -185,7 +185,7 @@ prop_signingHistoryUpdatesPreserveInvariants =
             stakeholders `forM_` \s' -> do
               let
                 stakeholderCount :: Int
-                stakeholderCount = fromIntegral $ fromMaybe 0 $ M.lookup
+                stakeholderCount = maybe 0 (fromIntegral . unBlockCount) $ M.lookup
                   s'
                   (shStakeholderCounts sh')
                 stakeholderCount' =
@@ -193,7 +193,7 @@ prop_signingHistoryUpdatesPreserveInvariants =
               stakeholderCount === stakeholderCount'
 
             -- The length of the overall sequence is less than or equal to 'k'
-            assert $ length (shSigningQueue sh') <= fromIntegral (shK sh')
+            assert $ length (shSigningQueue sh') <= fromIntegral (unBlockCount $ shK sh')
 
             pure sh'
 

--- a/test/Test/Cardano/Chain/Common/Example.hs
+++ b/test/Test/Cardano/Chain/Common/Example.hs
@@ -19,7 +19,6 @@ import Cardano.Chain.Common
   , AddrSpendingData(..)
   , Address
   , Attributes
-  , BlockCount(..)
   , ChainDifficulty(..)
   , StakeholderId
   , makeAddress
@@ -61,7 +60,7 @@ exampleAddress2 = makeAddress easd attrs
   hap   = Just (HDAddressPayload (getBytes 15 32))
 
 exampleChainDifficulty :: ChainDifficulty
-exampleChainDifficulty = ChainDifficulty (BlockCount 9999)
+exampleChainDifficulty = ChainDifficulty 9999
 
 exampleStakeholderId :: StakeholderId
 exampleStakeholderId = mkStakeholderId examplePublicKey

--- a/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/test/Test/Cardano/Chain/Common/Gen.hs
@@ -98,7 +98,7 @@ genCanonicalTxSizeLinear = TxSizeLinear <$> genLovelace' <*> genLovelace'
   maxCanonicalLovelaceVal = 9e6
 
 genChainDifficulty :: Gen ChainDifficulty
-genChainDifficulty = ChainDifficulty <$> genBlockCount
+genChainDifficulty = ChainDifficulty <$> Gen.word64 Range.constantBounded
 
 genCustomLovelace :: Word64 -> Gen Lovelace
 genCustomLovelace size =

--- a/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -43,6 +43,7 @@ import Ledger.Delegation (DCert, delegationMap, delegatorOf, mkDCert)
 import Ledger.Update (bkSgnCntW, bkSlotsPerEpoch, maxBkSz, maxHdrSz)
 import Cardano.Chain.Common
   ( BlockCount(BlockCount)
+  , ChainDifficulty(ChainDifficulty)
   , LovelacePortion(LovelacePortion)
   , TxFeePolicy(TxFeePolicyTxSizeLinear)
   , TxSizeLinear(TxSizeLinear)
@@ -73,7 +74,7 @@ elaborate config (_, _, pps) ast st ab = Concrete.ABlock
   bh0 = Concrete.mkHeaderExplicit
     (Genesis.configProtocolMagicId config)
     prevHash
-    0
+    (ChainDifficulty 0)
     sid
     ssk
     cDCert

--- a/test/Test/Cardano/Chain/Genesis/Dummy.hs
+++ b/test/Test/Cardano/Chain/Genesis/Dummy.hs
@@ -29,7 +29,7 @@ import Cardano.Prelude
 import Data.Time (Day(..), UTCTime(..))
 
 import Cardano.Chain.Common
-  ( BlockCount
+  ( BlockCount (..)
   , TxFeePolicy(..)
   , TxSizeLinear(..)
   , mkKnownLovelace
@@ -67,7 +67,7 @@ dummyConfigStartTime startTime =
   either (panic . show) identity $ mkConfig startTime dummyGenesisSpec
 
 dummyK :: BlockCount
-dummyK = 10
+dummyK = BlockCount 10
 
 dummyEpochSlots :: EpochSlots
 dummyEpochSlots = kEpochSlots dummyK

--- a/test/Test/Cardano/Chain/Genesis/Example.hs
+++ b/test/Test/Cardano/Chain/Genesis/Example.hs
@@ -75,7 +75,7 @@ exampleStaticConfig_GCSpec = GCSpec $ UnsafeGenesisSpec
   exampleGenesisAvvmBalances
   exampleGenesisDelegation
   exampleProtocolParameters
-  37
+  (BlockCount 37)
   (ProtocolMagic (ProtocolMagicId 1783847074) RequiresMagic)
   exampleGenesisInitializer
 

--- a/test/Test/Cardano/Chain/Txp/Validation.hs
+++ b/test/Test/Cardano/Chain/Txp/Validation.hs
@@ -25,6 +25,8 @@ import Hedgehog
   , withTests
   )
 
+import System.FilePath (takeFileName)
+
 import Cardano.Chain.Block (ABlund, blockSlot, blockTxPayload)
 import Cardano.Chain.Epoch.File (ParseError, parseEpochFile)
 import Cardano.Chain.Genesis (GenesisData(..), readGenesisData)
@@ -70,7 +72,7 @@ tests scenario = do
   -- check them all sequentially
   let
     properties :: [(PropertyName, Property)]
-    properties = zip (fromString <$> files) (epochValid pm utxoRef <$> files)
+    properties = zip (fromString . takeFileName <$> files) (epochValid pm utxoRef <$> files)
   checkSequential $ Group "Test.Cardano.Chain.Txp.Validation" properties
 
 

--- a/test/golden/json/genesis/StaticConfig_GCSpec
+++ b/test/golden/json/genesis/StaticConfig_GCSpec
@@ -26,7 +26,7 @@
             "unlockStakeEpoch": 99
         },
         "k": {
-            "getBlockCount": 37
+            "unBlockCount": 37
         },
         "avvmDistr": {
             "U4lgqRZyawnwXJ1NSpIrhbThGs_MFDRnPZUBm3qaUtI=": 36524597913081152,


### PR DESCRIPTION
These changes to make integration with `ouroboros-network` easier.

Also want to add a test that asserts that the previous header hash of the zeroth block on the mainnet chain is `Nothing` but will do that in a separate PR.