### PR TITLE
[#385] Address Discrimination Part 1: altering configuration

### DIFF
--- a/crypto/test/Test/Cardano/Crypto/Arbitrary.hs
+++ b/crypto/test/Test/Cardano/Crypto/Arbitrary.hs
@@ -54,7 +54,6 @@ import Cardano.Crypto.Signing.Redeem
   (RedeemPublicKey, RedeemSecretKey, RedeemSignature, redeemKeyGen, redeemSign)
 
 import Test.Cardano.Crypto.Arbitrary.Unsafe ()
-import Test.Cardano.Crypto.Dummy (dummyProtocolMagicId)
 
 
 instance Arbitrary ProtocolMagic where
@@ -144,27 +143,34 @@ genRedeemSignature
 genRedeemSignature pm genA = redeemSign pm <$> arbitrary <*> arbitrary <*> genA
 
 instance (Bi a, Arbitrary a) => Arbitrary (Signature a) where
-    arbitrary = genSignature dummyProtocolMagicId arbitrary
+  arbitrary = do
+    pm <- arbitrary
+    genSignature pm arbitrary
 
 instance (Bi a, Arbitrary a) => Arbitrary (RedeemSignature a) where
-    arbitrary = genRedeemSignature dummyProtocolMagicId arbitrary
+  arbitrary = do
+    pm <- arbitrary
+    genRedeemSignature pm arbitrary
 
 instance (Bi w, Arbitrary w) => Arbitrary (ProxyCert w) where
-    arbitrary = liftA3 (safeCreateProxyCert dummyProtocolMagicId) arbitrary arbitrary arbitrary
+    arbitrary = safeCreateProxyCert <$> arbitrary <*> arbitrary
+                                    <*> arbitrary <*> arbitrary
 
 instance (Bi w, Arbitrary w) => Arbitrary (ProxyVerificationKey w) where
-    arbitrary = liftA3 (createPsk dummyProtocolMagicId) arbitrary arbitrary arbitrary
+    arbitrary = createPsk <$> arbitrary <*> arbitrary
+                          <*> arbitrary <*> arbitrary
 
 instance (Bi w, Arbitrary w, Bi a, Arbitrary a) =>
          Arbitrary (ProxySignature w a) where
   arbitrary = do
     delegateSk <- arbitrary
+    pm <- arbitrary
     psk        <-
-      createPsk dummyProtocolMagicId
+      createPsk pm
       <$> arbitrary
       <*> pure (toPublic delegateSk)
       <*> arbitrary
-    proxySign dummyProtocolMagicId SignProxyVK delegateSk psk <$> arbitrary
+    proxySign pm SignProxyVK delegateSk psk <$> arbitrary
 
 
 --------------------------------------------------------------------------------

--- a/crypto/test/Test/Cardano/Crypto/Example.hs
+++ b/crypto/test/Test/Cardano/Crypto/Example.hs
@@ -6,6 +6,7 @@ module Test.Cardano.Crypto.Example
   , exampleProtocolMagic2
   , exampleProtocolMagic3
   , exampleProtocolMagic4
+  , exampleProtocolMagicId0
   , examplePublicKey
   , examplePublicKeys
   , exampleRedeemPublicKey
@@ -36,8 +37,11 @@ import Cardano.Crypto
 
 import Test.Cardano.Crypto.Bi (getBytes)
 
+exampleProtocolMagicId0 :: ProtocolMagicId
+exampleProtocolMagicId0 = ProtocolMagicId 31337
+
 exampleProtocolMagic0 :: ProtocolMagic
-exampleProtocolMagic0 = ProtocolMagic (ProtocolMagicId 31337) RequiresMagic
+exampleProtocolMagic0 = ProtocolMagic exampleProtocolMagicId0 RequiresMagic
 
 exampleProtocolMagic1 :: ProtocolMagic
 exampleProtocolMagic1 =

--- a/crypto/test/Test/Cardano/Crypto/Json.hs
+++ b/crypto/test/Test/Cardano/Crypto/Json.hs
@@ -12,35 +12,13 @@ import Hedgehog (Property)
 import qualified Hedgehog as H
 
 import Test.Cardano.Crypto.Example
-  ( exampleProtocolMagic0
-  , exampleProtocolMagic1
-  , exampleProtocolMagic2
-  , exampleProtocolMagic3
+  ( exampleProtocolMagic3
   , exampleProtocolMagic4
   )
 
 --------------------------------------------------------------------------------
 -- ProtocolMagic
 --------------------------------------------------------------------------------
-
--- Decode-only golden tests for ensuring that, when decoding the legacy
--- `ProtocolMagic` JSON format, the `RequiresNetworkMagic` field defaults to
--- `RequiresMagic`.
-
-goldenProtocolMagic0AesonDec :: Property
-goldenProtocolMagic0AesonDec = goldenTestJSONDec
-  exampleProtocolMagic0
-  "test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic"
-
-goldenProtocolMagic1AesonDec :: Property
-goldenProtocolMagic1AesonDec = goldenTestJSONDec
-  exampleProtocolMagic1
-  "test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic"
-
-goldenProtocolMagic2AesonDec :: Property
-goldenProtocolMagic2AesonDec = goldenTestJSONDec
-  exampleProtocolMagic2
-  "test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic"
 
 -- Legacy JSON encoding where requiresNetworkMagic was
 -- encoded as "NMMustBeNothing" or "NMMustBeJust"

--- a/src/Cardano/Chain/Genesis/Data.hs
+++ b/src/Cardano/Chain/Genesis/Data.hs
@@ -43,10 +43,7 @@ import Cardano.Chain.Genesis.NonAvvmBalances (GenesisNonAvvmBalances)
 import Cardano.Chain.Genesis.WStakeholders (GenesisWStakeholders)
 import Cardano.Chain.Update.ProtocolParameters (ProtocolParameters)
 import Cardano.Crypto
-  ( getProtocolMagic
-  , ProtocolMagic(..)
-  , ProtocolMagicId(..)
-  , RequiresNetworkMagic(..)
+  ( ProtocolMagicId(..)
   , hashRaw
   )
 
@@ -60,7 +57,7 @@ data GenesisData = GenesisData
     , gdNonAvvmBalances  :: !GenesisNonAvvmBalances
     , gdProtocolParameters :: !ProtocolParameters
     , gdK                :: !BlockCount
-    , gdProtocolMagic    :: !ProtocolMagic
+    , gdProtocolMagicId  :: !ProtocolMagicId
     , gdAvvmDistr        :: !GenesisAvvmBalances
     } deriving (Show, Eq)
 
@@ -76,7 +73,7 @@ instance Monad m => ToJSON m GenesisData where
     , ( "protocolConsts"
       , mkObject
         [ ("k"            , pure . JSNum . fromIntegral . unBlockCount $ gdK gd)
-        , ("protocolMagic", toJSON . getProtocolMagic $ gdProtocolMagic gd)
+        , ("protocolMagic", toJSON $ gdProtocolMagicId gd)
         ]
       )
     , ("avvmDistr", toJSON $ gdAvvmDistr gd)
@@ -98,7 +95,7 @@ instance MonadError SchemaError m => FromJSON m GenesisData where
       -- The above is called blockVersionData for backwards compatibility with
       -- mainnet genesis block
       <*> (BlockCount . (fromIntegral @Int54) <$> fromJSField protocolConsts "k")
-      <*> (ProtocolMagic . ProtocolMagicId <$> (fromJSField protocolConsts "protocolMagic") <*> pure RequiresMagic)
+      <*> (ProtocolMagicId <$> (fromJSField protocolConsts "protocolMagic"))
       <*> fromJSField obj "avvmDistr"
 
 data GenesisDataError

--- a/src/Cardano/Chain/Genesis/Generate.hs
+++ b/src/Cardano/Chain/Genesis/Generate.hs
@@ -223,7 +223,7 @@ generateGenesisData startTime genesisSpec = do
       , gdNonAvvmBalances = nonAvvmDistr
       , gdProtocolParameters = gsProtocolParameters genesisSpec
       , gdK         = gsK genesisSpec
-      , gdProtocolMagic = pm
+      , gdProtocolMagicId = getProtocolMagicId pm
       , gdAvvmDistr = fakeAvvmDistr <> realAvvmMultiplied
       }
 

--- a/test/Test/Cardano/Chain/Config.hs
+++ b/test/Test/Cardano/Chain/Config.hs
@@ -8,15 +8,18 @@ where
 import Cardano.Prelude
 
 import qualified Cardano.Chain.Genesis as Genesis
+import Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic(..))
 
 -- | Read the test mainnet configuration file from the @test@ directory.
 --
 -- An error is thrown if it is not possible to elaborate a genesis
 -- configuration from the genesis file.
+--
+-- We use `RequiresNoMagic`, as it indicates mainnet
 readMainetCfg :: MonadIO m => m Genesis.Config
 readMainetCfg =
   either
       (panic "TODO: Add buildable instance for Genesis.ConfigurationError")
       identity
     <$> runExceptT
-          (Genesis.mkConfigFromFile "test/mainnet-genesis.json" Nothing)
+          (Genesis.mkConfigFromFile RequiresNoMagic "test/mainnet-genesis.json" Nothing)

--- a/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -25,6 +25,7 @@ import Data.Time (Day(ModifiedJulianDay), UTCTime(UTCTime))
 
 import qualified Cardano.Binary.Class as Binary
 import qualified Cardano.Crypto.Hashing as H
+import Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic(..))
 
 import qualified Cardano.Chain.Block as Concrete
 import qualified Cardano.Chain.Common as Common
@@ -53,7 +54,7 @@ import Cardano.Chain.Common
 
 import Test.Cardano.Chain.Elaboration.Keys
   (elaborateKeyPair, elaborateVKeyGenesis, vKeyPair)
-import Test.Cardano.Crypto.Dummy (dummyProtocolMagic)
+import Test.Cardano.Crypto.Dummy (dummyProtocolMagicId)
 import Test.Cardano.Chain.Elaboration.Delegation (elaborateDCert)
 
 -- | Elaborate an abstract block into a concrete block (without annotations).
@@ -184,7 +185,7 @@ rcDCert vk ast = mkDCert vkg sigVkg vk (ast ^. epochL)
 --  | trace.
 --
 abEnvToCfg :: Transition.Environment CHAIN -> Genesis.Config
-abEnvToCfg (_, vkgs, pps) = Genesis.Config genesisData genesisHash Nothing
+abEnvToCfg (_, vkgs, pps) = Genesis.Config genesisData genesisHash Nothing RequiresNoMagic
  where
   genesisData = Genesis.GenesisData
     { Genesis.gdBootStakeholders = Genesis.GenesisWStakeholders
@@ -198,7 +199,7 @@ abEnvToCfg (_, vkgs, pps) = Genesis.Config genesisData genesisHash Nothing
         -- an abstract protocol parameter for k. Then we need to solve the
         -- problem that in the concrete implementation k and w are the same.
                             BlockCount (fromIntegral $ pps ^. bkSgnCntW)
-    , Genesis.gdProtocolMagic = dummyProtocolMagic
+    , Genesis.gdProtocolMagicId = dummyProtocolMagicId
     , Genesis.gdAvvmDistr = Genesis.GenesisAvvmBalances []
     }
 

--- a/test/Test/Cardano/Chain/Genesis/Example.hs
+++ b/test/Test/Cardano/Chain/Genesis/Example.hs
@@ -61,7 +61,7 @@ import Test.Cardano.Chain.Common.Example
   (exampleAddress, exampleAddress1, exampleStakeholderId)
 import Test.Cardano.Chain.Update.Example (exampleProtocolParameters)
 import Test.Cardano.Crypto.Bi (getBytes)
-import Test.Cardano.Crypto.Example (exampleProtocolMagic0)
+import Test.Cardano.Crypto.Example (exampleProtocolMagicId0)
 
 exampleBlockCount :: BlockCount
 exampleBlockCount = BlockCount 12344
@@ -99,7 +99,7 @@ exampleGenesisData0 = GenesisData
   , gdNonAvvmBalances = exampleGenesisNonAvvmBalances0
   , gdProtocolParameters = exampleProtocolParameters
   , gdK         = exampleBlockCount
-  , gdProtocolMagic = exampleProtocolMagic0
+  , gdProtocolMagicId = exampleProtocolMagicId0
   , gdAvvmDistr = exampleGenesisAvvmBalances
   }
 

--- a/test/Test/Cardano/Chain/Genesis/Gen.hs
+++ b/test/Test/Cardano/Chain/Genesis/Gen.hs
@@ -47,10 +47,8 @@ import Cardano.Chain.Genesis
   )
 import Cardano.Chain.Slotting (EpochIndex)
 import Cardano.Crypto
-  ( ProtocolMagic(..)
-  , ProtocolMagicId
+  ( ProtocolMagicId
   , ProxyCert(..)
-  , RequiresNetworkMagic(..)
   , Signature(..)
   , noPassSafeSigner
   , safeCreateProxyCert
@@ -83,13 +81,9 @@ genCanonicalGenesisData pm =
     <*> genGenesisNonAvvmBalances
     <*> genCanonicalProtocolParameters
     <*> genBlockCount'
-    <*> genProtocolMagicUniform
+    <*> genProtocolMagicId
     <*> genGenesisAvvmBalances
  where
-  genProtocolMagicUniform :: Gen ProtocolMagic
-  genProtocolMagicUniform =
-    (ProtocolMagic <$> genProtocolMagicId <*> pure RequiresMagic)
-
   genBlockCount' :: Gen BlockCount
   genBlockCount' = BlockCount <$> (Gen.word64 $ Range.linear 0 1000000000)
 
@@ -109,7 +103,7 @@ genGenesisData pm =
     <*> genGenesisNonAvvmBalances
     <*> genProtocolParameters
     <*> genBlockCount
-    <*> genProtocolMagic
+    <*> genProtocolMagicId
     <*> genGenesisAvvmBalances
 
 genGenesisHash :: Gen GenesisHash

--- a/test/Test/Cardano/Chain/Txp/Validation.hs
+++ b/test/Test/Cardano/Chain/Txp/Validation.hs
@@ -33,7 +33,7 @@ import Cardano.Chain.Genesis (GenesisData(..), readGenesisData)
 import Cardano.Chain.Slotting (SlotId)
 import Cardano.Chain.Txp
   (UTxO, UTxOValidationError, aUnTxPayload, genesisUtxo, updateUTxOWitness)
-import Cardano.Crypto (ProtocolMagicId, getProtocolMagicId)
+import Cardano.Crypto (ProtocolMagicId)
 import Cardano.Mirror (mainnetEpochFiles)
 
 import Test.Options (TestScenario(..))
@@ -53,7 +53,7 @@ tests scenario = do
     <$> runExceptT (readGenesisData "test/mainnet-genesis.json")
 
   -- Extract mainnet 'ProtocolMagic'
-  let pm = getProtocolMagicId $ gdProtocolMagic genesisData
+  let pm = gdProtocolMagicId genesisData
 
   -- Create an 'IORef' containing the genesis 'UTxO'
   utxoRef <- newIORef $ genesisUtxo genesisData


### PR DESCRIPTION
Relates to #385.

I think this is fairly well explained in the two commit messages:
```
    [#385] Revamp ProtocolMagic/Id in Genesis datatypes

    Instead of storing a @ProtocolMagic@ in @Genesis.Data@, and being
    forced to pick a default for the omitted @RequiresNetworkMagic@ field,
    switch to a @ProtocolMagicId@.

    Add a @RequiresNetworkMagic@ field to @Genesis.Config@.

    Leave @GenesisSpec@ the same - use its @ProtocolMagic@ to fill the
    @ProtocolMagicId@ of @Genesis.Data@ and the @RequiresNetworkMagic@
    of @Genesis.Config@.

    This seems to simplify the JSON instances considerably. We will no
    longer be backwards compatible with `cardano-sl`'s configuration,
    but that is ok.
```
and
```
    [#385] Use arbitrary @ProtocolMagic@s in arbitrary instances
```