### PR TITLE
[#385] Introduce & implement NetworkMagic

### DIFF
--- a/cardano-ledger.cabal
+++ b/cardano-ledger.cabal
@@ -54,6 +54,7 @@ library
                        Cardano.Chain.Common.Lovelace
                        Cardano.Chain.Common.LovelacePortion
                        Cardano.Chain.Common.Merkle
+                       Cardano.Chain.Common.NetworkMagic
                        Cardano.Chain.Common.StakeholderId
                        Cardano.Chain.Common.TxFeePolicy
                        Cardano.Chain.Common.TxSizeLinear

--- a/src/Cardano/Chain/Common.hs
+++ b/src/Cardano/Chain/Common.hs
@@ -13,6 +13,7 @@ import Cardano.Chain.Common.ChainDifficulty as X
 import Cardano.Chain.Common.Lovelace as X
 import Cardano.Chain.Common.LovelacePortion as X
 import Cardano.Chain.Common.Merkle as X
+import Cardano.Chain.Common.NetworkMagic as X
 import Cardano.Chain.Common.StakeholderId as X
 import Cardano.Chain.Common.TxFeePolicy as X
 import Cardano.Chain.Common.TxSizeLinear as X

--- a/src/Cardano/Chain/Common/NetworkMagic.hs
+++ b/src/Cardano/Chain/Common/NetworkMagic.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE OverloadedStrings          #-}
+
+module Cardano.Chain.Common.NetworkMagic
+       ( NetworkMagic (..)
+       , makeNetworkMagic
+       ) where
+
+import Cardano.Prelude hiding ((%))
+
+import           Formatting (bprint, build, (%))
+import qualified Formatting.Buildable as B
+
+import           Cardano.Crypto.ProtocolMagic (ProtocolMagic (..),
+                     RequiresNetworkMagic (..), getProtocolMagic)
+
+
+--------------------------------------------------------------------------------
+-- NetworkMagic
+--------------------------------------------------------------------------------
+
+-- Although it doesn't make sense for an identifier to have a sign, we're opting
+-- to maintain consistency with `ProtocolMagicId`, rather than risk subtle
+-- conversion bugs.
+data NetworkMagic
+    = NetworkMainOrStage
+    | NetworkTestnet {-# UNPACK #-} !Int32
+    deriving (Show, Eq, Ord, Generic, NFData)
+
+instance B.Buildable NetworkMagic where
+    build NetworkMainOrStage = "NetworkMainOrStage"
+    build (NetworkTestnet n) = bprint ("NetworkTestnet ("%build%")") n
+
+instance HeapWords NetworkMagic where
+  heapWords NetworkMainOrStage = 0
+  heapWords (NetworkTestnet _) = 2
+
+makeNetworkMagic :: ProtocolMagic -> NetworkMagic
+makeNetworkMagic pm = case getRequiresNetworkMagic pm of
+    RequiresNoMagic -> NetworkMainOrStage
+    RequiresMagic   -> NetworkTestnet (getProtocolMagic pm)

--- a/src/Cardano/Chain/Genesis/Config.hs
+++ b/src/Cardano/Chain/Genesis/Config.hs
@@ -135,8 +135,6 @@ data Config = Config
     -- ^ Secrets needed to access 'GenesisData' in testing
     , configReqNetMagic       :: RequiresNetworkMagic
     -- ^ Differentiates between Testnet and Mainet/Staging
-    --
-    --   TODO: Figure out how to split testing and mainnet needs
     }
 
 configGenesisHeaderHash :: Config -> HeaderHash

--- a/src/Cardano/Chain/Genesis/Generate.hs
+++ b/src/Cardano/Chain/Genesis/Generate.hs
@@ -45,6 +45,7 @@ import Cardano.Chain.Common
   , subLovelace
   , sumLovelace
   )
+import Cardano.Chain.Common.NetworkMagic (makeNetworkMagic)
 import qualified Cardano.Chain.Delegation.Certificate as Delegation
 import Cardano.Chain.Genesis.AvvmBalances (GenesisAvvmBalances(..))
 import Cardano.Chain.Genesis.Data (GenesisData(..))
@@ -165,10 +166,10 @@ generateGenesisData startTime genesisSpec = do
       :: MonadError GenesisDataGenerationError m => PoorSecret -> m Address
     createAddressPoor (PoorEncryptedSecret hdwSk) =
       maybe (throwError GenesisDataGenerationPassPhraseMismatch) (pure . fst)
-        $ deriveFirstHDAddress emptyPassphrase hdwSk
+        $ deriveFirstHDAddress nm emptyPassphrase hdwSk
     createAddressPoor (PoorSecret secret) =
-      pure $ makePubKeyAddress (toPublic secret)
-  let richAddresses = map (makePubKeyAddress . toPublic) richSecrets
+      pure $ makePubKeyAddress nm (toPublic secret)
+  let richAddresses = map (makePubKeyAddress nm . toPublic) richSecrets
 
   poorAddresses        <- mapM createAddressPoor poorSecrets
 
@@ -230,6 +231,7 @@ generateGenesisData startTime genesisSpec = do
   pure (genesisData, generatedSecrets)
  where
   pm          = gsProtocolMagic genesisSpec
+  nm          = makeNetworkMagic pm
   realAvvmBalances = gsAvvmDistr genesisSpec
 
   gi          = gsInitializer genesisSpec

--- a/src/Cardano/Chain/Txp/GenesisUTxO.hs
+++ b/src/Cardano/Chain/Txp/GenesisUTxO.hs
@@ -9,22 +9,30 @@ import Data.Coerce (coerce)
 import qualified Data.Map.Strict as M
 
 import Cardano.Chain.Common (Address, Lovelace, makeRedeemAddress)
+import Cardano.Chain.Common.NetworkMagic (NetworkMagic, makeNetworkMagic)
 import Cardano.Chain.Genesis
   (GenesisData(..), getGenesisAvvmBalances, getGenesisNonAvvmBalances)
+import qualified Cardano.Chain.Genesis as Genesis
 import Cardano.Chain.Txp.Tx (TxIn(..), TxOut(..))
 import Cardano.Chain.Txp.UTxO (UTxO)
 import qualified Cardano.Chain.Txp.UTxO as UTxO
 import Cardano.Crypto (hash)
 
 
-genesisUtxo :: GenesisData -> UTxO
-genesisUtxo genesisData = UTxO.fromList $ utxoEntry <$> preUtxo
+genesisUtxo :: Genesis.Config -> UTxO
+genesisUtxo genesisConfig = UTxO.fromList $ utxoEntry <$> preUtxo
  where
+  genesisData :: GenesisData
+  genesisData = Genesis.configGenesisData genesisConfig
+
+  networkMagic :: NetworkMagic
+  networkMagic = makeNetworkMagic (Genesis.configProtocolMagic genesisConfig)
+
   preUtxo :: [(Address, Lovelace)]
   preUtxo = avvmBalances <> nonAvvmBalances
 
   avvmBalances :: [(Address, Lovelace)]
-  avvmBalances = first makeRedeemAddress
+  avvmBalances = first (makeRedeemAddress networkMagic)
     <$> M.toList (getGenesisAvvmBalances $ gdAvvmDistr genesisData)
 
   nonAvvmBalances :: [(Address, Lovelace)]

--- a/test/Test/Cardano/Chain/Common/Example.hs
+++ b/test/Test/Cardano/Chain/Common/Example.hs
@@ -25,6 +25,7 @@ import Cardano.Chain.Common
   , mkAttributes
   , mkStakeholderId
   )
+import Cardano.Chain.Common (NetworkMagic(..))
 import Cardano.Crypto.HD (HDAddressPayload(..))
 
 import Test.Cardano.Crypto.Bi (getBytes)
@@ -41,23 +42,26 @@ exampleAddrSpendingData_PubKey = PubKeyASD examplePublicKey
 exampleAddress :: Address
 exampleAddress = makeAddress exampleAddrSpendingData_PubKey attrs
  where
-  attrs = AddrAttributes hap
+  attrs = AddrAttributes hap nm
   hap   = Just (HDAddressPayload (getBytes 32 32))
+  nm    = NetworkMainOrStage
 
 exampleAddress1 :: Address
 exampleAddress1 = makeAddress easd attrs
  where
   easd  = PubKeyASD pk
   [pk]  = examplePublicKeys 24 1
-  attrs = AddrAttributes hap
+  attrs = AddrAttributes hap nm
   hap   = Nothing :: Maybe HDAddressPayload
+  nm    = NetworkMainOrStage
 
 exampleAddress2 :: Address
 exampleAddress2 = makeAddress easd attrs
  where
   easd  = RedeemASD exampleRedeemPublicKey
-  attrs = AddrAttributes hap
+  attrs = AddrAttributes hap nm
   hap   = Just (HDAddressPayload (getBytes 15 32))
+  nm    = NetworkMainOrStage
 
 exampleChainDifficulty :: ChainDifficulty
 exampleChainDifficulty = ChainDifficulty 9999

--- a/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/test/Test/Cardano/Chain/Common/Gen.hs
@@ -42,6 +42,7 @@ import Cardano.Chain.Common
   , LovelacePortion(..)
   , MerkleRoot(..)
   , MerkleTree
+  , NetworkMagic(..)
   , StakeholderId
   , TxFeePolicy(..)
   , TxSizeLinear(..)
@@ -59,7 +60,7 @@ import Test.Cardano.Crypto.Gen
 
 
 genAddrAttributes :: Gen AddrAttributes
-genAddrAttributes = AddrAttributes <$> hap
+genAddrAttributes = AddrAttributes <$> hap <*> genNetworkMagic
   where hap = Gen.maybe genHDAddressPayload
 
 genAddress :: Gen Address
@@ -124,6 +125,12 @@ genMerkleTree genA = mkMerkleTree <$> Gen.list (Range.linear 0 10) genA
 -- slow
 genMerkleRoot :: Bi a => Gen a -> Gen (MerkleRoot a)
 genMerkleRoot genA = mtRoot <$> genMerkleTree genA
+
+genNetworkMagic :: Gen NetworkMagic
+genNetworkMagic = Gen.choice
+  [ pure NetworkMainOrStage
+  , NetworkTestnet <$> Gen.int32 Range.constantBounded
+  ]
 
 genScriptVersion :: Gen Word16
 genScriptVersion = Gen.word16 Range.constantBounded

--- a/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -25,7 +25,7 @@ import Data.Time (Day(ModifiedJulianDay), UTCTime(UTCTime))
 
 import qualified Cardano.Binary.Class as Binary
 import qualified Cardano.Crypto.Hashing as H
-import Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic(..))
+import Cardano.Crypto.ProtocolMagic (ProtocolMagic(..))
 
 import qualified Cardano.Chain.Block as Concrete
 import qualified Cardano.Chain.Common as Common
@@ -54,7 +54,6 @@ import Cardano.Chain.Common
 
 import Test.Cardano.Chain.Elaboration.Keys
   (elaborateKeyPair, elaborateVKeyGenesis, vKeyPair)
-import Test.Cardano.Crypto.Dummy (dummyProtocolMagicId)
 import Test.Cardano.Chain.Elaboration.Delegation (elaborateDCert)
 
 -- | Elaborate an abstract block into a concrete block (without annotations).
@@ -184,9 +183,11 @@ rcDCert vk ast = mkDCert vkg sigVkg vk (ast ^. epochL)
 --  | Make a genesis configuration from an initial abstract environment of the
 --  | trace.
 --
-abEnvToCfg :: Transition.Environment CHAIN -> Genesis.Config
-abEnvToCfg (_, vkgs, pps) = Genesis.Config genesisData genesisHash Nothing RequiresNoMagic
+abEnvToCfg :: ProtocolMagic -> Transition.Environment CHAIN -> Genesis.Config
+abEnvToCfg pm (_, vkgs, pps) = Genesis.Config genesisData genesisHash Nothing rnm
  where
+  rnm = getRequiresNetworkMagic pm
+
   genesisData = Genesis.GenesisData
     { Genesis.gdBootStakeholders = Genesis.GenesisWStakeholders
       genesisStakeHolders
@@ -199,7 +200,7 @@ abEnvToCfg (_, vkgs, pps) = Genesis.Config genesisData genesisHash Nothing Requi
         -- an abstract protocol parameter for k. Then we need to solve the
         -- problem that in the concrete implementation k and w are the same.
                             BlockCount (fromIntegral $ pps ^. bkSgnCntW)
-    , Genesis.gdProtocolMagicId = dummyProtocolMagicId
+    , Genesis.gdProtocolMagicId = getProtocolMagicId pm
     , Genesis.gdAvvmDistr = Genesis.GenesisAvvmBalances []
     }
 

--- a/test/Test/Cardano/Chain/Txp/Example.hs
+++ b/test/Test/Cardano/Chain/Txp/Example.hs
@@ -29,7 +29,13 @@ import Data.Maybe (fromJust)
 import qualified Data.Vector as V
 
 import Cardano.Chain.Common
-  (makePubKeyAddress, mkAttributes, mkKnownLovelace, mkMerkleTree, mtRoot)
+  ( NetworkMagic(..)
+  , makePubKeyAddress
+  , mkAttributes
+  , mkKnownLovelace
+  , mkMerkleTree
+  , mtRoot
+  )
 import Cardano.Chain.Txp
   ( Tx(..)
   , TxAux
@@ -79,7 +85,8 @@ exampleTxInUtxo :: TxIn
 exampleTxInUtxo = TxInUtxo exampleHashTx 47 -- TODO: loop here
 
 exampleTxOut :: TxOut
-exampleTxOut = TxOut (makePubKeyAddress pkey) (mkKnownLovelace @47)
+exampleTxOut = TxOut (makePubKeyAddress NetworkMainOrStage pkey)
+                     (mkKnownLovelace @47)
   where Right pkey = PublicKey <$> CC.xpub (getBytes 0 64)
 
 exampleTxOutList :: (NonEmpty TxOut)


### PR DESCRIPTION
NetworkMagic allows us to differentiate between Addresses which
come from different networks. This prevents users from accidentally
sending funds from a mainnet wallet to a testnet address, which would
technically be a valid address on mainnet, but would be controlled by
unknown keys not under the user's control (thus rendering the funds
unusable). When addresses are created, the @ProtocolMagicId@ of the
machine is inserted into the @NetworkMagic@, which is added to the
@Address@ datatype.

In this commit I introduce NetworkMagic, wire it up to @ProtocolMagic@
in the configuration, and modify functions so that @NetworkMagic@ can
be passed down to both address creation and transaction validation. I
add a new constructor to @TxValidationError@
- `TxValidationNetworkMagicMismatch` - which is thrown when we
encounter a @NetworkMagic@ coming from an address which doesn't match
our cluster's @NetworkMagic@.

Relates to #385.