### PR TITLE
Make slot numbers absolute

### DIFF
--- a/.stack-to-nix.cache
+++ b/.stack-to-nix.cache
@@ -10,3 +10,5 @@ https://github.com/well-typed/cborg 80fbe0ee5e67a5622e2cb9eaa9d8594a2214322d cbo
 https://github.com/input-output-hk/cardano-crypto 3c707936ba0a665375acf5bd240dc4b6eaa6c0bc . 0g8ln8k8wx4csdv92bz09pr7v9dp4lcyv1334b09c9rgwdwhqg1b cardano-crypto cardano-crypto.nix
 https://github.com/hedgehogqa/haskell-hedgehog 2505055760d06ba6343f803783ed023fb0ed6c48 hedgehog 0m29y881kbqvs12vjcbaaqrpbqbc2rvg3ffwx5wfaymbn1djyz9q hedgehog hedgehog.nix
 http://github.com/nc6/canonical-json a9dc9b893649bc2e2a770ab22d278a780f7e3a3c . 0alwbi9xqaj6fmwzs6lr2drqrnhlnp13d9k2qkl5ga7h4grz9zcr canonical-json canonical-json.nix
+https://github.com/input-output-hk/cardano-base c719857de4a2f18fa13bc5cdb85d74ae3841f50f binary 1p2g026xxc60xiqw7891cry2lwzjavbzdqbqx9mk7x7wlhcsb6jv cardano-binary cardano-binary.nix
+https://github.com/input-output-hk/cardano-base c719857de4a2f18fa13bc5cdb85d74ae3841f50f binary/test 1p2g026xxc60xiqw7891cry2lwzjavbzdqbqx9mk7x7wlhcsb6jv cardano-binary-test cardano-binary-test.nix

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -41,8 +41,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "2f33cbf9101dfee1cb488271ec96e210329eec96";
-      sha256 = "0ar9pwf1ibbla60pns6dqcmc6wc705j4nqfd6752xbij8ra144mi";
+      rev = "c719857de4a2f18fa13bc5cdb85d74ae3841f50f";
+      sha256 = "1p2g026xxc60xiqw7891cry2lwzjavbzdqbqx9mk7x7wlhcsb6jv";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -63,8 +63,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "2f33cbf9101dfee1cb488271ec96e210329eec96";
-      sha256 = "0ar9pwf1ibbla60pns6dqcmc6wc705j4nqfd6752xbij8ra144mi";
+      rev = "c719857de4a2f18fa13bc5cdb85d74ae3841f50f";
+      sha256 = "1p2g026xxc60xiqw7891cry2lwzjavbzdqbqx9mk7x7wlhcsb6jv";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/src/Cardano/Chain/Block/Validation.hs
+++ b/src/Cardano/Chain/Block/Validation.hs
@@ -55,12 +55,10 @@ import Cardano.Chain.Genesis as Genesis
   ( Config(..)
   , GenesisWStakeholders(..)
   , configBootStakeholders
-  , configEpochSlots
   , configGenesisHeaderHash
   , configK
   , configSlotSecurityParam
   )
-import Cardano.Chain.Slotting (flattenSlotId)
 import Cardano.Crypto
   ( PublicKey
   , hash
@@ -248,7 +246,7 @@ updateBody config cvs b = do
   pure $ cvs
     {cvsDelegationState = delegationState'}
  where
-  slot = flattenSlotId (configEpochSlots config) $ blockSlot b
+  slot = blockSlot b
   d    = configSlotSecurityParam config
 
   delegationState = cvsDelegationState cvs

--- a/src/Cardano/Chain/Slotting/EpochSlots.hs
+++ b/src/Cardano/Chain/Slotting/EpochSlots.hs
@@ -5,6 +5,7 @@
 
 module Cardano.Chain.Slotting.EpochSlots
   ( EpochSlots(..)
+  , WithEpochSlots (..)
   )
 where
 
@@ -26,3 +27,10 @@ instance Bi EpochSlots where
   decode = EpochSlots <$> decode
 
 deriving instance ToJSON EpochSlots
+
+-- | Data with an accompanying slots per epoch context.
+data WithEpochSlots a = WithEpochSlots
+  { epochSlots       :: EpochSlots
+  , unWithEpochSlots :: a
+  }
+  deriving (Show, Eq)

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,7 +14,7 @@ extra-deps:
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 2f33cbf9101dfee1cb488271ec96e210329eec96
+    commit: c719857de4a2f18fa13bc5cdb85d74ae3841f50f
     subdirs:
       - binary
       - binary/test

--- a/test/Test/Cardano/Chain/Config.hs
+++ b/test/Test/Cardano/Chain/Config.hs
@@ -2,6 +2,7 @@
 
 module Test.Cardano.Chain.Config
   ( readMainetCfg
+  , mainnetEpochSlots
   )
 where
 
@@ -9,6 +10,7 @@ import Cardano.Prelude
 
 import qualified Cardano.Chain.Genesis as Genesis
 import Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic(..))
+import Cardano.Chain.Slotting (EpochSlots(EpochSlots))
 
 -- | Read the test mainnet configuration file from the @test@ directory.
 --
@@ -23,3 +25,9 @@ readMainetCfg =
       identity
     <$> runExceptT
           (Genesis.mkConfigFromFile RequiresNoMagic "test/mainnet-genesis.json" Nothing)
+
+-- | Slots per epoch used in mainnet
+--
+-- This number has been fixed throughout the Byron era.
+mainnetEpochSlots :: EpochSlots
+mainnetEpochSlots = EpochSlots 21600

--- a/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -41,7 +41,7 @@ import Cardano.Spec.Chain.STS.Rule.Chain (CHAIN, disL, epochL)
 import qualified Cardano.Spec.Chain.STS.Block as Abstract
 import qualified Ledger.Core as Abstract
 import Ledger.Delegation (DCert, delegationMap, delegatorOf, mkDCert)
-import Ledger.Update (bkSgnCntW, bkSlotsPerEpoch, maxBkSz, maxHdrSz)
+import Ledger.Update (bkSgnCntW, bkSlotsPerEpoch, maxBkSz, maxHdrSz, PParams)
 import Cardano.Chain.Common
   ( BlockCount(BlockCount)
   , ChainDifficulty(ChainDifficulty)
@@ -75,6 +75,7 @@ elaborate config (_, _, pps) ast st ab = Concrete.ABlock
     (Genesis.configProtocolMagicId config)
     prevHash
     (ChainDifficulty 0)
+    (ppsEpochSlots pps)
     sid
     ssk
     cDCert
@@ -101,8 +102,9 @@ elaborate config (_, _, pps) ast st ab = Concrete.ABlock
     (Concrete.cvsPreviousHash st)
 
   sid =
-    Slotting.unflattenSlotId (coerce (pps ^. bkSlotsPerEpoch))
-      $ Slotting.FlatSlotId
+--    Slotting.unflattenSlotId (coerce (pps ^. bkSlotsPerEpoch))
+--      $
+      Slotting.FlatSlotId
           (ab ^. Abstract.bHeader . Abstract.bSlot . to Abstract.unSlot)
 
   issuer   = ab ^. Abstract.bHeader . Abstract.bIssuer
@@ -125,6 +127,11 @@ elaborate config (_, _, pps) ast st ab = Concrete.ABlock
             (elaborateDCert config)
           )
 
+ppsEpochSlots :: PParams -> Slotting.EpochSlots
+ppsEpochSlots pps = Slotting.EpochSlots epochSlots
+  where
+    Abstract.SlotCount epochSlots = pps ^. bkSlotsPerEpoch
+
 elaborateBS
   :: Genesis.Config -- TODO: Do we want this to come from the abstract
                     -- environment? (in such case we wouldn't need this
@@ -134,15 +141,17 @@ elaborateBS
   -> Concrete.ChainValidationState
   -> Abstract.Block
   -> Concrete.ABlock ByteString
-elaborateBS config aenv ast st ab =
-  annotateBlock $ elaborate config aenv ast st ab
+elaborateBS config aenv ast@(_, _, _, _, _, pps) st ab =
+  annotateBlock (ppsEpochSlots pps) $ elaborate config aenv ast st ab
 
-annotateBlock :: Concrete.Block -> Concrete.ABlock ByteString
-annotateBlock block =
+annotateBlock :: Slotting.EpochSlots -> Concrete.Block -> Concrete.ABlock ByteString
+annotateBlock epochSlots block =
   let
     decodedABlockOrBoundary =
       case
-          Binary.decodeFullDecoder "Block" Concrete.decodeABlockOrBoundary bytes
+          Binary.decodeFullDecoder
+            "Block"
+            (Concrete.decodeABlockOrBoundary epochSlots) bytes
         of
           Left err ->
             panic
@@ -155,7 +164,7 @@ annotateBlock block =
       Concrete.ABOBBlock bk -> bk
       Concrete.ABOBBoundary _ ->
         panic "This function should have decoded a block."
-  where bytes = Binary.serializeEncoding (Concrete.encodeBlock block)
+  where bytes = Binary.serializeEncoding (Concrete.encodeBlock epochSlots block)
 
 -- | Re-construct an abstract delegation certificate from the abstract state.
 --

--- a/test/Test/Cardano/Chain/Epoch/File.hs
+++ b/test/Test/Cardano/Chain/Epoch/File.hs
@@ -16,6 +16,7 @@ import qualified Streaming as S
 import Cardano.Chain.Epoch.File (ParseError, parseEpochFiles)
 import Cardano.Mirror (mainnetEpochFiles)
 
+import Test.Cardano.Chain.Config (mainnetEpochSlots)
 
 tests :: IO Bool
 tests = H.checkSequential $$(H.discoverPrefix "prop")
@@ -24,7 +25,11 @@ propDeserializeEpochs :: Property
 propDeserializeEpochs = H.withTests 1 $ H.property $ do
   files <- take 10 <$> liftIO mainnetEpochFiles
   H.assert $ not (null files)
-  let stream = parseEpochFiles files
+  -- TODO: the property cannot take any parameters (if we want discoverPrefix
+  -- to work). Now the question is whether it is OK to use an hardcoded value
+  -- for the number of slots per epoch, and if so in which module should we
+  -- store this constant?
+  let stream = parseEpochFiles mainnetEpochSlots files
   result <- (liftIO . runResourceT . runExceptT . S.run) (S.maps discard stream)
   result === Right ()
  where

--- a/test/Test/Cardano/Chain/Slotting/Example.hs
+++ b/test/Test/Cardano/Chain/Slotting/Example.hs
@@ -3,6 +3,7 @@
 module Test.Cardano.Chain.Slotting.Example
   ( exampleEpochIndex
   , exampleSlotId
+  , exampleFlatSlotId
   , exampleSlottingData
   )
 where
@@ -17,8 +18,10 @@ import Cardano.Chain.Slotting
   , EpochSlots(..)
   , SlotId(..)
   , SlottingData
+  , FlatSlotId
   , mkLocalSlotIndex
   , mkSlottingData
+  , flattenSlotId
   )
 
 
@@ -29,9 +32,13 @@ exampleEpochSlottingData :: EpochSlottingData
 exampleEpochSlottingData =
   EpochSlottingData {esdSlotDuration = 100e-6, esdStartDiff = 100e-6}
 
-exampleSlotId :: SlotId
-exampleSlotId = SlotId (EpochIndex 11) lsi
-  where Right lsi = mkLocalSlotIndex (EpochSlots 50) 47
+exampleFlatSlotId :: EpochSlots -> FlatSlotId
+exampleFlatSlotId es =
+  flattenSlotId es (exampleSlotId es)
+
+exampleSlotId :: EpochSlots -> SlotId
+exampleSlotId es = SlotId (EpochIndex 11) lsi
+  where Right lsi = mkLocalSlotIndex es 47
 
 exampleSlottingData :: SlottingData
 exampleSlottingData = slottingData


### PR DESCRIPTION
This is part of #170. In particular this addresses the following sub-task:

> Identify all the places in which a translation from `SlotId` to `FlatSlotId` is needed, so that the use of `SlotId` can be restricted to the block serialization and de-serialization. Note that we use old names here since renaming will/should take place at a later stage.

At first at thought about creating a draft PR, but since I had to rebase twice today, I'd like to speed up the integration of this to master, provided that what I did makes sense.

Closes #169 .