### PR TITLE
Add compact data types to be used in optimizing UTxO

### DIFF
--- a/cardano-ledger.cabal
+++ b/cardano-ledger.cabal
@@ -51,6 +51,7 @@ library
                        Cardano.Chain.Common.Attributes
                        Cardano.Chain.Common.BlockCount
                        Cardano.Chain.Common.ChainDifficulty
+                       Cardano.Chain.Common.Compact
                        Cardano.Chain.Common.Lovelace
                        Cardano.Chain.Common.LovelacePortion
                        Cardano.Chain.Common.Merkle
@@ -81,6 +82,7 @@ library
                        Cardano.Chain.Slotting.LocalSlotIndex
                        Cardano.Chain.Slotting.SlotId
 
+                       Cardano.Chain.Txp.Compact
                        Cardano.Chain.Txp.GenesisUTxO
                        Cardano.Chain.Txp.Tx
                        Cardano.Chain.Txp.TxAux

--- a/cardano-ledger.cabal
+++ b/cardano-ledger.cabal
@@ -169,6 +169,7 @@ test-suite cardano-ledger-test
                        Test.Cardano.Chain.Block.Validation.Spec
 
                        Test.Cardano.Chain.Common.Address
+                       Test.Cardano.Chain.Common.Compact
                        Test.Cardano.Chain.Common.Example
                        Test.Cardano.Chain.Common.Gen
                        Test.Cardano.Chain.Common.Lovelace
@@ -196,6 +197,7 @@ test-suite cardano-ledger-test
                        Test.Cardano.Chain.Slotting.Properties
 
                        Test.Cardano.Chain.Txp.Bi
+                       Test.Cardano.Chain.Txp.Compact
                        Test.Cardano.Chain.Txp.Example
                        Test.Cardano.Chain.Txp.Gen
                        Test.Cardano.Chain.Txp.Json

--- a/src/Cardano/Chain/Common.hs
+++ b/src/Cardano/Chain/Common.hs
@@ -10,6 +10,7 @@ import Cardano.Chain.Common.AddrSpendingData as X
 import Cardano.Chain.Common.Attributes as X
 import Cardano.Chain.Common.BlockCount as X
 import Cardano.Chain.Common.ChainDifficulty as X
+import Cardano.Chain.Common.Compact as X
 import Cardano.Chain.Common.Lovelace as X
 import Cardano.Chain.Common.LovelacePortion as X
 import Cardano.Chain.Common.Merkle as X

--- a/src/Cardano/Chain/Common/Compact.hs
+++ b/src/Cardano/Chain/Common/Compact.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+
+module Cardano.Chain.Common.Compact
+  ( CompactAddress
+  , toCompactAddress
+  , fromCompactAddress
+  )
+where
+
+import Cardano.Prelude
+
+import Cardano.Binary.Class (serialize', decodeFull')
+import qualified Data.ByteString.Short as BSS (fromShort, toShort)
+import Data.ByteString.Short (ShortByteString)
+
+import Cardano.Chain.Common.Address (Address(..))
+
+--------------------------------------------------------------------------------
+-- Compact Address
+--------------------------------------------------------------------------------
+
+-- | A compact in-memory representation for an 'Address'.
+--
+-- Convert using 'toCompactAddress' and 'fromCompactAddress'.
+--
+newtype CompactAddress = CompactAddress ShortByteString
+  deriving (Eq, Ord, Generic, Show)
+  deriving newtype HeapWords
+  deriving anyclass NFData
+
+toCompactAddress :: Address -> CompactAddress
+toCompactAddress addr =
+  CompactAddress (BSS.toShort (serialize' addr))
+
+fromCompactAddress :: CompactAddress -> Address
+fromCompactAddress (CompactAddress addr) =
+  case decodeFull' (BSS.fromShort addr) of
+    Left err      -> panic ("fromCompactAddress: impossible: " <> show err)
+    Right decAddr -> decAddr

--- a/src/Cardano/Chain/Txp.hs
+++ b/src/Cardano/Chain/Txp.hs
@@ -3,6 +3,7 @@ module Cardano.Chain.Txp
   )
 where
 
+import Cardano.Chain.Txp.Compact as X
 import Cardano.Chain.Txp.GenesisUTxO as X
 import Cardano.Chain.Txp.Tx as X
 import Cardano.Chain.Txp.TxAux as X

--- a/src/Cardano/Chain/Txp/Compact.hs
+++ b/src/Cardano/Chain/Txp/Compact.hs
@@ -1,0 +1,143 @@
+-- | The UTxO is large and is kept in-memory. It is important to use as
+-- small a representation as possible to keep overall memory use reasonable.
+--
+-- This module provides a special compact representation for data types
+-- contained within the UTxO.
+--
+-- The idea here is that the compact representation is optimised only for
+-- storage size and does not have to be the same as the representation used
+-- when operating on the data. Conversion functions are to be used when
+-- inserting and retrieving values from the UTxO.
+--
+
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+
+module Cardano.Chain.Txp.Compact
+  ( CompactTxIn
+  , toCompactTxIn
+  , fromCompactTxIn
+
+  , CompactTxId
+  , toCompactTxId
+  , fromCompactTxId
+
+  , CompactTxOut
+  , toCompactTxOut
+  , fromCompactTxOut
+  )
+where
+
+import Cardano.Prelude
+
+import Crypto.Hash (digestFromByteString)
+import Cardano.Crypto.Hashing (AbstractHash (..))
+import Data.Binary.Get (Get, getWord64le, runGet)
+import Data.Binary.Put (Put, putWord64le, runPut)
+import qualified Data.ByteArray as BA (convert)
+import qualified Data.ByteString.Lazy as BSL (fromStrict, toStrict)
+
+import Cardano.Chain.Common.Compact
+  ( CompactAddress
+  , fromCompactAddress
+  , toCompactAddress
+  )
+import Cardano.Chain.Common.Lovelace (Lovelace)
+import Cardano.Chain.Txp.Tx (TxId, TxIn (..), TxOut (..))
+
+--------------------------------------------------------------------------------
+-- Compact TxIn
+--------------------------------------------------------------------------------
+
+-- | A compact in-memory representation for a 'TxIn'.
+--
+-- Convert using 'toCompactTxIn' and 'fromCompactTxIn'.
+--
+data CompactTxIn = CompactTxInUtxo {-# UNPACK #-} !CompactTxId
+                                   {-# UNPACK #-} !Word32
+  deriving (Eq, Ord, Generic, Show)
+  deriving anyclass NFData
+
+instance HeapWords CompactTxIn where
+  heapWords _ = 6
+
+toCompactTxIn :: TxIn -> CompactTxIn
+toCompactTxIn (TxInUtxo txId txIndex) =
+  CompactTxInUtxo (toCompactTxId txId) txIndex
+
+fromCompactTxIn :: CompactTxIn -> TxIn
+fromCompactTxIn (CompactTxInUtxo compactTxId txIndex) =
+  TxInUtxo (fromCompactTxId compactTxId) txIndex
+
+--------------------------------------------------------------------------------
+-- Compact TxId
+--------------------------------------------------------------------------------
+
+-- | A compact in-memory representation for a 'TxId'.
+--
+-- Convert using 'toCompactTxId' and 'fromCompactTxId'.
+--
+-- Compared to a normal 'TxId', this takes 5 heap words rather than 12.
+--
+data CompactTxId = CompactTxId {-# UNPACK #-} !Word64
+                               {-# UNPACK #-} !Word64
+                               {-# UNPACK #-} !Word64
+                               {-# UNPACK #-} !Word64
+  deriving (Eq, Generic, Ord, Show)
+  deriving anyclass NFData
+
+instance HeapWords CompactTxId where
+  heapWords _ = 5
+
+getCompactTxId :: Get CompactTxId
+getCompactTxId =
+  CompactTxId <$> getWord64le
+              <*> getWord64le
+              <*> getWord64le
+              <*> getWord64le
+
+putCompactTxId :: CompactTxId -> Put
+putCompactTxId (CompactTxId a b c d) =
+  putWord64le a >> putWord64le b
+                >> putWord64le c
+                >> putWord64le d
+
+toCompactTxId :: TxId -> CompactTxId
+toCompactTxId txId =
+  let bs = BA.convert txId :: ByteString
+  in runGet getCompactTxId (BSL.fromStrict bs)
+
+fromCompactTxId :: CompactTxId -> TxId
+fromCompactTxId compactTxId =
+  let bs = BSL.toStrict $ runPut (putCompactTxId compactTxId)
+  in case digestFromByteString bs of
+    Just d  -> AbstractHash d
+    Nothing -> panic "fromCompactTxId: impossible: failed to reconstruct TxId from CompactTxId"
+
+--------------------------------------------------------------------------------
+-- Compact TxOut
+--------------------------------------------------------------------------------
+
+-- | A compact in-memory representation for a 'TxOut'.
+--
+-- Convert using 'toCompactTxOut' and 'fromCompactTxOut'.
+--
+data CompactTxOut = CompactTxOut {-# UNPACK #-} !CompactAddress
+                                 {-# UNPACK #-} !Lovelace
+  deriving (Eq, Ord, Generic, Show)
+  deriving anyclass NFData
+
+instance HeapWords CompactTxOut where
+  heapWords (CompactTxOut compactAddr _) =
+    3 + heapWordsUnpacked compactAddr
+
+toCompactTxOut :: TxOut -> CompactTxOut
+toCompactTxOut (TxOut addr lovelace) =
+  CompactTxOut (toCompactAddress addr) lovelace
+
+fromCompactTxOut :: CompactTxOut -> TxOut
+fromCompactTxOut (CompactTxOut compactAddr lovelace) =
+  TxOut (fromCompactAddress compactAddr) lovelace

--- a/src/Cardano/Chain/Txp/Compact.hs
+++ b/src/Cardano/Chain/Txp/Compact.hs
@@ -34,19 +34,16 @@ where
 import Cardano.Prelude
 
 import Crypto.Hash (digestFromByteString)
-import Cardano.Crypto.Hashing (AbstractHash (..))
+import Cardano.Crypto.Hashing (AbstractHash(..))
 import Data.Binary.Get (Get, getWord64le, runGet)
 import Data.Binary.Put (Put, putWord64le, runPut)
 import qualified Data.ByteArray as BA (convert)
 import qualified Data.ByteString.Lazy as BSL (fromStrict, toStrict)
 
 import Cardano.Chain.Common.Compact
-  ( CompactAddress
-  , fromCompactAddress
-  , toCompactAddress
-  )
+  (CompactAddress, fromCompactAddress, toCompactAddress)
 import Cardano.Chain.Common.Lovelace (Lovelace)
-import Cardano.Chain.Txp.Tx (TxId, TxIn (..), TxOut (..))
+import Cardano.Chain.Txp.Tx (TxId, TxIn(..), TxOut(..))
 
 --------------------------------------------------------------------------------
 -- Compact TxIn

--- a/test/Test/Cardano/Chain/Common/Compact.hs
+++ b/test/Test/Cardano/Chain/Common/Compact.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Test.Cardano.Chain.Common.Compact
+  ( tests
+  )
+where
+
+import Cardano.Prelude
+
+import Hedgehog (Property)
+import qualified Hedgehog as H
+import Hedgehog (MonadTest, tripping)
+
+import Cardano.Chain.Common
+  ( fromCompactAddress
+  , toCompactAddress
+  )
+
+import Test.Cardano.Chain.Common.Gen (genAddress)
+import Test.Cardano.Prelude
+  ( discoverGolden
+  , discoverRoundTrip
+  , eachOf
+  )
+
+--------------------------------------------------------------------------------
+-- Compact Address
+--------------------------------------------------------------------------------
+
+roundTripCompactAddress :: Property
+roundTripCompactAddress =
+  eachOf 1000 genAddress (trippingCompact toCompactAddress fromCompactAddress)
+
+-------------------------------------------------------------------------------
+-- Tripping util
+-------------------------------------------------------------------------------
+
+trippingCompact
+  :: (HasCallStack, MonadTest m, Show a, Show b, Eq a)
+  => (a -> b) -> (b -> a) -> a -> m ()
+trippingCompact toCompact fromCompact x =
+  tripping x toCompact (Identity . fromCompact)
+
+-------------------------------------------------------------------------------
+-- Main test export
+-------------------------------------------------------------------------------
+
+tests :: IO Bool
+tests = (&&) <$> H.checkSequential $$discoverGolden <*> H.checkParallel
+  $$discoverRoundTrip

--- a/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/test/Test/Cardano/Chain/Common/Gen.hs
@@ -12,6 +12,7 @@ module Test.Cardano.Chain.Common.Gen
   , genBlockCount
   , genCanonicalTxFeePolicy
   , genChainDifficulty
+  , genCompactAddress
   , genCustomLovelace
   , genLovelace
   , genLovelacePortion
@@ -41,6 +42,7 @@ import Cardano.Chain.Common
   , Address(..)
   , BlockCount(..)
   , ChainDifficulty(..)
+  , CompactAddress
   , Lovelace
   , LovelacePortion(..)
   , MerkleRoot(..)
@@ -56,6 +58,7 @@ import Cardano.Chain.Common
   , mkMerkleTree
   , mkStakeholderId
   , mtRoot
+  , toCompactAddress
   )
 
 import Test.Cardano.Crypto.Gen
@@ -110,6 +113,9 @@ genCanonicalTxSizeLinear = TxSizeLinear <$> genLovelace' <*> genLovelace'
 
 genChainDifficulty :: Gen ChainDifficulty
 genChainDifficulty = ChainDifficulty <$> Gen.word64 Range.constantBounded
+
+genCompactAddress :: Gen CompactAddress
+genCompactAddress = toCompactAddress <$> genAddress
 
 genCustomLovelace :: Word64 -> Gen Lovelace
 genCustomLovelace size =

--- a/test/Test/Cardano/Chain/Txp/Compact.hs
+++ b/test/Test/Cardano/Chain/Txp/Compact.hs
@@ -9,7 +9,17 @@ where
 
 import Cardano.Prelude
 
-import Hedgehog (MonadTest, Property, tripping)
+import Hedgehog
+  ( Property
+  , MonadTest
+  , assert
+  , property
+  , discover
+  , withTests
+  , forAll
+  , property
+  , tripping
+  )
 import qualified Hedgehog as H
 
 import Cardano.Chain.Txp
@@ -27,8 +37,7 @@ import Test.Cardano.Chain.Txp.Gen
   , genTxOut
   )
 import Test.Cardano.Prelude
-  ( discoverGolden
-  , discoverRoundTrip
+  ( discoverRoundTrip
   , eachOf
   )
 
@@ -40,6 +49,12 @@ roundTripCompactTxIn :: Property
 roundTripCompactTxIn =
   eachOf 1000 genTxIn (trippingCompact toCompactTxIn fromCompactTxIn)
 
+prop_heapWordsSavingsCompactTxIn :: Property
+prop_heapWordsSavingsCompactTxIn = withTests 1000 $ property $ do
+  txIn <- forAll genTxIn
+  let compactTxIn = toCompactTxIn txIn
+  assert $ heapWords compactTxIn < heapWords txIn
+
 --------------------------------------------------------------------------------
 -- Compact TxId
 --------------------------------------------------------------------------------
@@ -48,6 +63,12 @@ roundTripCompactTxId :: Property
 roundTripCompactTxId =
   eachOf 1000 genTxId (trippingCompact toCompactTxId fromCompactTxId)
 
+prop_heapWordsSavingsCompactTxId :: Property
+prop_heapWordsSavingsCompactTxId = withTests 1000 $ property $ do
+  txId <- forAll genTxId
+  let compactTxId = toCompactTxId txId
+  assert $ heapWords compactTxId < heapWords txId
+
 --------------------------------------------------------------------------------
 -- Compact TxOut
 --------------------------------------------------------------------------------
@@ -55,6 +76,12 @@ roundTripCompactTxId =
 roundTripCompactTxOut :: Property
 roundTripCompactTxOut =
   eachOf 1000 genTxOut (trippingCompact toCompactTxOut fromCompactTxOut)
+
+prop_heapWordsSavingsCompactTxOut :: Property
+prop_heapWordsSavingsCompactTxOut = withTests 1000 $ property $ do
+  txOut <- forAll genTxOut
+  let compactTxOut = toCompactTxOut txOut
+  assert $ heapWords compactTxOut < heapWords txOut
 
 -------------------------------------------------------------------------------
 -- Tripping util
@@ -71,5 +98,5 @@ trippingCompact toCompact fromCompact x =
 -------------------------------------------------------------------------------
 
 tests :: IO Bool
-tests = (&&) <$> H.checkSequential $$discoverGolden <*> H.checkParallel
+tests = (&&) <$> H.checkParallel $$discover <*> H.checkParallel
   $$discoverRoundTrip

--- a/test/Test/Cardano/Chain/Txp/Compact.hs
+++ b/test/Test/Cardano/Chain/Txp/Compact.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Test.Cardano.Chain.Txp.Compact
+  ( tests
+  )
+where
+
+import Cardano.Prelude
+
+import Hedgehog (MonadTest, Property, tripping)
+import qualified Hedgehog as H
+
+import Cardano.Chain.Txp
+  ( fromCompactTxId
+  , toCompactTxId
+  , fromCompactTxIn
+  , toCompactTxIn
+  , fromCompactTxOut
+  , toCompactTxOut
+  )
+
+import Test.Cardano.Chain.Txp.Gen
+  ( genTxId
+  , genTxIn
+  , genTxOut
+  )
+import Test.Cardano.Prelude
+  ( discoverGolden
+  , discoverRoundTrip
+  , eachOf
+  )
+
+--------------------------------------------------------------------------------
+-- Compact TxIn
+--------------------------------------------------------------------------------
+
+roundTripCompactTxIn :: Property
+roundTripCompactTxIn =
+  eachOf 1000 genTxIn (trippingCompact toCompactTxIn fromCompactTxIn)
+
+--------------------------------------------------------------------------------
+-- Compact TxId
+--------------------------------------------------------------------------------
+
+roundTripCompactTxId :: Property
+roundTripCompactTxId =
+  eachOf 1000 genTxId (trippingCompact toCompactTxId fromCompactTxId)
+
+--------------------------------------------------------------------------------
+-- Compact TxOut
+--------------------------------------------------------------------------------
+
+roundTripCompactTxOut :: Property
+roundTripCompactTxOut =
+  eachOf 1000 genTxOut (trippingCompact toCompactTxOut fromCompactTxOut)
+
+-------------------------------------------------------------------------------
+-- Tripping util
+-------------------------------------------------------------------------------
+
+trippingCompact
+  :: (HasCallStack, MonadTest m, Show a, Show b, Eq a)
+  => (a -> b) -> (b -> a) -> a -> m ()
+trippingCompact toCompact fromCompact x =
+  tripping x toCompact (Identity . fromCompact)
+
+-------------------------------------------------------------------------------
+-- Main test export
+-------------------------------------------------------------------------------
+
+tests :: IO Bool
+tests = (&&) <$> H.checkSequential $$discoverGolden <*> H.checkParallel
+  $$discoverRoundTrip

--- a/test/Test/Cardano/Chain/Txp/Gen.hs
+++ b/test/Test/Cardano/Chain/Txp/Gen.hs
@@ -1,5 +1,8 @@
 module Test.Cardano.Chain.Txp.Gen
-  ( genPkWitness
+  ( genCompactTxId
+  , genCompactTxIn
+  , genCompactTxOut
+  , genPkWitness
   , genRedeemWitness
   , genTx
   , genTxAttributes
@@ -37,7 +40,10 @@ import qualified Hedgehog.Range as Range
 
 import Cardano.Chain.Common (mkAttributes)
 import Cardano.Chain.Txp
-  ( Tx(..)
+  ( CompactTxId
+  , CompactTxIn
+  , CompactTxOut
+  , Tx(..)
   , TxAttributes
   , TxAux
   , TxId
@@ -55,6 +61,9 @@ import Cardano.Chain.Txp
   , TxpUndo
   , mkTxAux
   , mkTxPayload
+  , toCompactTxId
+  , toCompactTxIn
+  , toCompactTxOut
   )
 import Cardano.Crypto (Hash, ProtocolMagicId, decodeHash, sign)
 
@@ -69,6 +78,14 @@ import Test.Cardano.Crypto.Gen
   , genTextHash
   )
 
+genCompactTxId :: Gen CompactTxId
+genCompactTxId = toCompactTxId <$> genTxId
+
+genCompactTxIn :: Gen CompactTxIn
+genCompactTxIn = toCompactTxIn <$> genTxIn
+
+genCompactTxOut :: Gen CompactTxOut
+genCompactTxOut = toCompactTxOut <$> genTxOut
 
 genPkWitness :: ProtocolMagicId -> Gen TxInWitness
 genPkWitness pm = PkWitness <$> genPublicKey <*> genTxSig pm

--- a/test/cardano-ledger-test.cabal
+++ b/test/cardano-ledger-test.cabal
@@ -21,6 +21,7 @@ library
                        Test.Cardano.Chain.Block.Bi
                        Test.Cardano.Chain.Block.Gen
                        Test.Cardano.Chain.Common.Address
+                       Test.Cardano.Chain.Common.Compact
                        Test.Cardano.Chain.Common.Example
                        Test.Cardano.Chain.Common.Gen
                        Test.Cardano.Chain.Common.Lovelace
@@ -34,6 +35,7 @@ library
                        Test.Cardano.Chain.Slotting.Gen
                        Test.Cardano.Chain.Slotting.Properties
                        Test.Cardano.Chain.Txp.Bi
+                       Test.Cardano.Chain.Txp.Compact
                        Test.Cardano.Chain.Txp.Example
                        Test.Cardano.Chain.Txp.Gen
                        Test.Cardano.Chain.Txp.Json

--- a/test/test.hs
+++ b/test/test.hs
@@ -13,6 +13,7 @@ import Test.Options (Opts(..), optsParser)
 import qualified Test.Cardano.Chain.Block.Bi
 import qualified Test.Cardano.Chain.Block.Validation
 import qualified Test.Cardano.Chain.Common.Address
+import qualified Test.Cardano.Chain.Common.Compact
 import qualified Test.Cardano.Chain.Common.Lovelace
 import qualified Test.Cardano.Chain.Block.Validation.Spec
 import qualified Test.Cardano.Chain.Delegation.Bi
@@ -21,6 +22,7 @@ import qualified Test.Cardano.Chain.Genesis.Json
 import qualified Test.Cardano.Chain.Slotting.Properties
 import qualified Test.Cardano.Chain.Ssc.Bi
 import qualified Test.Cardano.Chain.Txp.Bi
+import qualified Test.Cardano.Chain.Txp.Compact
 import qualified Test.Cardano.Chain.Txp.Json
 import qualified Test.Cardano.Chain.Txp.Validation
 import qualified Test.Cardano.Chain.Update.Bi
@@ -35,6 +37,7 @@ main = do
   runTests
     [ Test.Cardano.Chain.Block.Bi.tests
     , Test.Cardano.Chain.Block.Validation.tests scenario
+    , Test.Cardano.Chain.Common.Compact.tests
     , Test.Cardano.Chain.Common.Lovelace.tests
     , Test.Cardano.Chain.Common.Address.tests
     , Test.Cardano.Chain.Delegation.Bi.tests
@@ -44,6 +47,7 @@ main = do
     , Test.Cardano.Chain.Slotting.Properties.tests
     , Test.Cardano.Chain.Ssc.Bi.tests
     , Test.Cardano.Chain.Txp.Bi.tests
+    , Test.Cardano.Chain.Txp.Compact.tests
     , Test.Cardano.Chain.Txp.Json.tests
     , Test.Cardano.Chain.Txp.Validation.tests scenario
     , Test.Cardano.Chain.Update.Bi.tests


### PR DESCRIPTION
This PR adds the compact/optimized data types:

- `CompactTxIn`
- `CompactTxId`
- `CompactTxOut`
- `CompactAddress`

In addition to this, for each of them, it also adds Hedgehog generators, round-trip tests, and tests which ensure that `heapWords` savings are gained.

_N.B. This is the first PR of two. The second PR will actually optimize/compact the `UTxO` data type by utilizing those which have been added in this PR._