### PR TITLE
Finish the implementation of the update mechanism.

### DIFF
--- a/cardano-ledger.cabal
+++ b/cardano-ledger.cabal
@@ -101,6 +101,7 @@ library
                        Cardano.Chain.Update.SystemTag
                        Cardano.Chain.Update.Validation.Endorsement
                        Cardano.Chain.Update.Validation.Interface
+                       Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
                        Cardano.Chain.Update.Validation.Registration
                        Cardano.Chain.Update.Validation.Voting
                        Cardano.Chain.Update.Vote

--- a/src/Cardano/Chain/Slotting/SlotId.hs
+++ b/src/Cardano/Chain/Slotting/SlotId.hs
@@ -21,6 +21,7 @@ module Cardano.Chain.Slotting.SlotId
   , subSlotNumber
   , slotNumberEpoch
   , crucialSlot
+  , twice
   )
 where
 
@@ -33,7 +34,7 @@ import qualified Formatting.Buildable as B
 import Text.JSON.Canonical (FromJSON(..), ToJSON(..))
 
 import Cardano.Binary.Class (Bi(..), encodeListLen, enforceSize)
-import Cardano.Chain.Common.BlockCount (BlockCount)
+import Cardano.Chain.Common.BlockCount (BlockCount, unBlockCount)
 import Cardano.Chain.ProtocolConstants (kEpochSlots, kSlotSecurityParam)
 import Cardano.Chain.Slotting.EpochIndex (EpochIndex(..))
 import Cardano.Chain.Slotting.LocalSlotIndex
@@ -189,3 +190,10 @@ crucialSlot k epochIdx = SlotId {siEpoch = epochIdx - 1, siSlot = slot}
     Left err ->
       panic $ sformat ("The impossible happened in crucialSlot: " . build) err
     Right lsi -> lsi
+
+-- | Compute the number of slots after which a block becomes stable as @2 * k@,
+-- where @k@ is the chain security parameter, which is expressed in number of
+-- blocks.
+--
+twice :: BlockCount -> FlatSlotId
+twice k = FlatSlotId (2 * unBlockCount k)

--- a/src/Cardano/Chain/Update/ProtocolParameters.hs
+++ b/src/Cardano/Chain/Update/ProtocolParameters.hs
@@ -44,6 +44,16 @@ data ProtocolParameters = ProtocolParameters
   , ppUpdateVoteThd     :: !LovelacePortion
   , ppUpdateProposalThd :: !LovelacePortion
   , ppUpdateImplicit    :: !FlatSlotId
+  -- ^ Time to live for a protocol update proposal. This used to be the number
+  -- of slots after which the system made a decision regarding an update
+  -- proposal confirmation, when a majority of votes was not reached in the
+  -- given number of slots. If there were more positive than negative votes the
+  -- proposal became confirmed, otherwise it was rejected. Since in the
+  -- Byron-Shelley bridge we do not have negative votes, and we aim at
+  -- simplifying the update mechanism, 'ppUpdateImplicit' is re-interpreted as
+  -- the number of slots a proposal has to gather a majority of votes. If a
+  -- majority of votes has not been reached before this period, then the
+  -- proposal is rejected.
   , ppSoftforkRule      :: !SoftforkRule
   , ppTxFeePolicy       :: !TxFeePolicy
   , ppUnlockStakeEpoch  :: !EpochIndex

--- a/src/Cardano/Chain/Update/Validation/Interface/ProtocolVersionBump.hs
+++ b/src/Cardano/Chain/Update/Validation/Interface/ProtocolVersionBump.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
+  ( Environment (..)
+  , State (..)
+  , tryBumpVersion
+  )
+where
+
+import Cardano.Prelude hiding (State)
+
+import Cardano.Chain.Common.BlockCount (BlockCount)
+import Cardano.Chain.Slotting (EpochIndex, FlatSlotId, twice)
+import Cardano.Chain.Update.ProtocolParameters (ProtocolParameters)
+import Cardano.Chain.Update.ProtocolVersion (ProtocolVersion)
+import Cardano.Chain.Update.Validation.Endorsement
+  ( CandidateProtocolUpdate(CandidateProtocolUpdate)
+  , cpuProtocolParameters
+  , cpuProtocolVersion
+  , cpuSlot
+  )
+
+data Environment = Environment
+  { k                         :: !BlockCount
+  , currentSlot               :: !FlatSlotId
+  , candidateProtocolVersions :: ![CandidateProtocolUpdate]
+  }
+
+data State = State
+  { currentEpoch              :: !EpochIndex
+  , nextProtocolVersion       :: !ProtocolVersion
+  , nextProtocolParameters    :: !ProtocolParameters
+  }
+
+-- | Change the protocol version when an epoch change is detected, and there is
+-- a candidate protocol update that was confirmed at least @2 * k@ slots ago,
+-- where @k@ is the chain security parameter.
+--
+-- This corresponds to the @PVBUMP@ rules in the Byron ledger specification.
+tryBumpVersion
+  :: Environment
+  -> State
+  -> EpochIndex
+  -> State
+tryBumpVersion env st lastSeenEpoch =
+  case (currentEpoch < lastSeenEpoch, stableCandidates) of
+    (True, newestStable:_) ->
+      let CandidateProtocolUpdate
+            { cpuProtocolVersion
+            , cpuProtocolParameters
+            } = newestStable
+      in
+        st { currentEpoch = lastSeenEpoch
+           , nextProtocolVersion = cpuProtocolVersion
+           , nextProtocolParameters = cpuProtocolParameters
+           }
+    _ -> st
+
+  where
+    Environment { k, currentSlot, candidateProtocolVersions } = env
+
+    State { currentEpoch } = st
+
+    stableCandidates =
+      filter ((<= currentSlot - twice k) . cpuSlot) candidateProtocolVersions

--- a/src/Cardano/Chain/Update/Validation/Voting.hs
+++ b/src/Cardano/Chain/Update/Validation/Voting.hs
@@ -19,11 +19,22 @@ import Cardano.Prelude hiding (State)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as Set
 
-import Cardano.Chain.Common
-import Cardano.Chain.Slotting
-import Cardano.Chain.Update.ProtocolParameters
+import Cardano.Chain.Common (StakeholderId, mkStakeholderId)
+import Cardano.Chain.Slotting (FlatSlotId)
+import Cardano.Chain.Update.ProtocolParameters (ProtocolParameters)
 import Cardano.Chain.Update.Vote
+  ( AVote
+  , UpId
+  , recoverSignedBytes
+  , uvKey
+  , uvProposalId
+  , uvSignature
+  )
 import Cardano.Crypto
+  ( ProtocolMagicId
+  , SignTag(SignUSVote)
+  , verifySignatureDecoded
+  )
 
 
 -- | Environment used to register votes and confirm proposals


### PR DESCRIPTION
- Implement `PVBUMP`, `UPIEND` and `UPIEC` rules
- Set the update proposal time to live to `ppUpdateImplicit`.
- Use named field puns in the interface more consistently.
- Add an environment to `Cardano.Chain.Update.Validation.Registration`
- Use explicit exports in the update modules.

Closes #189.