### PR TITLE
Utilize optimized/compact data types in UTxO

### DIFF
--- a/cardano-ledger.cabal
+++ b/cardano-ledger.cabal
@@ -238,6 +238,7 @@ test-suite cardano-ledger-test
                        -fno-warn-missing-import-lists
                        -fno-warn-safe
                        -fno-warn-unsafe
+                       "-with-rtsopts=-K450K -M200M"
 
   if (!flag(development))
     ghc-options:         -Werror

--- a/test/Test/Cardano/Chain/Txp/Gen.hs
+++ b/test/Test/Cardano/Chain/Txp/Gen.hs
@@ -20,6 +20,7 @@ module Test.Cardano.Chain.Txp.Gen
   , genTxSig
   , genTxSigData
   , genTxWitness
+  , genUTxO
   )
 where
 
@@ -53,6 +54,8 @@ import Cardano.Chain.Txp
   , TxSigData(..)
   , TxWitness
   , TxpConfiguration(..)
+  , UTxO
+  , fromList
   , mkTxAux
   , mkTxPayload
   , toCompactTxId
@@ -145,3 +148,9 @@ genTxInWitness pm = Gen.choice [genPkWitness pm, genRedeemWitness pm]
 genTxWitness :: ProtocolMagicId -> Gen TxWitness
 genTxWitness pm =
   V.fromList <$> Gen.list (Range.linear 1 10) (genTxInWitness pm)
+
+genUTxO :: Gen UTxO
+genUTxO = fromList <$> Gen.list (Range.constant 0 1000) genTxInTxOut
+  where
+    genTxInTxOut :: Gen (TxIn, TxOut)
+    genTxInTxOut = (,) <$> genTxIn <*> genTxOut


### PR DESCRIPTION
This PR utilizes the optimized data types, `CompactTxIn` and `CompactTxOut`, in the `UTxO` data type. Functions exposed by the `Cardano.Chain.Txp.UTxO` module still accept the same parameters such as `Tx`, `TxIn`, `UTxO`, etc. but internally utilize conversion functions defined in `Cardano.Chain.Txp.Compact`.

Manual inspection with `ghc-heap-view` and `ghc-datasize` indicates a savings of around ~51% in terms of `UTxO`'s heap memory consumption.

_Closes #213._

_N.B. This is the final PR following PR #401._