### PR TITLE
Make previous hash of a boundary block an Either

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,24 +14,24 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 28f22dd93ce55b8af3b7e18a5b74762bd919eea8
+  tag: d2a4f06827bfa11c021ce719285e8d0bb6ac8e44
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 28f22dd93ce55b8af3b7e18a5b74762bd919eea8
+  tag: d2a4f06827bfa11c021ce719285e8d0bb6ac8e44
   subdir: test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 2f33cbf9101dfee1cb488271ec96e210329eec96
+  tag: c719857de4a2f18fa13bc5cdb85d74ae3841f50f
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 2f33cbf9101dfee1cb488271ec96e210329eec96
+  tag: c719857de4a2f18fa13bc5cdb85d74ae3841f50f
   subdir: binary/test
 
 source-repository-package
@@ -67,3 +67,26 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-mainnet-mirror
   tag: 0232971dddd5cd235c5a0c18d7b4f342a887276f
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/iohk-monitoring-framework
+  tag: cec19ad55e489f7db6ab248e0475ee3fe8b36669
+  subdir: contra-tracer
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/iohk-monitoring-framework
+  tag: cec19ad55e489f7db6ab248e0475ee3fe8b36669
+  subdir: iohk-monitoring
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-shell
+  tag: fd48ab20512e24b72b6661c00bada8ed30ccc823
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl-x509
+  tag: 71115d199368f1cc969a4936a856808539063253
+

--- a/cardano-ledger.cabal
+++ b/cardano-ledger.cabal
@@ -124,6 +124,7 @@ library
                      , concurrency
                      , cryptonite
                      , Cabal
+                     , deepseq
                      , directory
                      , filepath
                      , formatting

--- a/iohk-nix.json
+++ b/iohk-nix.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "059b42f187e8e185789a34aa7bbb58f7355ee670",
-  "sha256": "1av7sq79g73w9ncrad5mf188mh78vgsv235rc06jx9y2ghsaah1l",
+  "rev": "0fa112c459a05bb60760cff18f64cf2dbdd2a9f4",
+  "sha256": "0nr0fyplp3gr133n9vg1azwy7zxadva3ynhb3hmnslgj29ih5kp7",
   "fetchSubmodules": false
 }

--- a/scripts/nix/stack-shell.nix
+++ b/scripts/nix/stack-shell.nix
@@ -4,5 +4,5 @@ with pkgs;
 haskell.lib.buildStackProject {
   name = "cardano-ledger-env";
   buildInputs = [ zlib openssl git ];
-  ghc = haskell.packages.ghc863.ghc;
+  ghc = haskell.packages.ghc864.ghc;
 }

--- a/src/Cardano/Chain/Genesis/Hash.hs
+++ b/src/Cardano/Chain/Genesis/Hash.hs
@@ -1,19 +1,23 @@
-{-# LANGUAGE Rank2Types         #-}
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE Rank2Types                 #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 
 module Cardano.Chain.Genesis.Hash
   ( GenesisHash(..)
   )
 where
 
+import Control.DeepSeq (NFData)
+
 import Cardano.Prelude
 
 import Cardano.Binary.Class (Raw)
 import Cardano.Crypto.Hashing (Hash)
 
-
 newtype GenesisHash = GenesisHash
   { unGenesisHash :: Hash Raw
-  }
+  } deriving (Eq, Generic, NFData)
 
 deriving instance Show GenesisHash

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/2256fd727c5f92e6218afdcf8cddf6e01c4a9dcd/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/d2a4f06827bfa11c021ce719285e8d0bb6ac8e44/snapshot.yaml
 
 packages:
   - .
@@ -44,7 +44,7 @@ extra-deps:
   - ekg-json-0.1.0.6@sha256:4ff2e9cac213a5868ae8b4a7c72a16a9a76fac14d944ae819b3d838a9725569b
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 8fb87e83468831289820ef9edb3d5ef912b0db0f
+    commit: cec19ad55e489f7db6ab248e0475ee3fe8b36669
     subdirs:
         - contra-tracer
         - iohk-monitoring

--- a/test/Test/Cardano/Chain/Block/Bi.hs
+++ b/test/Test/Cardano/Chain/Block/Bi.hs
@@ -143,7 +143,7 @@ ts_roundTripBlockCompat =
       trippingBuildable
         esb
         (serializeEncoding . encodeBlock es . unWithEpochSlots)
-        (fmap (WithEpochSlots es . fromJust) . decodeFullDecoder "Block" (decodeBlockOrBoundary es))
+        (fmap (WithEpochSlots es . fromJust) . decodeFullDecoder "Block" (decodeBlockOrBoundary es False))
 
 
 --------------------------------------------------------------------------------

--- a/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -97,13 +97,11 @@ elaborate config (_, _, pps) ast st ab = Concrete.ABlock
     , Concrete.ehdEBDataProof     = H.hash extraBodyData
     }
 
-  prevHash = fromMaybe
-    (Genesis.configGenesisHeaderHash config)
-    (Concrete.cvsPreviousHash st)
+  prevHash :: Concrete.HeaderHash
+  prevHash =
+    either Concrete.genesisHeaderHash identity $ Concrete.cvsPreviousHash st
 
   sid =
---    Slotting.unflattenSlotId (coerce (pps ^. bkSlotsPerEpoch))
---      $
       Slotting.FlatSlotId
           (ab ^. Abstract.bHeader . Abstract.bSlot . to Abstract.unSlot)
 
@@ -151,7 +149,7 @@ annotateBlock epochSlots block =
       case
           Binary.decodeFullDecoder
             "Block"
-            (Concrete.decodeABlockOrBoundary epochSlots) bytes
+            (Concrete.decodeABlockOrBoundary epochSlots False) bytes
         of
           Left err ->
             panic


### PR DESCRIPTION
This turned out the be the least invasive changes that was still able to represent the fact that that previous hash of the zerotth boundary block does not exist.
