### PR TITLE
[#396] Convert NetworkMagic & ProtocolMagic Int32 to Word32

### DIFF
--- a/crypto/src/Cardano/Crypto/ProtocolMagic.hs
+++ b/crypto/src/Cardano/Crypto/ProtocolMagic.hs
@@ -39,7 +39,7 @@ data ProtocolMagic = ProtocolMagic
   } deriving (Eq, Show, Generic, NFData)
 
 newtype ProtocolMagicId = ProtocolMagicId
-  { unProtocolMagicId :: Int32
+  { unProtocolMagicId :: Word32
   } deriving (Show, Eq, Generic)
     deriving newtype Bi
     deriving anyclass NFData
@@ -52,7 +52,7 @@ instance A.FromJSON ProtocolMagicId where
 
 -- mhueschen: For backwards-compatibility reasons, I redefine this function
 -- in terms of the two record accessors.
-getProtocolMagic :: ProtocolMagic -> Int32
+getProtocolMagic :: ProtocolMagic -> Word32
 getProtocolMagic = unProtocolMagicId . getProtocolMagicId
 
 instance A.ToJSON ProtocolMagic where

--- a/crypto/test/Test/Cardano/Crypto/Example.hs
+++ b/crypto/test/Test/Cardano/Crypto/Example.hs
@@ -48,13 +48,13 @@ exampleProtocolMagic1 =
   ProtocolMagic (ProtocolMagicId 2147000001) RequiresMagic
 
 exampleProtocolMagic2 :: ProtocolMagic
-exampleProtocolMagic2 = ProtocolMagic (ProtocolMagicId (-58952)) RequiresMagic
+exampleProtocolMagic2 = ProtocolMagic (ProtocolMagicId 58952) RequiresMagic
 
 exampleProtocolMagic3 :: ProtocolMagic
 exampleProtocolMagic3 = ProtocolMagic (ProtocolMagicId 31337) RequiresMagic
 
 exampleProtocolMagic4 :: ProtocolMagic
-exampleProtocolMagic4 = ProtocolMagic (ProtocolMagicId (-500)) RequiresNoMagic
+exampleProtocolMagic4 = ProtocolMagic (ProtocolMagicId 500) RequiresNoMagic
 
 examplePublicKey :: PublicKey
 examplePublicKey = pk where [pk] = examplePublicKeys 16 1 -- 16 could be any number, as we take the first key

--- a/crypto/test/Test/Cardano/Crypto/Gen.hs
+++ b/crypto/test/Test/Cardano/Crypto/Gen.hs
@@ -101,7 +101,7 @@ genProtocolMagic =
   ProtocolMagic <$> genProtocolMagicId <*> genRequiresNetworkMagic
 
 genProtocolMagicId :: Gen ProtocolMagicId
-genProtocolMagicId = ProtocolMagicId <$> Gen.int32 Range.constantBounded
+genProtocolMagicId = ProtocolMagicId <$> Gen.word32 Range.constantBounded
 
 genRequiresNetworkMagic :: Gen RequiresNetworkMagic
 genRequiresNetworkMagic = Gen.element [RequiresNoMagic, RequiresMagic]

--- a/crypto/test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+++ b/crypto/test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
@@ -1,1 +1,1 @@
-{"pm":-500,"requiresNetworkMagic":"NMMustBeNothing"}
+{"pm":500,"requiresNetworkMagic":"NMMustBeNothing"}

--- a/src/Cardano/Chain/Common/NetworkMagic.hs
+++ b/src/Cardano/Chain/Common/NetworkMagic.hs
@@ -20,12 +20,9 @@ import           Cardano.Crypto.ProtocolMagic (ProtocolMagic (..),
 -- NetworkMagic
 --------------------------------------------------------------------------------
 
--- Although it doesn't make sense for an identifier to have a sign, we're opting
--- to maintain consistency with `ProtocolMagicId`, rather than risk subtle
--- conversion bugs.
 data NetworkMagic
     = NetworkMainOrStage
-    | NetworkTestnet {-# UNPACK #-} !Int32
+    | NetworkTestnet {-# UNPACK #-} !Word32
     deriving (Show, Eq, Ord, Generic, NFData)
 
 instance B.Buildable NetworkMagic where

--- a/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/test/Test/Cardano/Chain/Common/Gen.hs
@@ -145,7 +145,7 @@ genMerkleRoot genA = mtRoot <$> genMerkleTree genA
 genNetworkMagic :: Gen NetworkMagic
 genNetworkMagic = Gen.choice
   [ pure NetworkMainOrStage
-  , NetworkTestnet <$> Gen.int32 Range.constantBounded
+  , NetworkTestnet <$> Gen.word32 Range.constantBounded
   ]
 
 genScriptVersion :: Gen Word16


### PR DESCRIPTION
Out of necessity, modify 2 example datatypes which had negative
values.

Closes #396.