### PR TITLE
decoded boundary blocks have epoch index

### DIFF
--- a/src/Cardano/Chain/Block/Boundary.hs
+++ b/src/Cardano/Chain/Block/Boundary.hs
@@ -4,14 +4,18 @@
 
 module Cardano.Chain.Block.Boundary
   ( dropBoundaryConsensusData
+  , dropBoundaryConsensusDataRetainEpochIndex
   , dropBoundaryExtraHeaderData
   , dropBoundaryBody
   , dropBoundaryExtraBodyData
   )
 where
 
+import Control.Monad (return, void)
+import Data.Word (Word64)
+
 import Cardano.Binary
-  (Dropper, dropBytes, dropList, dropWord64, enforceSize)
+  (Decoder, Dropper, decodeWord64, dropBytes, dropList, enforceSize)
 import Cardano.Chain.Common (dropAttributes, dropChainDifficulty)
 
 
@@ -20,10 +24,14 @@ import Cardano.Chain.Common (dropAttributes, dropChainDifficulty)
 --------------------------------------------------------------------------------
 
 dropBoundaryConsensusData :: Dropper s
-dropBoundaryConsensusData = do
+dropBoundaryConsensusData = void dropBoundaryConsensusDataRetainEpochIndex
+
+dropBoundaryConsensusDataRetainEpochIndex :: Decoder s Word64
+dropBoundaryConsensusDataRetainEpochIndex = do
   enforceSize "BoundaryConsensusData" 2
-  dropWord64
+  w <- decodeWord64
   dropChainDifficulty
+  return w
 
 
 --------------------------------------------------------------------------------

--- a/src/Cardano/Chain/Block/Header.hs
+++ b/src/Cardano/Chain/Block/Header.hs
@@ -88,7 +88,7 @@ import Cardano.Binary
   )
 import Cardano.Chain.Block.Body (Body)
 import Cardano.Chain.Block.Boundary
-  (dropBoundaryConsensusData, dropBoundaryExtraHeaderData)
+  (dropBoundaryConsensusDataRetainEpochIndex, dropBoundaryExtraHeaderData)
 import Cardano.Chain.Block.ExtraBodyData (ExtraBodyData)
 import Cardano.Chain.Block.ExtraHeaderData (ExtraHeaderData(..))
 import Cardano.Chain.Block.Proof (Proof(..), mkProof)
@@ -381,7 +381,7 @@ hashHeader es = unsafeAbstractHash . serializeEncoding . toCBORHeader es
 -- BoundaryHeader
 --------------------------------------------------------------------------------
 
-dropBoundaryHeader :: Decoder s HeaderHash
+dropBoundaryHeader :: Decoder s (HeaderHash, Word64)
 dropBoundaryHeader = do
   enforceSize "BoundaryHeader" 5
   dropInt32
@@ -389,9 +389,9 @@ dropBoundaryHeader = do
   hh <- fromCBOR
   -- BoundaryBodyProof
   dropBytes
-  dropBoundaryConsensusData
+  epoch <- dropBoundaryConsensusDataRetainEpochIndex
   dropBoundaryExtraHeaderData
-  pure hh
+  pure (hh, epoch)
 
 -- | These bytes must be prepended when hashing raw boundary header data
 --

--- a/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -139,7 +139,7 @@ ts_roundTripBlockCompat = eachOfTS
     esb
     (serializeEncoding . toCBORBlock es . unWithEpochSlots)
     ( fmap (WithEpochSlots es . fromJust)
-    . decodeFullDecoder "Block" (fromCBORBlockOrBoundary es False)
+    . decodeFullDecoder "Block" (fromCBORBlockOrBoundary es)
     )
 
 

--- a/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -155,7 +155,7 @@ annotateBlock epochSlots block =
       case
           Binary.decodeFullDecoder
             "Block"
-            (Concrete.fromCBORABlockOrBoundary epochSlots False) bytes
+            (Concrete.fromCBORABlockOrBoundary epochSlots) bytes
         of
           Left err ->
             panic


### PR DESCRIPTION
In the Byron proxy we store boundary blocks on disk. To open the `ImmutableDB` we need to give a parser which can figure out the slot number from genesis for a serialized block. In order to switch from the old `cardano-sl` block decoder to those from this package, I need to be able to decode the epoch index from a boundary block. I don't have a deep understanding of this repository but AFAICT this is a nice improvement: we don't need to give the `isEpochZero` parameter anymore.