### PR TITLE
Changes needed for consensus integration

### DIFF
--- a/cardano-ledger.cabal
+++ b/cardano-ledger.cabal
@@ -37,6 +37,7 @@ library
                        Cardano.Chain.Txp.UTxO
                        Cardano.Chain.Txp.Validation
                        Cardano.Chain.Update
+                       Cardano.Chain.Update.Validation.Interface
 
   other-modules:
                        Cardano.Chain.Block.Block
@@ -105,7 +106,6 @@ library
                        Cardano.Chain.Update.SoftwareVersion
                        Cardano.Chain.Update.SystemTag
                        Cardano.Chain.Update.Validation.Endorsement
-                       Cardano.Chain.Update.Validation.Interface
                        Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
                        Cardano.Chain.Update.Validation.Registration
                        Cardano.Chain.Update.Validation.Voting

--- a/crypto/src/Cardano/Crypto/Signing/Signature.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Signature.hs
@@ -34,6 +34,7 @@ import Cardano.Prelude
 import qualified Cardano.Crypto.Wallet as CC
 import Data.Aeson (FromJSON(..), ToJSON(..))
 import Data.ByteArray (ScrubbedBytes)
+import qualified Data.ByteString.Lazy as BSL
 import Data.Coerce (coerce)
 import Formatting (Format, bprint, build, formatToString, later, sformat, stext)
 import qualified Formatting.Buildable as B
@@ -49,6 +50,7 @@ import Cardano.Binary
   , Raw
   , ToCBOR(..)
   , serialize'
+  , serializeEncoding
   )
 import Cardano.Crypto.ProtocolMagic (ProtocolMagicId)
 import Cardano.Crypto.Signing.PublicKey (PublicKey(..))
@@ -176,15 +178,15 @@ safeSignRaw pm mbTag (SafeSigner (EncryptedSecretKey sk _) (PassPhrase pp)) x =
 
 -- | Verify a signature
 verifySignature
-  :: ToCBOR a
-  => ProtocolMagicId
+  :: (a -> Encoding)
+  -> ProtocolMagicId
   -> SignTag
   -> PublicKey
   -> a
   -> Signature a
   -> Bool
-verifySignature pm tag pk x sig =
-  verifySignatureRaw pk (signTag pm tag <> serialize' x) (coerce sig)
+verifySignature toEnc pm tag pk x sig =
+  verifySignatureRaw pk (signTag pm tag <> (BSL.toStrict . serializeEncoding $ toEnc x)) (coerce sig)
 
 -- | Verify a signature
 verifySignatureDecoded

--- a/crypto/src/Cardano/Crypto/Signing/Signature.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Signature.hs
@@ -137,12 +137,12 @@ sign
   -> SecretKey
   -> a
   -> Signature a
-sign pm tag sk = signEncoded pm tag sk . serialize'
+sign pm tag sk = signEncoded pm tag sk . toCBOR
 
 -- | Like 'sign' but without the 'ToCBOR' constraint
 signEncoded
-  :: ProtocolMagicId -> SignTag -> SecretKey -> ByteString -> Signature a
-signEncoded pm tag sk = coerce . signRaw pm (Just tag) sk
+  :: ProtocolMagicId -> SignTag -> SecretKey -> Encoding -> Signature a
+signEncoded pm tag sk = coerce . signRaw pm (Just tag) sk . BSL.toStrict . serializeEncoding
 
 -- | Sign a 'Raw' bytestring
 signRaw

--- a/crypto/test/Test/Cardano/Crypto/Gen.hs
+++ b/crypto/test/Test/Cardano/Crypto/Gen.hs
@@ -54,6 +54,7 @@ import Cardano.Prelude
 import Test.Cardano.Prelude
 
 import qualified Data.ByteArray as ByteArray
+import Data.Coerce (coerce)
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -86,7 +87,7 @@ import Cardano.Crypto.Signing
   , proxySign
   , safeCreateProxyCert
   , sign
-  , signEncoded
+  , signRaw
   , toPublic
   )
 import Cardano.Crypto.Signing.Redeem
@@ -201,7 +202,7 @@ genSignature pm genA = sign pm <$> genSignTag <*> genSecretKey <*> genA
 
 genSignatureEncoded :: Gen ByteString -> Gen (Signature a)
 genSignatureEncoded genB =
-  signEncoded <$> genProtocolMagicId <*> genSignTag <*> genSecretKey <*> genB
+  coerce . signRaw <$> genProtocolMagicId <*> (Just <$> genSignTag) <*> genSecretKey <*> genB
 
 genRedeemSignature
   :: ToCBOR a => ProtocolMagicId -> Gen a -> Gen (RedeemSignature a)

--- a/crypto/test/Test/Cardano/Crypto/Signing/Signing.hs
+++ b/crypto/test/Test/Cardano/Crypto/Signing/Signing.hs
@@ -9,6 +9,7 @@ import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
+import Cardano.Binary (toCBOR)
 import Cardano.Crypto.Signing (SignTag(..), sign, toPublic, verifySignature)
 
 import qualified Test.Cardano.Crypto.Dummy as Dummy
@@ -35,8 +36,8 @@ prop_sign = property $ do
   a        <- forAll genData
 
   assert
-    $ verifySignature Dummy.protocolMagicId SignForTestingOnly pk a
-    $ sign Dummy.protocolMagicId SignForTestingOnly sk a
+    $ verifySignature toCBOR Dummy.dummyProtocolMagicId SignForTestingOnly pk a
+    $ sign dummyProtocolMagicId SignForTestingOnly sk a
 
 -- | Signing fails when the wrong 'PublicKey' is used
 prop_signDifferentKey :: Property
@@ -47,8 +48,8 @@ prop_signDifferentKey = property $ do
 
   assert
     . not
-    $ verifySignature Dummy.protocolMagicId SignForTestingOnly pk a
-    $ sign Dummy.protocolMagicId SignForTestingOnly sk a
+    $ verifySignature toCBOR Dummy.dummyProtocolMagicId SignForTestingOnly pk a
+    $ sign dummyProtocolMagicId SignForTestingOnly sk a
 
 -- | Signing fails when then wrong signature data is used
 prop_signDifferentData :: Property
@@ -59,8 +60,8 @@ prop_signDifferentData = property $ do
 
   assert
     . not
-    $ verifySignature Dummy.protocolMagicId SignForTestingOnly pk b
-    $ sign Dummy.protocolMagicId SignForTestingOnly sk a
+    $ verifySignature toCBOR Dummy.dummyProtocolMagicId SignForTestingOnly pk b
+    $ sign dummyProtocolMagicId SignForTestingOnly sk a
 
 genData :: Gen [Int32]
 genData = Gen.list (Range.constant 0 50) (Gen.int32 Range.constantBounded)

--- a/src/Cardano/Chain/Block/Header.hs
+++ b/src/Cardano/Chain/Block/Header.hs
@@ -24,6 +24,7 @@ module Cardano.Chain.Block.Header
   -- * Accessors
   , headerSlot
   , headerLeaderKey
+  , headerHashAnnotated
   , headerIssuer
   , headerLength
   , headerDifficulty
@@ -116,6 +117,7 @@ import Cardano.Crypto
   , PublicKey
   , SecretKey
   , SignTag(..)
+  , hashDecoded
   , hashHexF
   , proxySign
   , pskIssuerPk
@@ -331,6 +333,9 @@ headerToSign epochSlots h = ToSign
   (unflattenSlotId epochSlots $ headerSlot h)
   (headerDifficulty h)
   (headerExtraData h)
+
+headerHashAnnotated :: AHeader ByteString -> HeaderHash
+headerHashAnnotated = hashDecoded . fmap wrapHeaderBytes
 
 headerLength :: AHeader ByteString -> Natural
 headerLength = fromIntegral . BS.length . headerAnnotation

--- a/src/Cardano/Chain/Block/Header.hs
+++ b/src/Cardano/Chain/Block/Header.hs
@@ -49,6 +49,7 @@ module Cardano.Chain.Block.Header
   , BlockSignature(..)
   , ToSign(..)
   , ConsensusData
+  , AConsensusData(..)
   , consensusData
 
   -- * 'ConsensusData' encoding and decoding

--- a/src/Cardano/Chain/Block/Validation.hs
+++ b/src/Cardano/Chain/Block/Validation.hs
@@ -21,6 +21,7 @@ module Cardano.Chain.Block.Validation
   , ChainValidationState(..)
   , initialChainValidationState
   , ChainValidationError
+  , HeaderEnvironment(..)
 
   -- * SigningHistory
   , SigningHistory(..)

--- a/src/Cardano/Chain/Block/Validation.hs
+++ b/src/Cardano/Chain/Block/Validation.hs
@@ -17,6 +17,7 @@ module Cardano.Chain.Block.Validation
   , updateHeader
   , updateBlock
   , BodyState(..)
+  , BodyEnvironment(..)
   , ChainValidationState(..)
   , initialChainValidationState
   , ChainValidationError

--- a/src/Cardano/Chain/Block/Validation.hs
+++ b/src/Cardano/Chain/Block/Validation.hs
@@ -16,6 +16,7 @@ module Cardano.Chain.Block.Validation
   , updateChainBoundary
   , updateHeader
   , updateBlock
+  , BodyState(..)
   , ChainValidationState(..)
   , initialChainValidationState
   , ChainValidationError

--- a/src/Cardano/Chain/Epoch/Validation.hs
+++ b/src/Cardano/Chain/Epoch/Validation.hs
@@ -29,6 +29,7 @@ import Cardano.Chain.Block
   , UTxOSize
   , blockSlot
   , calcUTxOSize
+  , cvsLastSlot
   , updateChainBlockOrBoundary
   )
 import Cardano.Chain.Epoch.File


### PR DESCRIPTION
This PR incorporates the various changes needed for integration with the consensus layer. They can be divided into three basic ideas:

- Firstly, we expose a bunch of things which were previously hidden, because they're needed.
- Secondly, we change some of the serialisation code to take a more explicit serialiser, rather than using `ToCBOR` constraints which the consensus layer can typically not satisfy.
- Finally, we split some of the rule processing to fit with an explicit header/body split.