### PR TITLE
Ensure resulting `appVersions` values are strict in `registerVote`

### DIFF
--- a/src/Cardano/Chain/Update/Validation/Interface.hs
+++ b/src/Cardano/Chain/Update/Validation/Interface.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns       #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -232,8 +233,9 @@ registerVote env st vote = do
       `wrapError` Voting
   let
     appVersions' =
+      currentSlot `seq`
       M.fromList $! [ (svAppName sv, (svNumber sv, currentSlot))
-                    | (pid, sv) <- M.toList registeredSoftwareUpdateProposals
+                    | (!pid, !sv) <- M.toList registeredSoftwareUpdateProposals
                     , pid `elem` M.keys confirmedProposals'
                     ]
   pure $!


### PR DESCRIPTION
It is possible that `registerVote` can return an update interface `State` which contains thunks within its `appVersion` field (a strict `Map ApplicationName (NumSoftwareVersion, FlatSlotId)`). 

Because a strict `Map` only ensures that keys and values are in WHNF, it is possible for a thunk to exist within the `(NumSoftwareVersion, FlatSlotId)` value. This exact thing seems to occur due to a list comprehension within `registerVote` which utilizes a generator that can produce lazy values. In order to remedy this, I simply added some bang patterns to the generator expression.

_(I may be wrong about the reasoning here. Anyone care to weigh in?)_.

This space leak was detected by using `ghc-heap` to specifically look at the `Cardano.Chain.Update.Validation.Interface.State`'s heap object representation during bulk chain validation.

### Before the Fix
`appVersions` field at epoch no. 2 (notice the `ThunkClosure`):
```
+- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 4, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004203940fd8/1,0x0000004203f1c648/1,0x000000000211cfa0/2,0x000000000211cfa0/2], dataArgs = [1], pkg = \"containers-0.6.0.1\", modl = \"Data.Map.Internal\", name = \"Bin\"}
|  |
|  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 2, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004203f1c860], dataArgs = [0,12], pkg = \"text-1.2.3.1\", modl = \"Data.Text.Internal\", name = \"Text\"}
|  |  |
|  |  `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 24, arrWords = [12666837815984227,28147931469119588,32370124839977057]}
|  |
|  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 2, nptrs = 0, tipe = CONSTR_2_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004203f1c888,0x0000004203f1c698/1], dataArgs = [], pkg = \"ghc-prim\", modl = \"GHC.Tuple\", name = \"(,)\"}
|  |  |
|  |  +- ThunkClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = THUNK_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004203f1c670/1], dataArgs = []}
|  |  |  |
|  |  |  `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 1, tipe = CONSTR_1_1, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004203940fd8/1], dataArgs = [1], pkg = \"cardano-ledger-0.1.0.0-GrvZSU1raNtyHMRMZltXs\", modl = \"Cardano.Chain.Update.SoftwareVersion\", name = \"SoftwareVersion\"}
|  |  |     |
|  |  |     `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 2, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004203f1c860], dataArgs = [0,12], pkg = \"text-1.2.3.1\", modl = \"Data.Text.Internal\", name = \"Text\"}
|  |  |        |
|  |  |        `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 24, arrWords = [12666837815984227,28147931469119588,32370124839977057]}
|  |  |
|  |  `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = [73494], pkg = \"base\", modl = \"GHC.Word\", name = \"W64#\"}
|  |
|  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 1, code = Nothing}, ptrArgs = [], dataArgs = [29611240], pkg = \"containers-0.6.0.1\", modl = \"Data.Map.Internal\", name = \"Tip\"}
|  |
|  `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 1, code = Nothing}, ptrArgs = [], dataArgs = [29611240], pkg = \"containers-0.6.0.1\", modl = \"Data.Map.Internal\", name = \"Tip\"}
|
```

### After the Fix
`appVersions` field at epoch no. 2 (notice that, instead of the `ThunkClosure`, there's now a `W32#`):
```
+- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 4, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042031934e8/1,0x0000004203193508/1,0x000000000211bfa0/2,0x000000000211bfa0/2], dataArgs = [1], pkg = \"containers-0.6.0.1\", modl = \"Data.Map.Internal\", name = \"Bin\"}
|  |
|  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 2, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042031939f0], dataArgs = [0,12], pkg = \"text-1.2.3.1\", modl = \"Data.Text.Internal\", name = \"Text\"}
|  |  |
|  |  `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 24, arrWords = [12666837815984227,28147931469119588,32370124839977057]}
|  |
|  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 2, nptrs = 0, tipe = CONSTR_2_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004203193a18/1,0x0000004203193558/1], dataArgs = [], pkg = \"ghc-prim\", modl = \"GHC.Tuple\", name = \"(,)\"}
|  |  |
|  |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = [1], pkg = \"base\", modl = \"GHC.Word\", name = \"W32#\"}
|  |  |
|  |  `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = [73494], pkg = \"base\", modl = \"GHC.Word\", name = \"W64#\"}
|  |
|  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 1, code = Nothing}, ptrArgs = [], dataArgs = [29611160], pkg = \"containers-0.6.0.1\", modl = \"Data.Map.Internal\", name = \"Tip\"}
|  |
|  `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 1, code = Nothing}, ptrArgs = [], dataArgs = [29611160], pkg = \"containers-0.6.0.1\", modl = \"Data.Map.Internal\", name = \"Tip\"}
|
```