### PR TITLE
Ensure resulting `cvsPreviousHash` is strict in `updateBlock`

### DIFF
--- a/src/Cardano/Chain/Block/Validation.hs
+++ b/src/Cardano/Chain/Block/Validation.hs
@@ -582,7 +582,7 @@ updateBlock config cvs b = do
 
   pure $ cvs
     { cvsLastSlot     = blockSlot b
-    , cvsPreviousHash = Right $ blockHashAnnotated b
+    , cvsPreviousHash = Right $! blockHashAnnotated b
     , cvsUtxo         = utxo
     , cvsUpdateState  = updateState
     , cvsDelegationState = delegationState


### PR DESCRIPTION
It is possible that `updateBlock` can return a `ChainValidationState` which contains thunks within its `cvsPreviousHash :: !(Either GenesisHash HeaderHash)` field.

### Before the fix
This is the heap object representation of the `cvsPreviousHash` field after validating mainnet epoch no. 1 (notice the `ThunkClosure`):
```
ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 1, code = Nothing}, ptrArgs = [0x0000004204429450], dataArgs = [], pkg = \"base\", modl = \"Data.Either\", name = \"Right\"}
|
`- ThunkClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = THUNK_1_0, srtlen = 28157384, code = Nothing}, ptrArgs = [0x0000004204429528/1], dataArgs = []}
   |
   `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 4, nptrs = 0, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004204429568/1,0x00000042044295a0/1,0x00000042044295c0/1,0x00000042044295d8/1], dataArgs = [], pkg = \"cardano-ledger-0.1.0.0-GrvZSU1raNtyHMRMZltXs\", modl = \"Cardano.Chain.Block.Block\", name = \"ABlock\"}
      |
      +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 6, nptrs = 0, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004204429640/1,0x0000004204429658/1,0x0000004204429670/1,0x0000004204429688/1,0x00000042044296b0/1,0x00000042044296c8/1], dataArgs = [], pkg = \"cardano-ledger-0.1.0.0-GrvZSU1raNtyHMRMZltXs\", modl = \"Cardano.Chain.Block.Header\", name = \"AHeader\"}
      |  |
      |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 2, nptrs = 0, tipe = CONSTR_2_0, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042044297d8/1,0x00000042044297b0/1], dataArgs = [], pkg = \"cardano-binary-1.5.0-4JPaYj1JXNrBeSyDLJ1mHT\", modl = \"Cardano.Binary.Annotated\", name = \"Annotated\"}
      |  |  |
      |  |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = [764824073], pkg = \"base\", modl = \"GHC.Word\", name = \"W32#\"}
      |  |  |
      |  |  `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 3, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004204435ee8/3], dataArgs = [283535015952,22013,5], pkg = \"bytestring-0.10.8.2\", modl = \"Data.ByteString.Internal\", name = \"PS\"}
      |  |     |
      |  |     `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 2, code = Nothing}, ptrArgs = [0x0000004204010000], dataArgs = [], pkg = \"base\", modl = \"GHC.ForeignPtr\", name = \"PlainPtr\"}
      |  |
      ...
```
We can see that the strictness annotation on the `cvsPreviousHash :: !(Either GenesisHash HeaderHash)` field at least guarantees that the `Either` value (in this case, the `Right` constructor) will be in WHNF. However, there's still the possibility for the `GenesisHash` or `HeaderHash` value to be lazy. 

### After the fix
No more `ThunkClosure` after validating mainnet epoch no. 1:
```
ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 1, code = Nothing}, ptrArgs = [0x00000042044283f0/1], dataArgs = [], pkg = \"base\", modl = \"Data.Either\", name = \"Right\"}
|
`- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004204428418], dataArgs = [], pkg = \"basement-0.0.10-2z2JaOuy7fVLQL3Bi1dEbr\", modl = \"Basement.Block.Base\", name = \"Block\"}
   |
   `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 32, arrWords = [15576469751458287675,4322980304539735369,4525514649686251034,1263748243132727432]}
```