### PR TITLE
Remove parseEpochFile/parseEpochFiles

### DIFF
--- a/src/Cardano/Chain/Epoch/File.hs
+++ b/src/Cardano/Chain/Epoch/File.hs
@@ -4,8 +4,6 @@
 
 module Cardano.Chain.Epoch.File
   ( mainnetEpochSlots
-  , parseEpochFile
-  , parseEpochFiles
   , parseEpochFileWithBoundary
   , parseEpochFilesWithBoundary
   , ParseError(..)
@@ -32,7 +30,7 @@ import System.FilePath ((-<.>))
 
 import Cardano.Binary (DecoderError, decodeFullDecoder, slice)
 import Cardano.Chain.Block.Block
-  (ABlock, ABlockOrBoundary(..), fromCBORABlockOrBoundary)
+  (ABlockOrBoundary(..), fromCBORABlockOrBoundary)
 import Cardano.Chain.Slotting (EpochSlots(..))
 
 
@@ -75,19 +73,6 @@ loadFileWithHeader file header =
 -- This number has been fixed throughout the Byron era.
 mainnetEpochSlots :: EpochSlots
 mainnetEpochSlots = EpochSlots 21600
-
-parseEpochFile
-  :: EpochSlots
-  -> FilePath
-  -> Stream (Of (ABlock ByteString)) (ExceptT ParseError ResIO) ()
-parseEpochFile epochSlots =
-  S.mapMaybe eitherToMaybe . parseEpochFileWithBoundary epochSlots
- where
-  eitherToMaybe
-    :: ABlockOrBoundary ByteString -> Maybe (ABlock ByteString)
-  eitherToMaybe = \case
-    ABOBBoundary _      -> Nothing
-    ABOBBlock    aBlock -> Just aBlock
 
 parseEpochFileWithBoundary
   :: EpochSlots
@@ -134,13 +119,6 @@ parseEpochFilesWithBoundary
        ()
 parseEpochFilesWithBoundary epochSlots fs =
   foldr (<>) mempty (parseEpochFileWithBoundary epochSlots <$> fs)
-
-parseEpochFiles
-  :: EpochSlots
-  -> [FilePath]
-  -> Stream (Of (ABlock ByteString)) (ExceptT ParseError ResIO) ()
-parseEpochFiles epochSlots fs =
-  foldr (<>) mempty (parseEpochFile epochSlots <$> fs)
 
 slotDataHeader :: LBS.ByteString
 slotDataHeader = "blnd"

--- a/test/Test/Cardano/Chain/Epoch/File.hs
+++ b/test/Test/Cardano/Chain/Epoch/File.hs
@@ -13,7 +13,7 @@ import qualified Hedgehog as H
 import Streaming (Of((:>)))
 import qualified Streaming as S
 
-import Cardano.Chain.Epoch.File (ParseError, mainnetEpochSlots, parseEpochFiles)
+import Cardano.Chain.Epoch.File (ParseError, mainnetEpochSlots, parseEpochFilesWithBoundary)
 
 import Test.Cardano.Mirror (mainnetEpochFiles)
 
@@ -29,7 +29,7 @@ propDeserializeEpochs = H.withTests 1 $ H.property $ do
   -- to work). Now the question is whether it is OK to use an hardcoded value
   -- for the number of slots per epoch, and if so in which module should we
   -- store this constant?
-  let stream = parseEpochFiles mainnetEpochSlots files
+  let stream = parseEpochFilesWithBoundary mainnetEpochSlots files
   result <- (liftIO . runResourceT . runExceptT . S.run) (S.maps discard stream)
   result === Right ()
  where


### PR DESCRIPTION
These functions parsed epochs ignoring the epoch boundary blocks,
but we should always parse the EBBs, so these can be dropped.