### PR TITLE
Extend coverage information to all packages

### DIFF
--- a/scripts/buildkite/rebuild.hs
+++ b/scripts/buildkite/rebuild.hs
@@ -49,7 +49,7 @@ coverageUploadStep = do
     Just repoToken -> do
       result <- proc
         "shc"
-        ["--repo-token", repoToken, "cardano-ledger", "cardano-ledger-test"]
+        ["--repo-token", repoToken, "combined", "all"]
         empty
       case result of
         ExitSuccess   -> printf "Coverage information upload successful.\n"


### PR DESCRIPTION
Testing to see whether the `shc combined all` command works to add coverage for the `cardano-crypto-wrapper` library