### PR TITLE
Assert that `ChainValidationState` is in normal form in `epochValid` prop

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,6 @@
 steps:
   - label: 'stack rebuild'
     env:
-      AWS_REGION: us-west-1
-      S3_BUCKET: appveyor-ci-cache
-      CACHE_S3_MAX_SIZE: 2500MB
       STACK_ROOT: "/build/cardano-ledger.stack"
     command:
       # cache-s3 needs a build directory that is the same across all buildkite agents.
@@ -15,13 +12,6 @@ steps:
       - "./stack-rebuild"
     agents:
       system: x86_64-linux
-
-  # - label: 'brittany'
-  #   command:
-  #     - "nix-build scripts/brittany -o check-brittany"
-  #     - "./check-brittany"
-  #   agents:
-  #     system: x86_64-linux
 
   - label: 'nix-tools'
     command: 'scripts/buildkite/check-nix-tools.sh'

--- a/.stack-to-nix.cache
+++ b/.stack-to-nix.cache
@@ -26,3 +26,6 @@ https://github.com/input-output-hk/cardano-ledger-specs ad86dcb64e8a5f3bd7670655
 https://github.com/input-output-hk/cardano-ledger-specs ad86dcb64e8a5f3bd7670655ab92b50921946479 byron/ledger/executable-spec 1p21vbqdpi3yxzvlmskcrlqlpkszmnif7i9rxgp7xnas6fyj079y cs-ledger cs-ledger.nix
 https://github.com/input-output-hk/cardano-ledger-specs ad86dcb64e8a5f3bd7670655ab92b50921946479 byron/chain/executable-spec 1p21vbqdpi3yxzvlmskcrlqlpkszmnif7i9rxgp7xnas6fyj079y cs-blockchain cs-blockchain.nix
 https://github.com/input-output-hk/cardano-shell de45bf135fc0c575753613ee157378a28f9261e2 . 0j3imc9c80904ybhbrl4mb0v6h9j3c7c9l6pij6idg3adh0rla9z cardano-shell cardano-shell.nix
+https://github.com/input-output-hk/cardano-prelude cca3c4f8da1de19321e96a5a7cca376bc6c37637 . 087yby0q18xk9i2f50a4gjz9rdn1jgwwp8yi3qv5b2nbwb2pzvn7 cardano-prelude cardano-prelude.nix
+https://github.com/input-output-hk/cardano-prelude cca3c4f8da1de19321e96a5a7cca376bc6c37637 test 087yby0q18xk9i2f50a4gjz9rdn1jgwwp8yi3qv5b2nbwb2pzvn7 cardano-prelude-test cardano-prelude-test.nix
+http://github.com/well-typed/canonical-json ddfe3593b80b5ceb88842bb7a6f2268df75d2c2f . 02fzn1xskis1lc1pkz0j92v6ipd89ww0k2p3dvwpm3yap5dpnm7k canonical-json canonical-json.nix

--- a/cabal.project
+++ b/cabal.project
@@ -18,12 +18,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: a136c4242b9c9f6124b811329bc8ccdfd86c514e
+  tag: cca3c4f8da1de19321e96a5a7cca376bc6c37637
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: a136c4242b9c9f6124b811329bc8ccdfd86c514e
+  tag: cca3c4f8da1de19321e96a5a7cca376bc6c37637
   subdir: test
 
 source-repository-package

--- a/cardano-ledger/cardano-ledger.cabal
+++ b/cardano-ledger/cardano-ledger.cabal
@@ -263,3 +263,44 @@ test-suite cardano-ledger-test
 
   if (!flag(development))
     ghc-options:         -Werror
+
+executable epoch-validation-normal-form-test
+  hs-source-dirs:      test
+  main-is:             NormalFormTest.hs
+
+  other-modules:
+                       Test.Cardano.Chain.Block.Validation
+                       Test.Cardano.Chain.Config
+                       Test.Cardano.Mirror
+                       Test.Options
+
+  build-depends:       base
+                     , bytestring
+                     , cardano-ledger
+                     , cardano-crypto-test
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , containers
+                     , directory
+                     , filepath
+                     , formatting
+                     , hedgehog
+                     , optparse-applicative
+                     , resourcet
+                     , streaming
+                     , tasty
+                     , tasty-hedgehog
+
+  default-language:    Haskell2010
+  default-extensions:  NoImplicitPrelude
+
+  ghc-options:         -Weverything
+                       -fno-warn-all-missed-specialisations
+                       -fno-warn-missing-import-lists
+                       -fno-warn-safe
+                       -fno-warn-unsafe
+                       "-with-rtsopts=-K450K -M500M"
+
+  if (!flag(development))
+    ghc-options:         -Werror

--- a/cardano-ledger/cardano-ledger.cabal
+++ b/cardano-ledger/cardano-ledger.cabal
@@ -17,6 +17,11 @@ flag development
     default: False
     manual: True
 
+flag test-normal-form
+    description: Test ledger state normal form during epoch validation
+    default: False
+    manual: True
+
 library
   hs-source-dirs:      src
   exposed-modules:
@@ -264,9 +269,13 @@ test-suite cardano-ledger-test
   if (!flag(development))
     ghc-options:         -Werror
 
-executable epoch-validation-normal-form-test
+test-suite epoch-validation-normal-form-test
+  if (!flag(test-normal-form))
+   buildable: False
+
   hs-source-dirs:      test
   main-is:             NormalFormTest.hs
+  type:                exitcode-stdio-1.0
 
   other-modules:
                        Test.Cardano.Chain.Block.Validation

--- a/cardano-ledger/cardano-ledger.cabal
+++ b/cardano-ledger/cardano-ledger.cabal
@@ -285,6 +285,7 @@ test-suite epoch-validation-normal-form-test
 
   build-depends:       base
                      , bytestring
+                     , cardano-binary
                      , cardano-ledger
                      , cardano-crypto-test
                      , cardano-crypto-wrapper
@@ -297,6 +298,7 @@ test-suite epoch-validation-normal-form-test
                      , hedgehog
                      , optparse-applicative
                      , resourcet
+                     , silently
                      , streaming
                      , tasty
                      , tasty-hedgehog

--- a/cardano-ledger/src/Cardano/Chain/Common/Address.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Address.hs
@@ -74,7 +74,13 @@ import Formatting
   (Format, bprint, build, builder, formatToString, later, sformat)
 import qualified Formatting.Buildable as B
 import Text.JSON.Canonical
-  (FromJSON(..), FromObjectKey(..), JSValue(..), ToJSON(..), ToObjectKey(..))
+  ( FromJSON(..)
+  , FromObjectKey(..)
+  , JSValue(..)
+  , ToJSON(..)
+  , ToObjectKey(..)
+  , toJSString
+  )
 
 import Cardano.Binary
   ( DecoderError(..)
@@ -173,7 +179,7 @@ instance B.Buildable [Address] where
   build = bprint listJson
 
 instance Monad m => ToObjectKey m Address where
-  toObjectKey = pure . formatToString addressF
+  toObjectKey = pure . toJSString . formatToString addressF
 
 instance MonadError SchemaError m => FromObjectKey m Address where
   fromObjectKey = fmap Just . parseJSString fromCBORTextAddress . JSString

--- a/cardano-ledger/src/Cardano/Chain/Common/KeyHash.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/KeyHash.hs
@@ -17,7 +17,8 @@ import Control.Monad.Except (MonadError)
 import Data.Aeson (FromJSONKey, ToJSONKey)
 import Formatting (formatToString)
 import Formatting.Buildable (Buildable)
-import Text.JSON.Canonical (FromObjectKey(..), JSValue(..), ToObjectKey(..))
+import Text.JSON.Canonical
+  (FromObjectKey(..), JSValue(..), ToObjectKey(..), toJSString)
 
 import Cardano.Binary (FromCBOR, ToCBOR)
 import Cardano.Chain.Common.AddressHash
@@ -41,12 +42,12 @@ newtype KeyHash = KeyHash
              )
 
 instance Monad m => ToObjectKey m KeyHash where
-    toObjectKey = pure . formatToString hashHexF . unKeyHash
+  toObjectKey = pure . toJSString . formatToString hashHexF . unKeyHash
 
 instance MonadError SchemaError m => FromObjectKey m KeyHash where
-    fromObjectKey = fmap (Just . KeyHash)
-        . parseJSString decodeAbstractHash
-        . JSString
+  fromObjectKey = fmap (Just . KeyHash)
+    . parseJSString decodeAbstractHash
+    . JSString
 
 hashKey :: VerificationKey -> KeyHash
 hashKey = KeyHash . addressHash

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
 

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
@@ -235,7 +235,9 @@ registerVote env st vote = do
   let
     appVersions' =
       currentSlot `seq`
-      M.fromList $! [ (svAppName sv, (svNumber sv, currentSlot))
+      M.fromList $! [ let !svAppName' = svAppName sv
+                          !svNumber'  = svNumber sv
+                      in (svAppName', (svNumber', currentSlot))
                     | (!pid, !sv) <- M.toList registeredSoftwareUpdateProposals
                     , pid `elem` M.keys confirmedProposals'
                     ]

--- a/cardano-ledger/test/NormalFormTest.hs
+++ b/cardano-ledger/test/NormalFormTest.hs
@@ -19,6 +19,8 @@ where
 
 import Cardano.Prelude
 
+import System.IO.Silently (hSilence)
+
 import Test.Options (ShouldAssertNF (..), mainWithTestScenario, tsGroupToTree)
 
 import qualified Test.Cardano.Chain.Block.Validation
@@ -26,6 +28,7 @@ import qualified Test.Cardano.Chain.Block.Validation
 
 main :: IO ()
 main =
-  mainWithTestScenario
+  hSilence [stderr]
+    . mainWithTestScenario
     . tsGroupToTree
     $ Test.Cardano.Chain.Block.Validation.tests AssertNF

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Validation.hs
@@ -87,14 +87,15 @@ ts_prop_mainnetEpochsValid scenario = withTests 1 . property $ do
   result <- (liftIO . runResourceT . runExceptT)
     (foldChainValidationState config cvs stream)
 
-  void $ evalEither result
+  cvs' <- evalEither result
+
+  assert =<< liftIO (isNormalForm $! cvs')
 
 
 data Error
   = ErrorParseError ParseError
   | ErrorChainValidationError (Maybe FlatSlotId) ChainValidationError
   deriving (Eq, Show)
-
 
 
 -- | Fold chain validation over a 'Stream' of 'Block's

--- a/cardano-ledger/test/test.hs
+++ b/cardano-ledger/test/test.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 module Main
   ( main
   )
@@ -7,12 +5,9 @@ where
 
 import Cardano.Prelude
 
-import Hedgehog (Group(..))
-import Hedgehog.Internal.Property (GroupName(..), PropertyName(..))
-import Test.Tasty (TestTree, askOption, testGroup)
-import Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty (testGroup)
 
-import Test.Options (TSGroup, mainWithTestScenario)
+import Test.Options (ShouldAssertNF(..), mainWithTestScenario, tsGroupToTree)
 
 import qualified Test.Cardano.Chain.Block.CBOR
 import qualified Test.Cardano.Chain.Block.Model
@@ -46,7 +41,7 @@ main =
     $   tsGroupToTree
     <$> [ Test.Cardano.Chain.Block.CBOR.tests
         , Test.Cardano.Chain.Block.Model.tests
-        , Test.Cardano.Chain.Block.Validation.tests
+        , Test.Cardano.Chain.Block.Validation.tests NoAssertNF
         , Test.Cardano.Chain.Common.Address.tests
         , Test.Cardano.Chain.Common.CBOR.tests
         , Test.Cardano.Chain.Common.Compact.tests
@@ -69,9 +64,3 @@ main =
         , Test.Cardano.Chain.Update.Json.tests
         , Test.Cardano.Chain.Update.Properties.tests
         ]
-
-tsGroupToTree :: TSGroup -> TestTree
-tsGroupToTree tsGroup = askOption $ \scenario -> case tsGroup scenario of
-  Group { groupName, groupProperties } -> testGroup
-    (unGroupName groupName)
-    (uncurry testProperty . first unPropertyName <$> groupProperties)

--- a/crypto/src/Cardano/Crypto/Signing/Redeem/VerificationKey.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Redeem/VerificationKey.hs
@@ -40,7 +40,8 @@ import qualified Data.Text as T
 import Formatting
   (Format, bprint, build, fitLeft, formatToString, later, sformat, stext, (%.))
 import qualified Formatting.Buildable as B
-import Text.JSON.Canonical (FromObjectKey(..), JSValue(..), ToObjectKey(..))
+import Text.JSON.Canonical
+  (FromObjectKey(..), JSValue(..), ToObjectKey(..), toJSString)
 
 import Cardano.Binary (FromCBOR, ToCBOR)
 import Cardano.Crypto.Orphans ()
@@ -52,7 +53,7 @@ newtype RedeemVerificationKey =
   deriving (Eq, Ord, Show, Generic, NFData, FromCBOR, ToCBOR)
 
 instance Monad m => ToObjectKey m RedeemVerificationKey where
-  toObjectKey = pure . formatToString redeemVKB64UrlF
+  toObjectKey = pure . toJSString . formatToString redeemVKB64UrlF
 
 instance MonadError SchemaError m => FromObjectKey m RedeemVerificationKey where
   fromObjectKey =

--- a/crypto/src/Cardano/Crypto/Signing/Signature.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Signature.hs
@@ -38,7 +38,7 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.Coerce (coerce)
 import Formatting (Format, bprint, build, formatToString, later, sformat, stext)
 import qualified Formatting.Buildable as B
-import Text.JSON.Canonical (JSValue(..))
+import Text.JSON.Canonical (JSValue(..), toJSString)
 import qualified Text.JSON.Canonical as TJC (FromJSON(..), ToJSON(..))
 
 import Cardano.Binary
@@ -79,7 +79,7 @@ instance ToJSON (Signature w) where
   toJSON = toJSON . sformat fullSignatureHexF
 
 instance Monad m => TJC.ToJSON m (Signature w) where
-  toJSON = pure . JSString . formatToString fullSignatureHexF
+  toJSON = pure . JSString . toJSString . formatToString fullSignatureHexF
 
 instance (Typeable x, MonadError SchemaError m) => TJC.FromJSON m (Signature x) where
   fromJSON = parseJSString parseFullSignature

--- a/crypto/src/Cardano/Crypto/Signing/VerificationKey.hs
+++ b/crypto/src/Cardano/Crypto/Signing/VerificationKey.hs
@@ -28,7 +28,7 @@ import qualified Data.Text.Lazy.Builder as Builder
 import Formatting
   (Format, bprint, fitLeft, formatToString, later, sformat, stext, (%.))
 import Formatting.Buildable (Buildable(..))
-import Text.JSON.Canonical (JSValue(..))
+import Text.JSON.Canonical (JSValue(..), toJSString)
 import qualified Text.JSON.Canonical as TJC (FromJSON(..), ToJSON(..))
 
 import Cardano.Binary
@@ -47,7 +47,7 @@ instance FromJSON VerificationKey where
   parseJSON v = parseJSON v >>= toAesonError . parseFullVerificationKey
 
 instance Monad m => TJC.ToJSON m VerificationKey where
-  toJSON = pure . JSString . formatToString fullVerificationKeyF
+  toJSON = pure . JSString . toJSString . formatToString fullVerificationKeyF
 
 instance MonadError SchemaError m => TJC.FromJSON m VerificationKey where
   fromJSON = parseJSString parseFullVerificationKey

--- a/nix/.stack.nix/canonical-json.nix
+++ b/nix/.stack.nix/canonical-json.nix
@@ -3,7 +3,7 @@
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "canonical-json"; version = "0.5.0.2"; };
+      identifier = { name = "canonical-json"; version = "0.6.0.0"; };
       license = "BSD-3-Clause";
       copyright = "Copyright 2015-2017 Well-Typed LLP";
       maintainer = "duncan@well-typed.com, edsko@well-typed.com";
@@ -20,6 +20,7 @@
           (hsPkgs.base)
           (hsPkgs.bytestring)
           (hsPkgs.containers)
+          (hsPkgs.deepseq)
           (hsPkgs.parsec)
           (hsPkgs.pretty)
           ];
@@ -30,6 +31,7 @@
             (hsPkgs.base)
             (hsPkgs.bytestring)
             (hsPkgs.canonical-json)
+            (hsPkgs.containers)
             (hsPkgs.aeson)
             (hsPkgs.vector)
             (hsPkgs.unordered-containers)
@@ -39,11 +41,22 @@
             ];
           };
         };
+      benchmarks = {
+        "parse-bench" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.bytestring)
+            (hsPkgs.canonical-json)
+            (hsPkgs.containers)
+            (hsPkgs.criterion)
+            ];
+          };
+        };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "http://github.com/nc6/canonical-json";
-      rev = "a9dc9b893649bc2e2a770ab22d278a780f7e3a3c";
-      sha256 = "0alwbi9xqaj6fmwzs6lr2drqrnhlnp13d9k2qkl5ga7h4grz9zcr";
+      url = "http://github.com/well-typed/canonical-json";
+      rev = "ddfe3593b80b5ceb88842bb7a6f2268df75d2c2f";
+      sha256 = "02fzn1xskis1lc1pkz0j92v6ipd89ww0k2p3dvwpm3yap5dpnm7k";
       });
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -1,6 +1,6 @@
 { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = { development = false; };
+    flags = { development = false; test-normal-form = false; };
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-ledger"; version = "0.1.0.0"; };
@@ -83,6 +83,27 @@
             (hsPkgs.text)
             (hsPkgs.time)
             (hsPkgs.vector)
+            ];
+          };
+        "epoch-validation-normal-form-test" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.bytestring)
+            (hsPkgs.cardano-ledger)
+            (hsPkgs.cardano-crypto-test)
+            (hsPkgs.cardano-crypto-wrapper)
+            (hsPkgs.cardano-prelude)
+            (hsPkgs.cardano-prelude-test)
+            (hsPkgs.containers)
+            (hsPkgs.directory)
+            (hsPkgs.filepath)
+            (hsPkgs.formatting)
+            (hsPkgs.hedgehog)
+            (hsPkgs.optparse-applicative)
+            (hsPkgs.resourcet)
+            (hsPkgs.streaming)
+            (hsPkgs.tasty)
+            (hsPkgs.tasty-hedgehog)
             ];
           };
         };

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -89,6 +89,7 @@
           depends = [
             (hsPkgs.base)
             (hsPkgs.bytestring)
+            (hsPkgs.cardano-binary)
             (hsPkgs.cardano-ledger)
             (hsPkgs.cardano-crypto-test)
             (hsPkgs.cardano-crypto-wrapper)
@@ -101,6 +102,7 @@
             (hsPkgs.hedgehog)
             (hsPkgs.optparse-applicative)
             (hsPkgs.resourcet)
+            (hsPkgs.silently)
             (hsPkgs.streaming)
             (hsPkgs.tasty)
             (hsPkgs.tasty-hedgehog)

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "a136c4242b9c9f6124b811329bc8ccdfd86c514e";
-      sha256 = "0blwf2s4z7zfra4r9mha0g4irdz1migqspa2dn1ysg9jf2cn1bwj";
+      rev = "cca3c4f8da1de19321e96a5a7cca376bc6c37637";
+      sha256 = "087yby0q18xk9i2f50a4gjz9rdn1jgwwp8yi3qv5b2nbwb2pzvn7";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -69,7 +69,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "a136c4242b9c9f6124b811329bc8ccdfd86c514e";
-      sha256 = "0blwf2s4z7zfra4r9mha0g4irdz1migqspa2dn1ysg9jf2cn1bwj";
+      rev = "cca3c4f8da1de19321e96a5a7cca376bc6c37637";
+      sha256 = "087yby0q18xk9i2f50a4gjz9rdn1jgwwp8yi3qv5b2nbwb2pzvn7";
       });
     }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -11,6 +11,7 @@
         "streaming-binary" = (((hackage.streaming-binary)."0.3.0.1").revisions).default;
         "transformers" = (((hackage.transformers)."0.5.6.2").revisions).default;
         "process" = (((hackage.process)."1.6.5.0").revisions).default;
+        "pretty-show" = (((hackage.pretty-show)."1.8.2").revisions).default;
         } // {
         cardano-ledger = ./cardano-ledger.nix;
         cardano-ledger-test = ./cardano-ledger-test.nix;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -21,7 +21,7 @@ let
   #  packages.cbors.patches = [ ./one.patch ];
   #  packages.cbors.flags.optimize-gmp = false;
   #
-  compiler = (stack-pkgs.extras {}).compiler.nix-name;
+  compiler = (stack-pkgs.extras haskell.hackage).compiler.nix-name;
   pkgSet = haskell.mkStackPkgSet {
     inherit stack-pkgs;
     # The overlay allows extension or restriction of the set of
@@ -47,6 +47,8 @@ let
 
         packages.cardano-ledger.preBuild =
           "export CARDANO_MAINNET_MIRROR=${cardano-mainnet-mirror}/epochs";
+
+        packages.cardano-ledger.flags.test-normal-form = true;
 
         packages.cardano-ledger.components.tests.cardano-ledger-test = {
           build-tools = [ pkgs.makeWrapper ];

--- a/release.nix
+++ b/release.nix
@@ -53,6 +53,7 @@ localLib.pkgs.lib.mapAttrsRecursiveCond
     jobs.nix-tools.libs.cardano-ledger.x86_64-darwin
     jobs.nix-tools.libs.cardano-ledger.x86_64-linux
     jobs.nix-tools.tests.cardano-ledger.cardano-ledger-test.x86_64-linux
+    jobs.nix-tools.tests.cardano-ledger.epoch-validation-normal-form-test.x86_64-linux
 
     # windows cross compilation targets
     jobs.nix-tools.libs.x86_64-pc-mingw32-cardano-ledger.x86_64-linux

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/a136c4242b9c9f6124b811329bc8ccdfd86c514e/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/cca3c4f8da1de19321e96a5a7cca376bc6c37637/snapshot.yaml
 
 packages:
   - cardano-ledger
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: a136c4242b9c9f6124b811329bc8ccdfd86c514e
+    commit: cca3c4f8da1de19321e96a5a7cca376bc6c37637
     subdirs:
       - .
       - test

--- a/test/NormalFormTest.hs
+++ b/test/NormalFormTest.hs
@@ -1,0 +1,31 @@
+{-|
+This module basically just runs the mainnet epoch validation tests from
+"Test.Cardano.Chain.Block.Validation" but provided a 'ShouldAssertNF' value of
+'AssertNF'.
+
+We've created a separate test executable for this as, in our typical CI jobs,
+we utilize @hpc@ (i.e. building with @ghc -fhpc@ or @stack --coverage@) for
+providing code coverage. @hpc@ appears to introduce thunks around our Haskell
+expressions for its program coverage measurement purposes which prevents us
+from accurately determining whether a given expression is in normal form. As a
+result, we have another CI job which will build and run this test executable
+without @hpc@.
+-}
+
+module Main
+  ( main
+  )
+where
+
+import Cardano.Prelude
+
+import Test.Options (ShouldAssertNF (..), mainWithTestScenario, tsGroupToTree)
+
+import qualified Test.Cardano.Chain.Block.Validation
+
+
+main :: IO ()
+main =
+  mainWithTestScenario
+    . tsGroupToTree
+    $ Test.Cardano.Chain.Block.Validation.tests AssertNF


### PR DESCRIPTION
I've added an option to `Test.Cardano.Chain.Block.Validation.tests` which either enables or disables an assertion to ensure that the `ChainValidationState` is always in normal form after validating each epoch. 

- In our existing `cardano-ledger-test` test-suite, we specify **not** to assert that the `ChainValidationState` is in normal form (`NoAssertNF`).
- Added a new test executable, `epoch-validation-normal-form-test`, in which we specify to assert that the `ChainValidationState` is in normal form (`AssertNF`). I've also added a new CI job which builds and executes this without `hpc` coverage.

The new test executable and CI job was added as a means of circumventing an "issue" which was encountered in our existing CI job. Because our existing CI job builds with `hpc` (`ghc -fhpc`/`stack --coverage`), thunks are introduced throughout our program for `hpc`'s program coverage measurement purposes and this prevents us from accurately determining whether a given expression is in normal form. 

So, following @erikd's advice, I've introduced this new test executable (which will be built without `hpc`) which basically just calls upon `Test.Cardano.Chain.Block.Validation.tests` and provides it with an argument of `AssertNF`. This way, we can still build and test our normal test-suite with code coverage and also test this new normal form assertion in a separate CI job.

### Notes

The function [`heap_view_closurePtrs`](https://gitlab.haskell.org/ghc/ghc/blob/3bdf0d01ff47977830ada30ce85f174098486e23/rts/Heap.c#L79) in [`ghc/rts/Heap.c`](https://gitlab.haskell.org/ghc/ghc/blob/3bdf0d01ff47977830ada30ce85f174098486e23/rts/Heap.c) currently does not handle closures of type `CONSTR_NOCAF` and, as a result, it `fprintf`s a message to `stderr` every time it encounters one: `"closurePtrs: Cannot handle type CONSTR_NOCAF yet"`. 

Since the `isNormalForm` function utilizes this function it could get a bit "spammy" if we run into `CONSTR_NOCAF`s when running the test-suite. However, I've only seen that `CompactTxInUtxo`s are allocated as `CONSTR_NOCAF`s when we compile with `-O2`. In our CI jobs, we tend to use `stack --fast` (`-O0`) so we don't see this sort of spammy output to `stderr` in the logs.

It's also worth noting that [Joachim Breitner has recently raised a PR with `ghc` for specifically handling `CONSTR_NOCAF` objects in `heap_view_closurePtrs`](https://gitlab.haskell.org/ghc/ghc/merge_requests/867) 