### PR TITLE
Consensus Integration

### DIFF
--- a/cardano-ledger.cabal
+++ b/cardano-ledger.cabal
@@ -37,6 +37,7 @@ library
                        Cardano.Chain.UTxO.UTxO
                        Cardano.Chain.UTxO.Validation
                        Cardano.Chain.Update
+                       Cardano.Chain.Update.Validation.Interface
 
   other-modules:
                        Cardano.Chain.Block.Block
@@ -104,7 +105,6 @@ library
                        Cardano.Chain.Update.SoftwareVersion
                        Cardano.Chain.Update.SystemTag
                        Cardano.Chain.Update.Validation.Endorsement
-                       Cardano.Chain.Update.Validation.Interface
                        Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
                        Cardano.Chain.Update.Validation.Registration
                        Cardano.Chain.Update.Validation.Voting

--- a/crypto/src/Cardano/Crypto/Signing/Signature.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Signature.hs
@@ -137,12 +137,12 @@ sign
   -> SigningKey
   -> a
   -> Signature a
-sign pm tag sk = signEncoded pm tag sk . serialize'
+sign pm tag sk = signEncoded pm tag sk . toCBOR
 
 -- | Like 'sign' but without the 'ToCBOR' constraint
 signEncoded
-  :: ProtocolMagicId -> SignTag -> SigningKey -> ByteString -> Signature a
-signEncoded pm tag sk = coerce . signRaw pm (Just tag) sk
+  :: ProtocolMagicId -> SignTag -> SigningKey -> Encoding -> Signature a
+signEncoded pm tag sk = coerce . signRaw pm (Just tag) sk . BSL.toStrict . serializeEncoding
 
 -- | Sign a 'Raw' bytestring
 signRaw

--- a/crypto/test/Test/Cardano/Crypto/Gen.hs
+++ b/crypto/test/Test/Cardano/Crypto/Gen.hs
@@ -54,6 +54,7 @@ import Cardano.Prelude
 import Test.Cardano.Prelude
 
 import qualified Data.ByteArray as ByteArray
+import Data.Coerce (coerce)
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -86,7 +87,7 @@ import Cardano.Crypto.Signing
   , proxySign
   , safeCreateProxyCert
   , sign
-  , signEncoded
+  , signRaw
   , toVerification
   )
 import Cardano.Crypto.Signing.Redeem
@@ -201,7 +202,7 @@ genSignature pm genA = sign pm <$> genSignTag <*> genSigningKey <*> genA
 
 genSignatureEncoded :: Gen ByteString -> Gen (Signature a)
 genSignatureEncoded genB =
-  signEncoded <$> genProtocolMagicId <*> genSignTag <*> genSigningKey <*> genB
+  coerce . signRaw <$> genProtocolMagicId <*> (Just <$> genSignTag) <*> genSigningKey <*> genB
 
 genRedeemSignature
   :: ToCBOR a => ProtocolMagicId -> Gen a -> Gen (RedeemSignature a)

--- a/crypto/test/Test/Cardano/Crypto/Signing/Signing.hs
+++ b/crypto/test/Test/Cardano/Crypto/Signing/Signing.hs
@@ -9,6 +9,7 @@ import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
+import Cardano.Binary (toCBOR)
 import Cardano.Crypto.Signing (SignTag(..), sign, toVerification, verifySignature)
 
 import qualified Test.Cardano.Crypto.Dummy as Dummy
@@ -35,7 +36,7 @@ prop_sign = property $ do
   a        <- forAll genData
 
   assert
-    $ verifySignature Dummy.protocolMagicId SignForTestingOnly vk a
+    $ verifySignature toCBOR Dummy.protocolMagicId SignForTestingOnly vk a
     $ sign Dummy.protocolMagicId SignForTestingOnly sk a
 
 -- | Signing fails when the wrong 'VerificationKey' is used
@@ -47,7 +48,7 @@ prop_signDifferentKey = property $ do
 
   assert
     . not
-    $ verifySignature Dummy.protocolMagicId SignForTestingOnly vk a
+    $ verifySignature toCBOR Dummy.protocolMagicId SignForTestingOnly vk a
     $ sign Dummy.protocolMagicId SignForTestingOnly sk a
 
 -- | Signing fails when then wrong signature data is used
@@ -59,7 +60,7 @@ prop_signDifferentData = property $ do
 
   assert
     . not
-    $ verifySignature Dummy.protocolMagicId SignForTestingOnly vk b
+    $ verifySignature toCBOR Dummy.protocolMagicId SignForTestingOnly vk b
     $ sign Dummy.protocolMagicId SignForTestingOnly sk a
 
 genData :: Gen [Int32]

--- a/src/Cardano/Chain/Block/Validation.hs
+++ b/src/Cardano/Chain/Block/Validation.hs
@@ -21,6 +21,7 @@ module Cardano.Chain.Block.Validation
   , ChainValidationState(..)
   , initialChainValidationState
   , ChainValidationError
+  , HeaderEnvironment(..)
 
   -- * SigningHistory
   , SigningHistory(..)

--- a/src/Cardano/Chain/Block/Validation.hs
+++ b/src/Cardano/Chain/Block/Validation.hs
@@ -17,6 +17,7 @@ module Cardano.Chain.Block.Validation
   , updateHeader
   , updateBlock
   , BodyState(..)
+  , BodyEnvironment(..)
   , ChainValidationState(..)
   , initialChainValidationState
   , ChainValidationError

--- a/src/Cardano/Chain/Block/Validation.hs
+++ b/src/Cardano/Chain/Block/Validation.hs
@@ -16,6 +16,7 @@ module Cardano.Chain.Block.Validation
   , updateChainBoundary
   , updateHeader
   , updateBlock
+  , BodyState(..)
   , ChainValidationState(..)
   , initialChainValidationState
   , ChainValidationError


### PR DESCRIPTION
This PR incorporates the various changes needed for integration with the consensus layer. They can be divided into three basic ideas:

- Firstly, we expose a bunch of things which were previously hidden, because they're needed.
- Secondly, we change some of the serialisation code to take a more explicit serialiser, rather than using ToCBOR constraints which the consensus layer can typically not satisfy.

This replaces PR #474