### PR TITLE
Removed obsolete cardano-mainnet-mirror submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "cardano-mainnet-mirror"]
-	path = cardano-mainnet-mirror
-	url = https://github.com/input-output-hk/cardano-mainnet-mirror.git


### PR DESCRIPTION
 Now provided through a nix import since #476.
 Side note: using git submodule makes nix caching
 less efficient, especially for large submodules.