### PR TITLE
[#501] Revisit Header and Block serialization functions

### DIFF
--- a/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -34,16 +34,16 @@ import Cardano.Chain.Block
   , Proof(..)
   , ToSign(..)
   , body
-  , fromCBORBlockOrBoundary
-  , fromCBORHeader
-  , fromCBORHeader'
   , dropBoundaryBody
   , dropBoundaryConsensusData
   , dropBoundaryHeader
-  , toCBORBlock
-  , toCBORHeader
-  , toCBORHeader'
+  , fromCBORABOBBlock
+  , fromCBORHeader
+  , fromCBORHeaderToHash
   , mkHeaderExplicit
+  , toCBORABOBBlock
+  , toCBORHeader
+  , toCBORHeaderToHash
   )
 import qualified Cardano.Chain.Delegation as Delegation
 import Cardano.Chain.Slotting
@@ -95,8 +95,8 @@ exampleEs = EpochSlots 50
 goldenHeader :: Property
 goldenHeader = goldenTestCBORExplicit
   "Header"
-  (toCBORHeader' exampleEs)
-  (fromCBORHeader' exampleEs)
+  (toCBORHeader exampleEs)
+  (fromCBORHeader exampleEs)
   exampleHeader
   "test/golden/cbor/block/Header"
 
@@ -110,9 +110,9 @@ ts_roundTripHeaderCompat = eachOfTS
   roundTripsHeaderCompat :: WithEpochSlots Header -> H.PropertyT IO ()
   roundTripsHeaderCompat esh@(WithEpochSlots es _) = trippingBuildable
     esh
-    (serializeEncoding . toCBORHeader es . unWithEpochSlots)
+    (serializeEncoding . toCBORHeaderToHash es . unWithEpochSlots)
     ( fmap (WithEpochSlots es . fromJust)
-    . decodeFullDecoder "Header" (fromCBORHeader es)
+    . decodeFullDecoder "Header" (fromCBORHeaderToHash es)
     )
 
 --------------------------------------------------------------------------------
@@ -129,9 +129,9 @@ ts_roundTripBlockCompat = eachOfTS
   roundTripsBlockCompat :: WithEpochSlots Block -> H.PropertyT IO ()
   roundTripsBlockCompat esb@(WithEpochSlots es _) = trippingBuildable
     esb
-    (serializeEncoding . toCBORBlock es . unWithEpochSlots)
+    (serializeEncoding . toCBORABOBBlock es . unWithEpochSlots)
     ( fmap (WithEpochSlots es . fromJust)
-    . decodeFullDecoder "Block" (fromCBORBlockOrBoundary es)
+    . decodeFullDecoder "Block" (fromCBORABOBBlock es)
     )
 
 

--- a/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -153,7 +153,7 @@ annotateBlock epochSlots block =
       Concrete.ABOBBlock bk -> bk
       Concrete.ABOBBoundary _ ->
         panic "This function should have decoded a block."
-  where bytes = Binary.serializeEncoding (Concrete.toCBORBlock epochSlots block)
+  where bytes = Binary.serializeEncoding (Concrete.toCBORABOBBlock epochSlots block)
 
 -- | Re-construct an abstract delegation certificate from the abstract state.
 --


### PR DESCRIPTION
Closes #501

@nc6 I think this might affect the consensus-ledger integration when updating `cardano-ledger` dep. Can you make a note of the changes:

`toCBORHeader` -> `toCBORHeaderToHash`
`fromCBORHeader` -> `fromCBORHeaderToHash`
`toCBORHeader'` -> `toCBORHeader`
`fromCBORHeader'` -> `fromCBORHeader`
`toCBORBlock` -> `toCBORABOBBlock`
`fromCBORBlockOrBoundary` -> `fromCBORABOBBlock`
`toCBORBlockWithoutBoundary` -> `toCBORBlock`

So now any encoding of just a block or header has the default name and deviations for hashing or boundaries have other names. Hopefully this makes more sense now!