### PR TITLE
adding a cabal flag reduces the number of extra dependencies

### DIFF
--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -5,9 +5,6 @@
         "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.0").revisions).default;
         "haskell-src-exts" = (((hackage.haskell-src-exts)."1.21.0").revisions).default;
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
-        "ekg-prometheus-adapter" = (((hackage.ekg-prometheus-adapter)."0.1.0.4").revisions).default;
-        "prometheus" = (((hackage.prometheus)."2.1.1").revisions).default;
-        "containers" = (((hackage.containers)."0.5.11.0").revisions).default;
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;
         "hedgehog" = (((hackage.hedgehog)."1.0").revisions).default;
         "micro-recursion-schemes" = (((hackage.micro-recursion-schemes)."5.0.2.2").revisions).default;

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -3,7 +3,7 @@
     flags = {
       disable-aggregation = false;
       disable-ekg = false;
-      disable-prometheus = false;
+      disable-prometheus = true;
       disable-gui = false;
       disable-monitoring = false;
       disable-observables = false;

--- a/stack.yaml
+++ b/stack.yaml
@@ -46,16 +46,16 @@ extra-deps:
       - contra-tracer
       - iohk-monitoring
 
-  - ekg-prometheus-adapter-0.1.0.4
-  - prometheus-2.1.1
-  - containers-0.5.11.0
-
   # Extracted from cardano-sl since it's quite useful
   - git: https://github.com/input-output-hk/cardano-sl-x509
     commit: e8bfc1294e088f90e5ae0b4aedbc82ee46ac5ee4
 
   - git: https://github.com/joelwilliamson/bimap
     commit: 997fbb38b08dec14d225d064dac05b0a85f4ceae
+
+flags:
+  iohk-monitoring:
+    disable-prometheus: true
 
 nix:
   shell-file: nix/stack-shell.nix


### PR DESCRIPTION
Signed-off-by: Alexander Diemand <codieplusplus@apax.net>

adding this flag already reduces the transitive depencies.