### PR TITLE
Add ToCBOR and FromCBOR instances for ChainValidationState

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -42,11 +42,19 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.Coerce (coerce)
 import qualified Data.Map.Strict as M
 import Data.Sequence (Seq(..), (<|))
+import qualified Data.Sequence as Seq
 import Formatting.Buildable (Buildable)
 import Streaming (Of(..), Stream, hoist)
 import qualified Streaming.Prelude as S
 
-import Cardano.Binary (Annotated(..), serialize')
+import Cardano.Binary
+  ( Annotated(..)
+  , FromCBOR(..)
+  , ToCBOR(..)
+  , encodeListLen
+  , enforceSize
+  , serialize'
+  )
 import Cardano.Chain.Block.Body (ABody (..))
 import Cardano.Chain.Block.Block
   ( ABlock(..)
@@ -130,6 +138,21 @@ data SigningHistory = SigningHistory
   , shKeyHashCounts :: !(Map KeyHash BlockCount)
   } deriving (Eq, Show, Generic, NFData)
 
+instance FromCBOR SigningHistory where
+  fromCBOR = do
+    enforceSize "SigningHistory" 3
+    SigningHistory
+      <$> fromCBOR
+      <*> (Seq.fromList <$> fromCBOR)
+      <*> fromCBOR
+
+instance ToCBOR SigningHistory where
+  toCBOR sh =
+    encodeListLen 3
+      <> toCBOR (shK sh)
+      <> toCBOR (toList (shSigningQueue sh))
+      <> toCBOR (shKeyHashCounts sh)
+
 -- | Update the `SigningHistory` with a new signer, removing the oldest value if
 --   the sequence is @K@ blocks long
 updateSigningHistory :: VerificationKey -> SigningHistory -> SigningHistory
@@ -174,6 +197,27 @@ data ChainValidationState = ChainValidationState
   , cvsUpdateState     :: !UPI.State
   , cvsDelegationState :: !DI.State
   } deriving (Eq, Show, Generic, NFData)
+
+instance FromCBOR ChainValidationState where
+  fromCBOR = do
+    enforceSize "ChainValidationState" 6
+    ChainValidationState
+      <$> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+
+instance ToCBOR ChainValidationState where
+  toCBOR c =
+    encodeListLen 6
+      <> toCBOR (cvsLastSlot c)
+      <> toCBOR (cvsSigningHistory c)
+      <> toCBOR (cvsPreviousHash c)
+      <> toCBOR (cvsUtxo c)
+      <> toCBOR (cvsUpdateState c)
+      <> toCBOR (cvsDelegationState c)
 
 -- | Create the state needed to validate the zeroth epoch of the chain. The
 --   zeroth epoch starts with a boundary block where the previous hash is the

--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -135,7 +135,7 @@ import Cardano.Chain.ValidationMode
 data SigningHistory = SigningHistory
   { shK                 :: !BlockCount
   , shSigningQueue      :: !(Seq KeyHash)
-  , shKeyHashCounts :: !(Map KeyHash BlockCount)
+  , shKeyHashCounts     :: !(Map KeyHash BlockCount)
   } deriving (Eq, Show, Generic, NFData)
 
 instance FromCBOR SigningHistory where

--- a/cardano-ledger/src/Cardano/Chain/Common/Compact.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Compact.hs
@@ -13,7 +13,7 @@ where
 
 import Cardano.Prelude
 
-import Cardano.Binary (serialize', decodeFull')
+import Cardano.Binary (FromCBOR(..), ToCBOR(..), serialize', decodeFull')
 import qualified Data.ByteString.Short as BSS (fromShort, toShort)
 import Data.ByteString.Short (ShortByteString)
 
@@ -31,6 +31,12 @@ newtype CompactAddress = CompactAddress ShortByteString
   deriving (Eq, Ord, Generic, Show)
   deriving newtype HeapWords
   deriving anyclass NFData
+
+instance FromCBOR CompactAddress where
+  fromCBOR = CompactAddress . BSS.toShort <$> fromCBOR
+
+instance ToCBOR CompactAddress where
+  toCBOR (CompactAddress sbs) = toCBOR (BSS.fromShort sbs)
 
 toCompactAddress :: Address -> CompactAddress
 toCompactAddress addr =

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Map.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Map.hs
@@ -25,6 +25,7 @@ import Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
 import qualified Data.Set as Set
 
+import Cardano.Binary (FromCBOR(..), ToCBOR(..))
 import Cardano.Chain.Common.KeyHash (KeyHash)
 
 
@@ -33,6 +34,11 @@ newtype Map = Map
   } deriving (Eq, Show, Generic)
     deriving anyclass NFData
 
+instance FromCBOR Map where
+  fromCBOR = Map . Bimap.fromList <$> fromCBOR
+
+instance ToCBOR Map where
+  toCBOR = toCBOR . Bimap.toList . unMap
 
 --------------------------------------------------------------------------------
 -- Query

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Activation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Activation.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.Chain.Delegation.Validation.Activation
   (
@@ -14,6 +15,7 @@ import Cardano.Prelude hiding (State)
 
 import qualified Data.Map.Strict as M
 
+import Cardano.Binary (FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize)
 import Cardano.Chain.Common (KeyHash)
 import qualified Cardano.Chain.Delegation as Delegation
 import Cardano.Chain.Delegation.Validation.Scheduling (ScheduledDelegation(..))
@@ -30,6 +32,19 @@ data State = State
   { delegationMap   :: !Delegation.Map
   , delegationSlots :: !(Map KeyHash SlotNumber)
   } deriving (Eq, Show, Generic, NFData)
+
+instance FromCBOR State where
+  fromCBOR = do
+    enforceSize "State" 2
+    State
+      <$> fromCBOR
+      <*> fromCBOR
+
+instance ToCBOR State where
+  toCBOR s =
+    encodeListLen 2
+      <> toCBOR (delegationMap s)
+      <> toCBOR (delegationSlots s)
 
 -- | Activate a 'ScheduledDelegation' if its activation slot is less than the
 --   previous delegation slot for this delegate, otherwise discard it. This is

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Hash.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Hash.hs
@@ -13,11 +13,11 @@ import Control.DeepSeq (NFData)
 
 import Cardano.Prelude
 
-import Cardano.Binary (Raw)
+import Cardano.Binary (Raw, FromCBOR, ToCBOR)
 import Cardano.Crypto.Hashing (Hash)
 
 newtype GenesisHash = GenesisHash
   { unGenesisHash :: Hash Raw
-  } deriving (Eq, Generic, NFData)
+  } deriving (Eq, Generic, NFData, FromCBOR, ToCBOR)
 
 deriving instance Show GenesisHash

--- a/cardano-ledger/src/Cardano/Chain/UTxO/Compact.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/Compact.hs
@@ -40,6 +40,7 @@ import Data.Binary.Put (Put, putWord64le, runPut)
 import qualified Data.ByteArray as BA (convert)
 import qualified Data.ByteString.Lazy as BSL (fromStrict, toStrict)
 
+import Cardano.Binary (FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize)
 import Cardano.Chain.Common.Compact
   (CompactAddress, fromCompactAddress, toCompactAddress)
 import Cardano.Chain.Common.Lovelace (Lovelace)
@@ -76,6 +77,19 @@ instance HeapWords CompactTxIn where
     -- +---------------------------------------------+
     --
     = 6
+
+instance FromCBOR CompactTxIn where
+  fromCBOR = do
+    enforceSize "CompactTxIn" 2
+    CompactTxInUtxo
+      <$> fromCBOR
+      <*> fromCBOR
+
+instance ToCBOR CompactTxIn where
+  toCBOR (CompactTxInUtxo txId txIndex) =
+    encodeListLen 2
+      <> toCBOR txId
+      <> toCBOR txIndex
 
 toCompactTxIn :: TxIn -> CompactTxIn
 toCompactTxIn (TxInUtxo txId txIndex) =
@@ -124,6 +138,23 @@ instance HeapWords CompactTxId where
     -- +-----------------------------------+
     --
     = 5
+
+instance FromCBOR CompactTxId where
+  fromCBOR = do
+    enforceSize "CompactTxId" 4
+    CompactTxId
+      <$> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+
+instance ToCBOR CompactTxId where
+  toCBOR (CompactTxId a b c d) =
+    encodeListLen 4
+      <> toCBOR a
+      <> toCBOR b
+      <> toCBOR c
+      <> toCBOR d
 
 getCompactTxId :: Get CompactTxId
 getCompactTxId =
@@ -193,6 +224,19 @@ instance HeapWords CompactTxOut where
     --                +--------------+
     --
     = 3 + heapWordsUnpacked compactAddr
+
+instance FromCBOR CompactTxOut where
+  fromCBOR = do
+    enforceSize "CompactTxOut" 2
+    CompactTxOut
+      <$> fromCBOR
+      <*> fromCBOR
+
+instance ToCBOR CompactTxOut where
+  toCBOR (CompactTxOut compactAddr lovelace) =
+    encodeListLen 2
+      <> toCBOR compactAddr
+      <> toCBOR lovelace
 
 toCompactTxOut :: TxOut -> CompactTxOut
 toCompactTxOut (TxOut addr lovelace) =

--- a/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
@@ -33,6 +33,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 
+import Cardano.Binary (FromCBOR, ToCBOR)
 import Cardano.Chain.Common
   (Address, Lovelace, LovelaceError, isRedeemAddress, sumLovelace)
 import Cardano.Chain.UTxO.Tx (Tx(..), TxId, TxIn(..), TxOut(..))
@@ -50,7 +51,7 @@ import Cardano.Crypto (hash)
 newtype UTxO = UTxO
   { unUTxO :: Map CompactTxIn CompactTxOut
   } deriving (Eq, Show, Generic)
-    deriving newtype HeapWords
+    deriving newtype (HeapWords, FromCBOR, ToCBOR)
     deriving anyclass NFData
 
 data UTxOError

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -229,6 +229,20 @@ ts_roundTripProofCBOR = eachOfTS 20 (feedPM genProof) roundTripsCBORBuildable
 
 
 --------------------------------------------------------------------------------
+-- SigningHistory
+--------------------------------------------------------------------------------
+
+-- TODO:
+-- goldenSigningHistory :: Property
+-- goldenSigningHistory =
+--   goldenTestCBOR exampleSigningHistory "test/golden/cbor/block/SigningHistory"
+
+ts_roundTripSigningHistoryCBOR :: TSProperty
+ts_roundTripSigningHistoryCBOR =
+  eachOfTS 20 genSigningHistory roundTripsCBORShow
+
+
+--------------------------------------------------------------------------------
 -- ToSign
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This requires `ToCBOR` and `FromCBOR` instances for a whole bunch of other types
too.

The consensus storage layer needs these instances in order to write/read snapshots of the ledger state to/from disk.

Roundtrip property tests and golden tests still need to be written. Can somebody of the ledger team do this? Feel free to push more commits to this PR.

 I tried to adhere to the existing style as much as I could, but I might have made some mistakes.