### PR TITLE
Add a specific tag for genesis block

### DIFF
--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
@@ -203,19 +203,10 @@ genBlock protocolMagicId epochSlots =
         body
 
 genBoundaryValidationData :: Gen (BoundaryValidationData ())
-genBoundaryValidationData = do
-    (epoch, hash) <- genBVDHash
-    BoundaryValidationData
-      <$> pure 0
-      <*> pure hash
-      <*> pure epoch
-      <*> genChainDifficulty
-      <*> pure ()
-  where
-    genBVDHash = Gen.choice
-      [ ((,) <$> Gen.word64 (Range.constantFrom 10 1 100)
-             <*> (Right <$> genHeaderHash))
-      , ((,) <$> pure 0
-             <*> (Left . GenesisHash . coerce <$> genTextHash)
-        )
-      ]
+genBoundaryValidationData = 
+  BoundaryValidationData
+    <$> pure 0
+    <*> (Gen.choice [Right <$> genHeaderHash, Left . GenesisHash . coerce <$> genTextHash])
+    <*> (Gen.word64 (Range.constantFrom 10 0 1000))
+    <*> genChainDifficulty
+    <*> pure ()


### PR DESCRIPTION
This is a little ugly. The ouroboros-consensus demo does not necessarily start in epoch 0 (it does this in order to easily synchronise time). This means we have a "genesis" EBB in a non-0 epoch. In order to round-trip the serialisation here correctly, we add an extra tag into the attributes which encodes the presence of a genesis hash.

This only applies on non-0 epochs, so should not be invoked by any existing code - these will only be produced in the demo, and everything else should carry on regardless.