### PR TITLE
BoundaryValidationData annotation for whole block

### DIFF
--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
@@ -210,3 +210,4 @@ genBoundaryValidationData =
     <*> (Gen.word64 (Range.constantFrom 10 0 1000))
     <*> genChainDifficulty
     <*> pure ()
+    <*> pure ()


### PR DESCRIPTION
byron-proxy needs to de-serialize and re-serialize boundary blocks.
By retaining the bytes of the whole boundary block, this is now
possible. The CBOR list length and tag discriminator bytes can be
pre-pended to this byte string annotation.