### PR TITLE
Derive `Monoid` and `Semigroup` instances for `AbstractToConcreteIdMaps` ...

### DIFF
--- a/cardano-ledger/cardano-ledger.cabal
+++ b/cardano-ledger/cardano-ledger.cabal
@@ -258,6 +258,7 @@ test-suite cardano-ledger-test
                      , directory
                      , filepath
                      , formatting
+                     , generic-monoid
                      , hedgehog
                      , lens
                      , mtl

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -1,8 +1,11 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE OverloadedLists   #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia        #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE OverloadedLists    #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TypeApplications   #-}
 
 -- | This module provides functionality for translating abstract blocks into
 -- concrete blocks. The abstract blocks are generated according the small-step
@@ -28,8 +31,10 @@ import Data.Bimap (Bimap)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce (coerce)
 import qualified Data.Map as Map
+import Data.Monoid.Generic (GenericSemigroup (GenericSemigroup), GenericMonoid (GenericMonoid))
 import qualified Data.Set as Set
 import Data.Time (Day(ModifiedJulianDay), UTCTime(UTCTime))
+import GHC.Generics (Generic)
 
 import qualified Cardano.Binary as Binary
 import qualified Cardano.Crypto.Hashing as H
@@ -80,15 +85,9 @@ import qualified Test.Cardano.Crypto.Dummy as Dummy
 data AbstractToConcreteIdMaps = AbstractToConcreteIdMaps
   { transactionIds :: !(Map Abstract.TxId UTxO.TxId)
   , proposalIds :: !(Map Abstract.Update.UpId Update.UpId)
-  } deriving (Eq, Show)
-
-instance Semigroup AbstractToConcreteIdMaps where
-  (AbstractToConcreteIdMaps tids0 pids0) <> (AbstractToConcreteIdMaps tids1 pids1) =
-    AbstractToConcreteIdMaps (tids0 <> tids1) (pids0 <> pids1)
-
-instance Monoid AbstractToConcreteIdMaps where
-  mempty = AbstractToConcreteIdMaps Map.empty Map.empty
-
+  } deriving (Eq, Show, Generic)
+  deriving Semigroup via GenericSemigroup AbstractToConcreteIdMaps
+  deriving Monoid via GenericMonoid AbstractToConcreteIdMaps
 
 -- | Elaborate an abstract block into a concrete block (without annotations).
 elaborate

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -72,6 +72,7 @@
             (hsPkgs.directory)
             (hsPkgs.filepath)
             (hsPkgs.formatting)
+            (hsPkgs.generic-monoid)
             (hsPkgs.hedgehog)
             (hsPkgs.lens)
             (hsPkgs.mtl)

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -5,6 +5,7 @@
         "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;
         "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.1").revisions).default;
         "haskell-src-exts" = (((hackage.haskell-src-exts)."1.21.0").revisions).default;
+        "generic-monoid" = (((hackage.generic-monoid)."0.1.0.0").revisions).default;
         "bimap" = (((hackage.bimap)."0.4.0").revisions).default;
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,11 +9,12 @@ packages:
 extra-deps:
   - libsystemd-journal-1.4.4
 
-  # Currently Hackage only
   - tasty-hedgehog-1.0.0.1
 
   # To be able to use `stack hoogle`
   - haskell-src-exts-1.21.0
+
+  - generic-monoid-0.1.0.0
 
   - git: https://github.com/input-output-hk/cardano-prelude
     commit: d673b92f2a2d9354d102514d0a0fa74f8248b14a


### PR DESCRIPTION
... using `generic-monoid`.