### PR TITLE
export KeyHash constructor

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Common/KeyHash.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/KeyHash.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE UndecidableInstances       #-}
 
 module Cardano.Chain.Common.KeyHash
-  ( KeyHash
+  ( KeyHash (..)
   , hashKey
   )
 where


### PR DESCRIPTION
I have an application in which I need to construct a KeyHash from an
already hashed thing, namely a StakeholderId from cardano-sl.

This doesn't make it any less safe. `KeyHash` has `FromCBOR` so you
could always use that to construct one that's not actually a hash of a
`VerificationKey`.