### PR TITLE
Fixes the order of transaction application

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -45,19 +45,19 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 423a7359049b0fd6fb2a931c50877cae2a96eaae
+  tag: c3ab05c9966091c76ffecd27866e6f7f0f0c026f
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 423a7359049b0fd6fb2a931c50877cae2a96eaae
+  tag: c3ab05c9966091c76ffecd27866e6f7f0f0c026f
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 423a7359049b0fd6fb2a931c50877cae2a96eaae
+  tag: c3ab05c9966091c76ffecd27866e6f7f0f0c026f
   subdir: byron/chain/executable-spec
 
 source-repository-package

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -155,7 +155,7 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
 
   (txPayload, txIdMap') = first (fmap void) $ elaborateTxWitnesses
     txIdMap
-    (reverse $ abstractBlock ^. Abstract.bBody . Abstract.bUtxo)
+    (abstractBlock ^. Abstract.bBody . Abstract.bUtxo)
 
   updatePayload :: Update.APayload ()
   updatePayload =


### PR DESCRIPTION
Per https://github.com/input-output-hk/cardano-ledger-specs/issues/655 this fixes the order in which transactions are applied.

It takes care of the other half of issue https://github.com/input-output-hk/cardano-ledger-specs/issues/655.