### PR TITLE
Remove most Ord instances for crypto keys

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,12 +17,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 8273fe5f00ac03b0c66ef3841c8e957139ee18f2
+  tag: 4c48d34fd60991bb1b9168d293cfe31a975d858e
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 8273fe5f00ac03b0c66ef3841c8e957139ee18f2
+  tag: 4c48d34fd60991bb1b9168d293cfe31a975d858e
   subdir: test
 
 source-repository-package
@@ -63,13 +63,13 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 0dae43937d2858b437bfc93f7952ba93b88607e6
+  tag: 38d601eb3dd20e8a27b7b7008aa90c70db911089
   subdir: contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 0dae43937d2858b437bfc93f7952ba93b88607e6
+  tag: 38d601eb3dd20e8a27b7b7008aa90c70db911089
   subdir: iohk-monitoring
 
 source-repository-package

--- a/crypto/cardano-crypto-wrapper.cabal
+++ b/crypto/cardano-crypto-wrapper.cabal
@@ -96,6 +96,7 @@ test-suite test
                        Test.Cardano.Crypto.Json
                        Test.Cardano.Crypto.Keys
                        Test.Cardano.Crypto.Limits
+                       Test.Cardano.Crypto.Orphans
                        Test.Cardano.Crypto.Random
                        Test.Cardano.Crypto.Signing.Redeem
                        Test.Cardano.Crypto.Signing.Safe

--- a/crypto/src/Cardano/Crypto/Orphans.hs
+++ b/crypto/src/Cardano/Crypto/Orphans.hs
@@ -35,15 +35,6 @@ fromByteStringToScrubbedBytes = BA.convert
 toByteString :: (BA.ByteArrayAccess bin) => bin -> ByteString
 toByteString = BA.convert
 
-instance Ord Ed25519.PublicKey where
-  compare x1 x2 = compare (toByteString x1) (toByteString x2)
-
-instance Ord Ed25519.SecretKey where
-  compare x1 x2 = compare (toByteString x1) (toByteString x2)
-
-instance Ord Ed25519.Signature where
-  compare x1 x2 = compare (toByteString x1) (toByteString x2)
-
 fromCryptoFailable :: T.Text -> CryptoFailable a -> Either T.Text a
 fromCryptoFailable item (CryptoFailed e) =
   Left $ "Cardano.Crypto.Orphan." <> item <> " failed because " <> show e

--- a/crypto/src/Cardano/Crypto/Signing/Redeem/Signature.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Redeem/Signature.hs
@@ -32,7 +32,10 @@ import Cardano.Crypto.Signing.Tag (SignTag, signTag, signTagDecoded)
 -- | Wrapper around 'Ed25519.Signature'
 newtype RedeemSignature a =
   RedeemSignature Ed25519.Signature
-  deriving (Eq, Ord, Show, Generic, NFData, FromCBOR, ToCBOR)
+  deriving (Eq, Show, Generic, NFData, FromCBOR, ToCBOR)
+
+-- Note that there is deliberately no Ord instance. The crypto libraries
+-- encourage using key /hashes/ not keys for things like sets, map etc.
 
 instance B.Buildable (RedeemSignature a) where
   build _ = "<redeem signature>"

--- a/crypto/src/Cardano/Crypto/Signing/Redeem/SigningKey.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Redeem/SigningKey.hs
@@ -22,7 +22,10 @@ import Cardano.Crypto.Signing.Redeem.VerificationKey
 -- | Wrapper around 'Ed25519.SecretKey'.
 newtype RedeemSigningKey =
   RedeemSigningKey Ed25519.SecretKey
-  deriving (Eq, Ord, Show, Generic, NFData, FromCBOR, ToCBOR)
+  deriving (Eq, Show, Generic, NFData, FromCBOR, ToCBOR)
+
+-- Note that there is deliberately no Ord instance. The crypto libraries
+-- encourage using key /hashes/ not keys for things like sets, map etc.
 
 instance B.Buildable RedeemSigningKey where
   build = bprint ("redeem_sec_of_vk:" . redeemVKB64F) . redeemToVerification

--- a/crypto/src/Cardano/Crypto/Signing/Redeem/VerificationKey.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Redeem/VerificationKey.hs
@@ -50,7 +50,18 @@ import Cardano.Crypto.Orphans ()
 -- | Wrapper around 'Ed25519.PublicKey'.
 newtype RedeemVerificationKey =
   RedeemVerificationKey Ed25519.PublicKey
-  deriving (Eq, Ord, Show, Generic, NFData, FromCBOR, ToCBOR)
+  deriving (Eq, Show, Generic, NFData, FromCBOR, ToCBOR)
+
+-- Note that normally we would not provide any Ord instances.
+-- The crypto libraries encourage using key /hashes/ not keys for
+-- things like sets, map etc. However due to a historical mistake the
+-- AVVM balances use whole keys, not key hashes. So we compromise here
+-- and provide Ord instances so we can use RedeemVerificationKey
+-- as the key type in a Data.Map.
+
+instance Ord RedeemVerificationKey where
+  RedeemVerificationKey a `compare` RedeemVerificationKey b =
+    BA.convert a `compare` (BA.convert b :: ByteString)
 
 instance Monad m => ToObjectKey m RedeemVerificationKey where
   toObjectKey = pure . toJSString . formatToString redeemVKB64UrlF

--- a/crypto/src/Cardano/Crypto/Signing/SigningKey.hs
+++ b/crypto/src/Cardano/Crypto/Signing/SigningKey.hs
@@ -19,21 +19,22 @@ import Formatting (bprint)
 
 import Cardano.Binary (Decoder, Encoding, FromCBOR(..), ToCBOR(..))
 import Cardano.Crypto.Signing.VerificationKey (VerificationKey(..), shortVerificationKeyHexF)
-import Cardano.Crypto.Hashing (hash)
 
 
 -- | Wrapper around 'CC.XPrv'.
 newtype SigningKey = SigningKey CC.XPrv
     deriving (NFData)
 
+-- Note that there is deliberately no Eq instance. The cardano-crypto library
+-- does not define one for XPrv.
+
+-- Note that there is deliberately no Ord instance. The crypto libraries
+-- encourage using key /hashes/ not keys for things like sets, map etc.
+
 -- | Generate a verification key from a signing key. Fast (it just drops some bytes
 -- off the signing key).
 toVerification :: SigningKey -> VerificationKey
 toVerification (SigningKey k) = VerificationKey (CC.toXPub k)
-
--- | Direct comparison of signing keys is a security issue (cc @vincent)
-instance Eq SigningKey where
-  a == b = hash a == hash b
 
 instance Show SigningKey where
   show sk = "<signing of " ++ show (toVerification sk) ++ ">"

--- a/crypto/test/Test/Cardano/Crypto/Gen.hs
+++ b/crypto/test/Test/Cardano/Crypto/Gen.hs
@@ -84,6 +84,7 @@ import Cardano.Crypto.Signing.Redeem
   , redeemDeterministicKeyGen
   , redeemSign
   )
+import Test.Cardano.Crypto.Orphans ()
 
 
 --------------------------------------------------------------------------------

--- a/crypto/test/Test/Cardano/Crypto/Orphans.hs
+++ b/crypto/test/Test/Cardano/Crypto/Orphans.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Cardano.Crypto.Orphans
+  ()
+where
+
+import Cardano.Prelude
+
+import qualified Data.ByteArray as BA
+import qualified Crypto.PubKey.Ed25519 as Ed25519
+import           Cardano.Crypto
+                   ( SigningKey(..)
+                   )
+import           Cardano.Crypto.Hashing (hash)
+
+
+-- Note that we /only/ provide these Eq and Ord instances for test suites.
+-- The crypto libraries encourage using key /hashes/ not keys for things
+-- like sets, map etc.
+
+
+instance Eq SigningKey where
+  a == b = hash a == hash b
+
+instance Ord Ed25519.PublicKey where
+  compare x1 x2 = compare (toByteString x1) (toByteString x2)
+
+instance Ord Ed25519.SecretKey where
+  compare x1 x2 = compare (toByteString x1) (toByteString x2)
+
+instance Ord Ed25519.Signature where
+  compare x1 x2 = compare (toByteString x1) (toByteString x2)
+
+toByteString :: (BA.ByteArrayAccess bin) => bin -> ByteString
+toByteString = BA.convert
+

--- a/crypto/test/cardano-crypto-test.cabal
+++ b/crypto/test/cardano-crypto-test.cabal
@@ -23,6 +23,7 @@ library
                        Test.Cardano.Crypto.Example
                        Test.Cardano.Crypto.Gen
                        Test.Cardano.Crypto.Json
+                       Test.Cardano.Crypto.Orphans
 
   build-depends:       base
                      , bytestring

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "8273fe5f00ac03b0c66ef3841c8e957139ee18f2";
-      sha256 = "0ggfi3jxks5c8k3mszd6k0sfvmbvrkkwimln33r501dzj3m283rs";
+      rev = "4c48d34fd60991bb1b9168d293cfe31a975d858e";
+      sha256 = "104lw3lbm18lphnv24w4j3ykrw8kwc8wf5xqhy39pjvb7sgj89x3";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -69,7 +69,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "8273fe5f00ac03b0c66ef3841c8e957139ee18f2";
-      sha256 = "0ggfi3jxks5c8k3mszd6k0sfvmbvrkkwimln33r501dzj3m283rs";
+      rev = "4c48d34fd60991bb1b9168d293cfe31a975d858e";
+      sha256 = "104lw3lbm18lphnv24w4j3ykrw8kwc8wf5xqhy39pjvb7sgj89x3";
       });
     }

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "0dae43937d2858b437bfc93f7952ba93b88607e6";
-      sha256 = "1251hgvdak2l5s377vxvcc5nx91w5j5aqks4rb8acjcsxq14nn59";
+      rev = "38d601eb3dd20e8a27b7b7008aa90c70db911089";
+      sha256 = "124w5lihspg7vshdk5vyql4g8cpdfx0ijcsvynvkpxadhxw92bar";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -156,8 +156,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "0dae43937d2858b437bfc93f7952ba93b88607e6";
-      sha256 = "1251hgvdak2l5s377vxvcc5nx91w5j5aqks4rb8acjcsxq14nn59";
+      rev = "38d601eb3dd20e8a27b7b7008aa90c70db911089";
+      sha256 = "124w5lihspg7vshdk5vyql4g8cpdfx0ijcsvynvkpxadhxw92bar";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/8273fe5f00ac03b0c66ef3841c8e957139ee18f2/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/4c48d34fd60991bb1b9168d293cfe31a975d858e/snapshot.yaml
 
 packages:
   - cardano-ledger
@@ -17,7 +17,7 @@ extra-deps:
   - generic-monoid-0.1.0.0
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 8273fe5f00ac03b0c66ef3841c8e957139ee18f2
+    commit: 4c48d34fd60991bb1b9168d293cfe31a975d858e
     subdirs:
       - .
       - test
@@ -45,7 +45,7 @@ extra-deps:
   - time-units-1.0.0
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 0dae43937d2858b437bfc93f7952ba93b88607e6
+    commit: 38d601eb3dd20e8a27b7b7008aa90c70db911089
     subdirs:
       - contra-tracer
       - iohk-monitoring


### PR DESCRIPTION
The pattern that our crypto libraries use is that they deliberately do not provide `Ord` instances for keys (verification or signing keys). Instead our crypto library encourage the use of comparisons on key hashes.

The one remaining Ord instance is for `RedeemVerificationKey` because the `AvvmBalances` type uses it as a Data.Map key type, though it probably should not.

Many tests do (quite reasonably) rely on `Ord` so this patch moves the required orphan instances into the test suite.