### PR TITLE
factor BoundaryValidationData into header/body

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Block/Boundary.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Boundary.hs
@@ -5,9 +5,9 @@
 module Cardano.Chain.Block.Boundary
   ( fromCBORBoundaryConsensusData
   , dropBoundaryExtraHeaderData
+  , dropBoundaryExtraHeaderDataRetainGenesisTag
   , dropBoundaryBody
   , dropBoundaryExtraBodyData
-  , dropBoundaryExtraBodyDataRetainGenesisTag
   )
 where
 
@@ -41,6 +41,24 @@ dropBoundaryExtraHeaderData = do
   dropAttributes
 
 
+-- | When starting a new chain in ourorobos-consensus, we often start from a
+--   non-zero epoch. This is done in order to ensure synchronisation between
+--   nodes - we assume that the chain started at some fixed point in the past
+--   (e.g. midnight) which all nodes can agree on despite different node start
+--   times. However, the standard deserialisation assumes that the genesis EBB
+--   is precisely that in epoch zero.
+--
+--   In order to successfully round-trip a genesis EBB in a non-zero epoch,
+--   then, we add a "magic" tag which indicates the presense of the genesis
+--   hash. The choice of 255 and the word "Genesis" is completely arbitrary, and
+--   only done to correspond with the matching encoder. This encoding will only
+--   ever be seen when processing blocks from a demo.
+dropBoundaryExtraHeaderDataRetainGenesisTag :: Decoder s Bool
+dropBoundaryExtraHeaderDataRetainGenesisTag = do
+  enforceSize "BoundaryExtraHeaderData" 1
+  attrData <$> fromCBORAttributes False
+    (\w8 bs t -> pure . Just $ t || w8 == 255 && bs == "Genesis")
+
 --------------------------------------------------------------------------------
 -- BoundaryBody
 --------------------------------------------------------------------------------
@@ -57,21 +75,3 @@ dropBoundaryExtraBodyData :: Dropper s
 dropBoundaryExtraBodyData = do
   enforceSize "BoundaryExtraBodyData" 1
   dropAttributes
-
--- | When starting a new chain in ourorobos-consensus, we often start from a
---   non-zero epoch. This is done in order to ensure synchronisation between
---   nodes - we assume that the chain started at some fixed point in the past
---   (e.g. midnight) which all nodes can agree on despite different node start
---   times. However, the standard deserialisation assumes that the genesis EBB
---   is precisely that in epoch zero.
---
---   In order to successfully round-trip a genesis EBB in a non-zero epoch,
---   then, we add a "magic" tag which indicates the presense of the genesis
---   hash. The choice of 255 and the word "Genesis" is completely arbitrary, and
---   only done to correspond with the matching encoder. This encoding will only
---   ever be seen when processing blocks from a demo.
-dropBoundaryExtraBodyDataRetainGenesisTag :: Decoder s Bool
-dropBoundaryExtraBodyDataRetainGenesisTag = do
-  enforceSize "BoundaryExtraBodyData" 1
-  attrData <$> fromCBORAttributes False 
-    (\w8 bs t -> pure . Just $ t || w8 == 255 && bs == "Genesis")

--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -60,7 +60,7 @@ import Cardano.Chain.Block.Body (ABody (..))
 import Cardano.Chain.Block.Block
   ( ABlock(..)
   , ABlockOrBoundary(..)
-  , BoundaryValidationData(..)
+  , ABoundaryBlock(..)
   , blockAProtocolMagicId
   , blockDlgPayload
   , blockHashAnnotated
@@ -75,6 +75,7 @@ import Cardano.Chain.Block.Block
   )
 import Cardano.Chain.Block.Header
   ( AHeader (..)
+  , ABoundaryHeader (..)
   , BlockSignature
   , HeaderHash
   , headerLength
@@ -347,10 +348,10 @@ updateChainBlockOrBoundary config c b = case b of
 updateChainBoundary
   :: MonadError ChainValidationError m
   => ChainValidationState
-  -> BoundaryValidationData ByteString
+  -> ABoundaryBlock ByteString
   -> m ChainValidationState
 updateChainBoundary cvs bvd = do
-  case (cvsPreviousHash cvs, boundaryPrevHash bvd) of
+  case (cvsPreviousHash cvs, boundaryPrevHash (boundaryHeader bvd)) of
     (Left expected, Left actual) ->
         (expected == actual)
           `orThrowError` ChainValidationGenesisHashMismatch expected actual
@@ -375,7 +376,7 @@ updateChainBoundary cvs bvd = do
       . hashRaw
       . BSL.fromStrict
       . wrapBoundaryBytes
-      $ boundaryHeaderBytes bvd
+      $ boundaryHeaderAnnotation (boundaryHeader bvd)
     }
 
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -31,22 +31,22 @@ import Cardano.Chain.Block
   , Block
   , BlockSignature
   , Body
-  , BoundaryValidationData(boundaryBlockLength)
+  , ABoundaryBlock(boundaryBlockLength)
   , pattern Body
   , Header
   , HeaderHash
   , Proof(..)
   , ToSign(..)
   , dropBoundaryBody
-  , dropBoundaryBlock
+  , fromCBORABoundaryBlock
   , fromCBORBoundaryConsensusData
-  , dropBoundaryHeader
+  , fromCBORABoundaryHeader
   , fromCBORABOBBlock
   , fromCBORHeader
   , fromCBORHeaderToHash
   , mkHeaderExplicit
   , toCBORABOBBlock
-  , toCBORBoundaryBlock
+  , toCBORABoundaryBlock
   , toCBORHeader
   , toCBORHeaderToHash
   )
@@ -159,7 +159,7 @@ ts_roundTripBlockSignatureCBOR =
 goldenDeprecatedBoundaryBlockHeader :: Property
 goldenDeprecatedBoundaryBlockHeader = deprecatedGoldenDecode
   "BoundaryBlockHeader"
-  (void dropBoundaryHeader)
+  (void fromCBORABoundaryHeader)
   "test/golden/cbor/block/BoundaryBlockHeader"
 
 ts_roundTripBoundaryBlock :: TSProperty
@@ -169,16 +169,16 @@ ts_roundTripBoundaryBlock = eachOfTS
     roundTripsBVD
   where
     -- We ignore the size of the BVD here, since calculating it is annoying.
-    roundTripsBVD :: (ProtocolMagicId, BoundaryValidationData ()) -> H.PropertyT IO ()
+    roundTripsBVD :: (ProtocolMagicId, ABoundaryBlock ()) -> H.PropertyT IO ()
     roundTripsBVD (pm, bvd) = trippingBuildable
       bvd
-      (serializeEncoding . toCBORBoundaryBlock pm)
-      (fmap (dropSize . fmap (const ())) <$> decodeFullDecoder "BoundaryValidationData" dropBoundaryBlock)
+      (serializeEncoding . toCBORABoundaryBlock pm)
+      (fmap (dropSize . fmap (const ())) <$> decodeFullDecoder "BoundaryBlock" fromCBORABoundaryBlock)
 
-    genBVDWithPM :: ProtocolMagicId -> H.Gen (ProtocolMagicId, BoundaryValidationData ())
-    genBVDWithPM pm = (,) <$> pure pm <*> genBoundaryValidationData
+    genBVDWithPM :: ProtocolMagicId -> H.Gen (ProtocolMagicId, ABoundaryBlock ())
+    genBVDWithPM pm = (,) <$> pure pm <*> genBoundaryBlock
 
-    dropSize :: BoundaryValidationData a -> BoundaryValidationData a
+    dropSize :: ABoundaryBlock a -> ABoundaryBlock a
     dropSize bvd = bvd { boundaryBlockLength = 0 }
 
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
@@ -10,7 +10,8 @@ module Test.Cardano.Chain.Block.Gen
   , genToSign
   , genBlock
   , genBlockWithEpochSlots
-  , genBoundaryValidationData
+  , genBoundaryBlock
+  , genBoundaryHeader
   )
 where
 
@@ -26,7 +27,9 @@ import Cardano.Chain.Block
   , Block
   , BlockSignature
   , Body
-  , BoundaryValidationData(..)
+  , ABoundaryBlock(..)
+  , ABoundaryBody(..)
+  , ABoundaryHeader(..)
   , pattern Body
   , Header
   , HeaderHash
@@ -202,12 +205,18 @@ genBlock protocolMagicId epochSlots =
         )
         body
 
-genBoundaryValidationData :: Gen (BoundaryValidationData ())
-genBoundaryValidationData = 
-  BoundaryValidationData
+genBoundaryBlock :: Gen (ABoundaryBlock ())
+genBoundaryBlock = 
+  ABoundaryBlock
     <$> pure 0
-    <*> (Gen.choice [Right <$> genHeaderHash, Left . GenesisHash . coerce <$> genTextHash])
+    <*> genBoundaryHeader
+    <*> pure (ABoundaryBody ())
+    <*> pure ()
+
+genBoundaryHeader :: Gen (ABoundaryHeader ())
+genBoundaryHeader =
+  ABoundaryHeader
+    <$> (Gen.choice [Right <$> genHeaderHash, Left . GenesisHash . coerce <$> genTextHash])
     <*> (Gen.word64 (Range.constantFrom 10 0 1000))
     <*> genChainDifficulty
-    <*> pure ()
     <*> pure ()


### PR DESCRIPTION
Motivation: cardano-byron-proxy needs to decode epoch boundary block
headers, not just entire blocks. Now cardano-ledger makes it possible by
fromCBORABoundaryHeader. The boundary block is defined in terms of
ABoundaryHeader, and includes the total block length and its body (just
an annotation, since body data is dropped).

The genesis trick is moved from the boundary extra data to the header
extra data.