### PR TITLE
Export validateHeaderMatchesBody in Cardano.Chain.Block.Validation

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -15,6 +15,7 @@ module Cardano.Chain.Block.Validation
   , updateChainBoundary
   , epochTransition
   , headerIsValid
+  , validateHeaderMatchesBody
   , updateBlock
   , BodyState(..)
   , BodyEnvironment(..)


### PR DESCRIPTION
This function is required for https://github.com/input-output-hk/ouroboros-network/issues/595. It seems I forgot to export it in https://github.com/input-output-hk/cardano-ledger/pull/549.