### PR TITLE
fix slot duration parsing

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Update/ProtocolParametersUpdate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/ProtocolParametersUpdate.hs
@@ -15,7 +15,6 @@ where
 import Cardano.Prelude hiding (empty)
 
 import Data.Text.Lazy.Builder (Builder)
-import Data.Time (NominalDiffTime)
 import Formatting (Format, bprint, build, bytes, later, shortest)
 import qualified Formatting.Buildable as B
 
@@ -29,7 +28,7 @@ import Cardano.Chain.Update.SoftforkRule (SoftforkRule)
 -- | Data which represents modifications of block (aka protocol) version
 data ProtocolParametersUpdate = ProtocolParametersUpdate
   { ppuScriptVersion     :: !(Maybe Word16)
-  , ppuSlotDuration      :: !(Maybe NominalDiffTime)
+  , ppuSlotDuration      :: !(Maybe Natural)
   , ppuMaxBlockSize      :: !(Maybe Natural)
   , ppuMaxHeaderSize     :: !(Maybe Natural)
   , ppuMaxTxSize         :: !(Maybe Natural)
@@ -48,7 +47,7 @@ data ProtocolParametersUpdate = ProtocolParametersUpdate
 instance B.Buildable ProtocolParametersUpdate where
   build ppu = bprint
     ( "{ script version: " . bmodifier build
-    . ", slot duration: " . bmodifier build
+    . ", slot duration: " . bmodifier bytes'
     . ", block size limit: " . bmodifier bytes'
     . ", header size limit: " . bmodifier bytes'
     . ", tx size limit: " . bmodifier bytes'

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
@@ -65,7 +65,7 @@ exampleProtocolVersion = ProtocolVersion 1 1 1
 exampleProtocolParameters :: ProtocolParameters
 exampleProtocolParameters = ProtocolParameters
   (999 :: Word16)
-  (999e-6 :: NominalDiffTime)
+  (999e-3 :: NominalDiffTime)
   (999 :: Natural)
   (999 :: Natural)
   (999 :: Natural)

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
@@ -24,7 +24,6 @@ import Test.Cardano.Prelude
 
 import Data.List ((!!))
 import qualified Data.Map.Strict as Map
-import Data.Time (NominalDiffTime)
 
 import Cardano.Binary (Raw(..))
 import Cardano.Chain.Common
@@ -65,7 +64,7 @@ exampleProtocolVersion = ProtocolVersion 1 1 1
 exampleProtocolParameters :: ProtocolParameters
 exampleProtocolParameters = ProtocolParameters
   (999 :: Word16)
-  (999e-3 :: NominalDiffTime)
+  (999 :: Natural)
   (999 :: Natural)
   (999 :: Natural)
   (999 :: Natural)
@@ -90,7 +89,7 @@ exampleProtocolParameters = ProtocolParameters
 exampleProtocolParametersUpdate :: ProtocolParametersUpdate
 exampleProtocolParametersUpdate = ProtocolParametersUpdate
   (Just (999 :: Word16))
-  (Just (999e-6 :: NominalDiffTime))
+  (Just (999 :: Natural))
   (Just (999 :: Natural))
   (Just (999 :: Natural))
   (Just (999 :: Natural))

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Gen.hs
@@ -74,7 +74,7 @@ genCanonicalProtocolParameters :: Gen ProtocolParameters
 genCanonicalProtocolParameters =
   ProtocolParameters
     <$> genScriptVersion
-    <*> genNominalDiffTime
+    <*> genNatural
     <*> genNatural
     <*> genNatural
     <*> genNatural
@@ -99,7 +99,7 @@ genProtocolParameters :: Gen ProtocolParameters
 genProtocolParameters =
   ProtocolParameters
     <$> genScriptVersion
-    <*> genNominalDiffTime
+    <*> genNatural
     <*> genNatural
     <*> genNatural
     <*> genNatural
@@ -117,7 +117,7 @@ genProtocolParametersUpdate :: Gen ProtocolParametersUpdate
 genProtocolParametersUpdate =
   ProtocolParametersUpdate
     <$> Gen.maybe genScriptVersion
-    <*> Gen.maybe genNominalDiffTime
+    <*> Gen.maybe genNatural
     <*> Gen.maybe genNatural
     <*> Gen.maybe genNatural
     <*> Gen.maybe genNatural


### PR DESCRIPTION
Observed a problem when using `mainnet-genesis.json` from `cardano-sl`: the slot duration was reported to be 0.020 seconds. In that file, and in the `yaml` genesis specs, slot duration is milliseconds. Before this patch, the `FromJSON NominalDiffTime` instance was used for parsing. Now, the `FromJSON Integer` instance is used, and the `Integer` milliseconds are explicitly converted to `NominalDiffTime`.