### PR TITLE
Move Byron specific CBOR utils from cardano-base

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -28,13 +28,13 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 6b808ad5506cb097cdf5832e1cd5cad0c83c58d6
+  tag: f73df8f35da5e322cf14cf50f118d76b2aa8a423
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 6b808ad5506cb097cdf5832e1cd5cad0c83c58d6
+  tag: f73df8f35da5e322cf14cf50f118d76b2aa8a423
   subdir: binary/test
 
 source-repository-package
@@ -45,31 +45,31 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 423a7359049b0fd6fb2a931c50877cae2a96eaae
+  tag: 8107dd49a3c402401a6bbc9d14017b4edc75ac92
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 423a7359049b0fd6fb2a931c50877cae2a96eaae
+  tag: 8107dd49a3c402401a6bbc9d14017b4edc75ac92
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 423a7359049b0fd6fb2a931c50877cae2a96eaae
+  tag: 8107dd49a3c402401a6bbc9d14017b4edc75ac92
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: b2022cf7f5925e486f9e0a31f6f6d02145d5ebda
+  tag: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
   subdir: contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: b2022cf7f5925e486f9e0a31f6f6d02145d5ebda
+  tag: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
   subdir: iohk-monitoring
 
 source-repository-package

--- a/cardano-ledger/cardano-ledger.cabal
+++ b/cardano-ledger/cardano-ledger.cabal
@@ -63,6 +63,7 @@ library
                        Cardano.Chain.Common.AddressHash
                        Cardano.Chain.Common.Attributes
                        Cardano.Chain.Common.BlockCount
+                       Cardano.Chain.Common.CBOR
                        Cardano.Chain.Common.ChainDifficulty
                        Cardano.Chain.Common.Compact
                        Cardano.Chain.Common.KeyHash
@@ -140,6 +141,7 @@ library
                      , cryptonite
                      , Cabal
                      , deepseq
+                     , digest
                      , directory
                      , filepath
                      , formatting

--- a/cardano-ledger/src/Cardano/Chain/Common.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common.hs
@@ -9,6 +9,7 @@ import Cardano.Chain.Common.AddressHash as X
 import Cardano.Chain.Common.AddrSpendingData as X
 import Cardano.Chain.Common.Attributes as X
 import Cardano.Chain.Common.BlockCount as X
+import Cardano.Chain.Common.CBOR as X
 import Cardano.Chain.Common.ChainDifficulty as X
 import Cardano.Chain.Common.Compact as X
 import Cardano.Chain.Common.Lovelace as X

--- a/cardano-ledger/src/Cardano/Chain/Common/Address.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Address.hs
@@ -80,14 +80,13 @@ import Cardano.Binary
   , Encoding
   , FromCBOR(..)
   , ToCBOR(..)
-  , decodeCrcProtected
   , decodeFull'
   , decodeListLenCanonical
-  , encodeCrcProtected
-  , encodedCrcProtectedSizeExpr
   , matchSize
   , serialize'
   )
+import Cardano.Chain.Common.CBOR
+  (encodeCrcProtected, encodedCrcProtectedSizeExpr, decodeCrcProtected)
 import Cardano.Chain.Common.AddrAttributes (AddrAttributes(..))
 import Cardano.Chain.Common.AddressHash (AddressHash, addressHash)
 import Cardano.Chain.Common.AddrSpendingData

--- a/cardano-ledger/src/Cardano/Chain/Common/CBOR.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/CBOR.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+
+-- | CBOR encoding utilities needed for the Byron transaction format
+--
+module Cardano.Chain.Common.CBOR
+  (
+  -- * CBOR in CBOR
+  -- | These utilities are is used in the Byron-era chain encodings in cases
+  -- where there are extensible parts of the encoding. In thse cases we have to
+  -- be able to handle unknown extensions and thus decode values where we do
+  -- not know the concrete type.
+  --
+  -- To solve this, the serialised representation uses nested CBOR-in-CBOR
+  -- <https://tools.ietf.org/html/rfc7049#section-2.4.4.1>. The nesting means
+  -- that the size is known without having to decode the body in those cases
+  -- where we cannot decode the body.
+  --
+  -- The functions in this module handle the encoding and decoding for the
+  -- cases of the known and unknown types.
+
+    encodeKnownCborDataItem
+  , encodeUnknownCborDataItem
+  , knownCborDataItemSizeExpr
+  , unknownCborDataItemSizeExpr
+  , decodeKnownCborDataItem
+  , decodeUnknownCborDataItem
+
+  -- * Cyclic redundancy check
+  -- | The Byron era address format includes a CRC to help resist accidental
+  -- corruption. These functions deal with encoding and decoding the format
+  -- that is used.
+  , encodeCrcProtected
+  , encodedCrcProtectedSizeExpr
+  , decodeCrcProtected
+  )
+where
+
+import Cardano.Prelude
+
+import Data.Word (Word32)
+import Data.Typeable (typeOf)
+import Data.Proxy (Proxy(Proxy))
+import Formatting (Format, sformat, shown)
+
+import Data.Digest.CRC32 (CRC32(..))
+
+import Cardano.Binary
+         ( Encoding, Size, ToCBOR(..), enforceSize, serialize
+         , encodeListLen, encodeNestedCbor, encodeNestedCborBytes
+         , nestedCborSizeExpr, nestedCborBytesSizeExpr
+         , Decoder, FromCBOR(..), decodeFull'
+         , decodeNestedCbor, decodeNestedCborBytes )
+
+
+-- | This is an alias for 'encodeNestedCbor'.
+--
+-- This function is used to handle the case of a known type, but compatible
+-- with the encoding used by 'encodeUnknownCborDataItem'.
+--
+encodeKnownCborDataItem :: ToCBOR a => a -> Encoding
+encodeKnownCborDataItem = encodeNestedCbor
+
+-- | This is an alias for 'encodeNestedCborBytes', so all its details apply.
+--
+-- This function is used to handle the case of an unknown type, so it takes an
+-- opaque blob that is the representation of the value of the unknown type.
+--
+encodeUnknownCborDataItem :: LByteString -> Encoding
+encodeUnknownCborDataItem = encodeNestedCborBytes
+
+knownCborDataItemSizeExpr :: Size -> Size
+knownCborDataItemSizeExpr = nestedCborSizeExpr
+
+unknownCborDataItemSizeExpr :: Size -> Size
+unknownCborDataItemSizeExpr = nestedCborBytesSizeExpr
+
+-- | This is an alias for 'decodeNestedCbor'.
+--
+-- This function is used to handle the case of a known type, but compatible
+-- with the encoding used by 'decodeUnknownCborDataItem'.
+--
+decodeKnownCborDataItem :: FromCBOR a => Decoder s a
+decodeKnownCborDataItem = decodeNestedCbor
+
+-- | This is an alias for 'decodeNestedCborBytes', so all its details apply.
+--
+-- This function is used to handle the case of an unknown type, so it returns
+-- an opaque blob that is the representation of the value of the unknown type.
+--
+decodeUnknownCborDataItem :: Decoder s ByteString
+decodeUnknownCborDataItem = decodeNestedCborBytes
+
+
+--------------------------------------------------------------------------------
+-- Cyclic redundancy check
+--------------------------------------------------------------------------------
+
+-- | Encodes a value of type @a@, protecting it from accidental corruption by
+-- protecting it with a CRC.
+--
+encodeCrcProtected :: ToCBOR a => a -> Encoding
+encodeCrcProtected x =
+    encodeListLen 2 <> encodeUnknownCborDataItem body <> toCBOR (crc32 body)
+  where
+    body = serialize x
+
+encodedCrcProtectedSizeExpr
+  :: forall a
+   . ToCBOR a
+  => (forall t. ToCBOR t => Proxy t -> Size)
+  -> Proxy a
+  -> Size
+encodedCrcProtectedSizeExpr size pxy =
+    2
+  + unknownCborDataItemSizeExpr (size pxy)
+  + size (pure $ crc32 (serialize (panic "unused" :: a)))
+
+-- | Decodes a CBOR blob into a value of type @a@, checking the serialised CRC
+--   corresponds to the computed one
+decodeCrcProtected :: forall s a . FromCBOR a => Decoder s a
+decodeCrcProtected = do
+    enforceSize ("decodeCrcProtected: " <> show (typeOf (Proxy :: Proxy a))) 2
+    body        <- decodeUnknownCborDataItem
+    expectedCrc <- fromCBOR
+    let
+      actualCrc :: Word32
+      actualCrc = crc32 body
+    let
+      crcErrorFmt :: Format r (Word32 -> Word32 -> r)
+      crcErrorFmt =
+        "decodeCrcProtected, expected CRC "
+          . shown
+          . " was not the computed one, which was "
+          . shown
+    when (actualCrc /= expectedCrc)
+      $ cborError (sformat crcErrorFmt expectedCrc actualCrc)
+    toCborError $ decodeFull' body

--- a/cardano-ledger/src/Cardano/Chain/Common/TxFeePolicy.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/TxFeePolicy.hs
@@ -30,11 +30,11 @@ import Cardano.Binary
   ( DecoderError(DecoderErrorUnknownTag)
   , FromCBOR(..)
   , ToCBOR(..)
-  , decodeKnownCborDataItem
-  , encodeKnownCborDataItem
   , encodeListLen
   , enforceSize
   )
+import Cardano.Chain.Common.CBOR
+  (decodeKnownCborDataItem, encodeKnownCborDataItem)
 import Cardano.Chain.Common.Lovelace
   (Lovelace, LovelaceError, lovelaceToInteger, mkLovelace)
 import Cardano.Chain.Common.TxSizeLinear (TxSizeLinear(..))

--- a/cardano-ledger/src/Cardano/Chain/UTxO/Tx.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/Tx.hs
@@ -40,13 +40,12 @@ import Cardano.Binary
   , DecoderError(DecoderErrorUnknownTag)
   , FromCBOR(..)
   , ToCBOR(..)
-  , decodeKnownCborDataItem
-  , encodeKnownCborDataItem
   , encodeListLen
   , enforceSize
-  , knownCborDataItemSizeExpr
   , szCases
   )
+import Cardano.Chain.Common.CBOR
+  (encodeKnownCborDataItem, knownCborDataItemSizeExpr, decodeKnownCborDataItem)
 import Cardano.Chain.Common
   ( Address(..)
   , Lovelace

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
@@ -30,15 +30,14 @@ import Cardano.Binary
   , DecoderError(DecoderErrorUnknownTag)
   , FromCBOR(..)
   , ToCBOR(..)
-  , decodeKnownCborDataItem
   , decodeListLen
-  , encodeKnownCborDataItem
   , encodeListLen
-  , knownCborDataItemSizeExpr
   , matchSize
   , serialize'
   , szCases
   )
+import Cardano.Chain.Common.CBOR
+  (encodeKnownCborDataItem, knownCborDataItemSizeExpr, decodeKnownCborDataItem)
 import Cardano.Chain.Common (addressHash)
 import Cardano.Chain.UTxO.Tx (Tx)
 import Cardano.Crypto

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
@@ -70,10 +70,27 @@ import Test.Cardano.Chain.Common.Gen
   , genTxFeePolicy
   , genTxSizeLinear
   )
+
+import Cardano.Binary
+  (serializeEncoding, decodeFullDecoder)
+import Cardano.Chain.Common
+  (encodeCrcProtected, decodeCrcProtected)
+
 import Test.Cardano.Crypto.CBOR (getBytes)
 import Test.Cardano.Crypto.Gen (genHashRaw)
 import Test.Options (TSGroup, TSProperty, concatTSGroups, eachOfTS)
+import Hedgehog  (property, forAll, (===))
 
+
+--------------------------------------------------------------------------------
+-- CRC encoding
+--------------------------------------------------------------------------------
+
+prop_roundTripCrcProtected :: Property
+prop_roundTripCrcProtected = property $ do
+  x <- forAll genAddress
+  let crcEncodedBS = serializeEncoding . encodeCrcProtected $ x
+  decodeFullDecoder "" decodeCrcProtected crcEncodedBS === Right x
 
 --------------------------------------------------------------------------------
 -- Address

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "6b808ad5506cb097cdf5832e1cd5cad0c83c58d6";
-      sha256 = "1cpn117lnyjxfnc18i0pawzf4cd60my7z9ifmgyjvzg6xaiv8v6a";
+      rev = "f73df8f35da5e322cf14cf50f118d76b2aa8a423";
+      sha256 = "1cm2hxylr6d4fmz0bp66igdp6m2cz7x1ihj4425asz2zb7hlb765";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "6b808ad5506cb097cdf5832e1cd5cad0c83c58d6";
-      sha256 = "1cpn117lnyjxfnc18i0pawzf4cd60my7z9ifmgyjvzg6xaiv8v6a";
+      rev = "f73df8f35da5e322cf14cf50f118d76b2aa8a423";
+      sha256 = "1cm2hxylr6d4fmz0bp66igdp6m2cz7x1ihj4425asz2zb7hlb765";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -35,6 +35,7 @@
           (hsPkgs.cryptonite)
           (hsPkgs.Cabal)
           (hsPkgs.deepseq)
+          (hsPkgs.digest)
           (hsPkgs.directory)
           (hsPkgs.filepath)
           (hsPkgs.formatting)

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "b2022cf7f5925e486f9e0a31f6f6d02145d5ebda";
-      sha256 = "0h816f3nh7n6hk42pdy0l56a56vz8b998x0d0ysg3bkj0dc9sh0w";
+      rev = "bd31cd2f3922010ddb76bb869f29c4e63bb8001b";
+      sha256 = "1dfk505qbpk6p3gcpxa31wmg98qvx9hlrxlf0khaj7hizf3b8b60";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -155,8 +155,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "b2022cf7f5925e486f9e0a31f6f6d02145d5ebda";
-      sha256 = "0h816f3nh7n6hk42pdy0l56a56vz8b998x0d0ysg3bkj0dc9sh0w";
+      rev = "bd31cd2f3922010ddb76bb869f29c4e63bb8001b";
+      sha256 = "1dfk505qbpk6p3gcpxa31wmg98qvx9hlrxlf0khaj7hizf3b8b60";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,7 +23,7 @@ extra-deps:
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 6b808ad5506cb097cdf5832e1cd5cad0c83c58d6
+    commit: f73df8f35da5e322cf14cf50f118d76b2aa8a423
     subdirs:
       - binary
       - binary/test
@@ -45,7 +45,7 @@ extra-deps:
   - time-units-1.0.0
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: b2022cf7f5925e486f9e0a31f6f6d02145d5ebda
+    commit: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
     subdirs:
       - contra-tracer
       - iohk-monitoring


### PR DESCRIPTION
The CRC is specific to the Byron encoding and does not need to live in a general base library.

The "known"/"unknown" CBOR trick is also pecific to the Byron encoding. The names now wrap the same code, which still exist but under more general names in cardano-base.

This is part 2. Part 1 was https://github.com/input-output-hk/cardano-base/pull/34