### PR TITLE
Bumped version of cardano-shell.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -75,7 +75,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-shell
-  tag: 1c4d504b39c560da95abaab48122a5611ee1f46f
+  tag: 455c006e5d1a0c1cf3d31777df24752afcbaab10
 
 source-repository-package
   type: git

--- a/cardano-ledger/src/Cardano/Chain/Conversion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Conversion.hs
@@ -34,7 +34,7 @@ convertConfig
 convertConfig cc = do
 
     -- Genesis hash
-    let mainnetGenFp = geSrc . coGenesis $ ccCore cc
+    let mainnetGenFp = coGenesisFile $ ccCore cc
     gHash <- decodeGenesisHash genesisHash `wrapError` GenesisHashDecodeError
 
     mkConfigFromFile (cvtRNM . coRequiresNetworkMagic $ ccCore cc) mainnetGenFp gHash
@@ -42,8 +42,10 @@ convertConfig cc = do
  where
   decodeGenesisHash :: Text -> Either Text (Hash Raw)
   decodeGenesisHash genHash = decodeAbstractHash genHash
+
   genesisHash :: Text
-  genesisHash = geGenesisHash . coGenesis $ ccCore cc
+  genesisHash = coGenesisHash $ ccCore cc
+
   cvtRNM :: Shell.RequireNetworkMagic -> RequiresNetworkMagic
   cvtRNM Shell.NoRequireNetworkMagic = RequiresNoMagic
   cvtRNM Shell.RequireNetworkMagic   = RequiresMagic

--- a/nix/.stack.nix/cardano-shell.nix
+++ b/nix/.stack.nix/cardano-shell.nix
@@ -4,7 +4,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-shell"; version = "0.1.0.0"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2018 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK";
@@ -37,7 +37,8 @@
           (hsPkgs.stm)
           (hsPkgs.text)
           (hsPkgs.transformers)
-          ];
+          (hsPkgs.generic-monoid)
+          ] ++ (pkgs.lib).optional (system.isWindows) (hsPkgs.Win32);
         };
       exes = {
         "cardano-shell-exe" = {
@@ -102,7 +103,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-shell";
-      rev = "1c4d504b39c560da95abaab48122a5611ee1f46f";
-      sha256 = "1db0500x97f6mjdw25jrjd0vzjm4b3x64w1014dgplxab0nmv5r2";
+      rev = "455c006e5d1a0c1cf3d31777df24752afcbaab10";
+      sha256 = "0y9s5f6fgpqk9qlxgznpddpb6fr42ppkrmpp1kxn7k3dqmydqk7z";
       });
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,7 @@ extra-deps:
 
   # Following deps are for cardano-shell
   - git: https://github.com/input-output-hk/cardano-shell
-    commit: 1c4d504b39c560da95abaab48122a5611ee1f46f
+    commit: 455c006e5d1a0c1cf3d31777df24752afcbaab10
 
   - time-units-1.0.0
 


### PR DESCRIPTION
Bumping the version of `cardano-shell`.

Update can be found in this commit - https://github.com/input-output-hk/cardano-shell/commit/539171ecbb7e1ed9732520bcc904ede178a69090