### PR TITLE
Remove the mempool size param from the UTxOConfiguration

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/UTxO/UTxOConfiguration.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/UTxOConfiguration.hs
@@ -9,14 +9,10 @@ import Cardano.Prelude
 
 import Cardano.Chain.Common.Address (Address)
 
--- | Delegation configruation part.
+-- | Additional configuration for ledger validation.
 data UTxOConfiguration = UTxOConfiguration
-  { -- | Limit on the number of transactions that can be stored in
-    -- the mem pool.
-    ccMemPoolLimitTx      :: !Int
-
-    -- | Set of source address which are asset-locked. Transactions which
+  { -- | Set of source address which are asset-locked. Transactions which
     -- use these addresses as transaction inputs will be silently dropped.
-  , tcAssetLockedSrcAddrs :: !(Set Address)
+    tcAssetLockedSrcAddrs :: !(Set Address)
   } deriving (Eq,Show,Generic)
 

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
@@ -125,8 +125,7 @@ genTxOutList = Gen.nonEmpty (Range.linear 1 100) genTxOut
 genUTxOConfiguration :: Gen UTxOConfiguration
 genUTxOConfiguration =
   UTxOConfiguration
-    <$> Gen.int (Range.constant 0 200)
-    <*> (S.fromList <$> Gen.list (Range.linear 0 50) genAddress)
+    <$> (S.fromList <$> Gen.list (Range.linear 0 50) genAddress)
 
 genTxPayload :: ProtocolMagicId -> Gen TxPayload
 genTxPayload pm = mkTxPayload <$> Gen.list (Range.linear 0 10) (genTxAux pm)


### PR DESCRIPTION
The mempool is not part of the ledger library in the new implementation so this paramater is not needed here. This is handled in the consensus library.

Built on #601 will need to be rebased before merging.