### PR TITLE
No more generating genesis config on the fly

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Genesis/Config.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Config.hs
@@ -116,13 +116,17 @@ configProtocolParameters = gdProtocolParameters . configGenesisData
 configAvvmDistr :: Config -> GenesisAvvmBalances
 configAvvmDistr = gdAvvmDistr . configGenesisData
 
+-- | Construct a 'Config' from an external genesis file.
+--
+-- The 'FilePath' refers to a canonical JSON file. It will be hashed and
+-- checked against the expected hash, which should be known from config.
+--
 mkConfigFromFile
   :: (MonadError ConfigurationError m, MonadIO m)
   => RequiresNetworkMagic
   -> FilePath
   -> Hash Raw
-  -- ^ This hash comes from 'CardanoConfiguration'
-  -- which lives in cardano-shell
+  -- ^ The expected hash of the file
   -> m Config
 mkConfigFromFile rnm fp expectedHash = do
   (genesisData, genesisHash) <-

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Config.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Config.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
 
 module Cardano.Chain.Genesis.Config
   ( Config(..)
@@ -27,8 +24,6 @@ import Cardano.Prelude
 
 import Control.Monad.Except (MonadError(..))
 import Data.Time (UTCTime)
-import Formatting (build, bprint, string)
-import qualified Formatting.Buildable as B
 
 import Cardano.Binary (Annotated(..), Raw)
 import Cardano.Chain.Block.Header (HeaderHash, genesisHeaderHash)
@@ -152,23 +147,3 @@ data ConfigurationError
   -- ^ An error occured while decoding the genesis hash.
   deriving (Show)
 
-instance B.Buildable ConfigurationError where
-  build = \case
-    ConfigurationGenesisDataError genesisDataError ->
-      bprint ("Error in constructing GenesisData: "
-             . build
-             )
-             genesisDataError
-    GenesisHashMismatch genesisHash expectedHash ->
-      bprint ("GenesisData canonical JSON hash is different than expected. GenesisHash: "
-             . string
-             . " Expected hash: "
-             . string
-             )
-             (show genesisHash)
-             (show expectedHash)
-    GenesisHashDecodeError decodeErr ->
-     bprint ("GenesisHashDecodeError: "
-            . string
-            )
-            (toS decodeErr)

--- a/cardano-ledger/test/Test/Cardano/Chain/Config.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Config.hs
@@ -7,8 +7,6 @@ where
 
 import Cardano.Prelude
 
-import Formatting (build, sformat)
-
 import Cardano.Binary (Raw)
 import qualified Cardano.Chain.Genesis as Genesis
 import Cardano.Crypto.Hashing (Hash, decodeHash)
@@ -24,11 +22,11 @@ readMainetCfg :: MonadIO m => m Genesis.Config
 readMainetCfg = do
   let
     genHash = either
-      (panic . sformat build . Genesis.GenesisHashDecodeError)
+      (panic . show . Genesis.GenesisHashDecodeError)
       identity
       (decodeHash
         "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
       ) :: Hash Raw
 
-  either (panic . sformat build) identity <$> runExceptT
+  either (panic . show) identity <$> runExceptT
     (Genesis.mkConfigFromFile RequiresNoMagic "mainnet-genesis.json" genHash)

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -250,7 +250,6 @@ abEnvToCfg (_currentSlot, _genesisUtxo, allowedDelegators, protocolParams, stabl
   Genesis.Config {
       Genesis.configGenesisData       = genesisData
     , Genesis.configGenesisHash       = genesisHash
-    , Genesis.configGeneratedSecrets  = Nothing
     , Genesis.configReqNetMagic       = rnm
     , Genesis.configUTxOConfiguration = UTxO.defaultUTxOConfiguration
     }

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
@@ -47,7 +47,7 @@ import Cardano.Chain.Genesis
   , TestnetBalanceOptions(..)
   , gsSigningKeys
   , gsSigningKeysPoor
-  , mkConfig
+  , generateGenesisConfig
   )
 import Cardano.Chain.ProtocolConstants (kEpochSlots, kSlotSecurityParam)
 import Cardano.Chain.Slotting (EpochNumber(..), EpochSlots, SlotCount)
@@ -61,7 +61,7 @@ dummyConfig           :: Config
 dummyGeneratedSecrets :: GeneratedSecrets
 (dummyConfig, dummyGeneratedSecrets) =
     either (panic . show) identity $
-      mkConfig startTime dummyGenesisSpec
+      generateGenesisConfig startTime dummyGenesisSpec
   where
     startTime = UTCTime (ModifiedJulianDay 0) 0
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
@@ -4,7 +4,6 @@
 
 module Test.Cardano.Chain.Genesis.Dummy
   ( dummyConfig
-  , dummyConfigStartTime
   , dummyK
   , dummyEpochSlots
   , dummySlotSecurityParam
@@ -19,7 +18,6 @@ module Test.Cardano.Chain.Genesis.Dummy
   , dummyGenesisSpec
   , dummyProtocolParameters
   , dummyGenesisData
-  , dummyGenesisDataStartTime
   , dummyGenesisHash
   )
 where
@@ -59,12 +57,13 @@ import Cardano.Crypto (SigningKey)
 import qualified Test.Cardano.Crypto.Dummy as Dummy
 
 
-dummyConfig :: Config
-dummyConfig = dummyConfigStartTime (UTCTime (ModifiedJulianDay 0) 0)
-
-dummyConfigStartTime :: UTCTime -> Config
-dummyConfigStartTime startTime =
-  either (panic . show) identity $ mkConfig startTime dummyGenesisSpec
+dummyConfig           :: Config
+dummyGeneratedSecrets :: GeneratedSecrets
+(dummyConfig, dummyGeneratedSecrets) =
+    either (panic . show) identity $
+      mkConfig startTime dummyGenesisSpec
+  where
+    startTime = UTCTime (ModifiedJulianDay 0) 0
 
 dummyK :: BlockCount
 dummyK = BlockCount 10
@@ -74,14 +73,6 @@ dummyEpochSlots = kEpochSlots dummyK
 
 dummySlotSecurityParam :: SlotCount
 dummySlotSecurityParam = kSlotSecurityParam dummyK
-
-dummyGeneratedSecrets :: GeneratedSecrets
-dummyGeneratedSecrets =
-  fromMaybe
-      (panic
-        "The impossible happened: GeneratedSecrets should be in dummyConfig"
-      )
-    $ configGeneratedSecrets dummyConfig
 
 dummyGenesisSecretsRich :: [SigningKey]
 dummyGenesisSecretsRich = gsRichSecrets dummyGeneratedSecrets
@@ -153,9 +144,6 @@ dummyGenesisInitializer = GenesisInitializer
 
 dummyGenesisData :: GenesisData
 dummyGenesisData = configGenesisData dummyConfig
-
-dummyGenesisDataStartTime :: UTCTime -> GenesisData
-dummyGenesisDataStartTime = configGenesisData . dummyConfigStartTime
 
 dummyGenesisHash :: GenesisHash
 dummyGenesisHash = configGenesisHash dummyConfig

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
@@ -8,8 +8,7 @@ module Test.Cardano.Chain.Genesis.Example
   , exampleGenesisData0
   , exampleGenesisDelegation
   , exampleGenesisInitializer
-  , exampleStaticConfig_GCSpec
-  , exampleStaticConfig_GCSrc
+  , exampleGenesisSpec
   )
 where
 
@@ -22,7 +21,7 @@ import Data.Maybe (fromJust)
 import qualified Data.Set as Set
 import Data.Time (UTCTime(..), Day(..), secondsToDiffTime)
 
-import Cardano.Binary (Annotated(..), Raw(..))
+import Cardano.Binary (Annotated(..))
 import Cardano.Chain.Common
   ( BlockCount(..)
   , LovelacePortion(..)
@@ -40,7 +39,6 @@ import Cardano.Chain.Genesis
   , GenesisInitializer(..)
   , GenesisSpec(..)
   , GenesisKeyHashes(..)
-  , StaticConfig(..)
   , TestnetBalanceOptions(..)
   )
 import Cardano.Chain.Slotting (EpochNumber(..))
@@ -50,7 +48,6 @@ import Cardano.Crypto
   , RequiresNetworkMagic(..)
   , RedeemVerificationKey
   , Signature(..)
-  , abstractHash
   , redeemDeterministicKeyGen
   )
 import Cardano.Crypto.Signing (VerificationKey(..))
@@ -66,12 +63,8 @@ import Test.Cardano.Crypto.Example (exampleProtocolMagicId0)
 exampleBlockCount :: BlockCount
 exampleBlockCount = BlockCount 12344
 
-exampleStaticConfig_GCSrc :: StaticConfig
-exampleStaticConfig_GCSrc =
-  GCSrc "dRaMwdYsH3QA3dChe" (abstractHash (Raw "Test"))
-
-exampleStaticConfig_GCSpec :: StaticConfig
-exampleStaticConfig_GCSpec = GCSpec $ UnsafeGenesisSpec
+exampleGenesisSpec :: GenesisSpec
+exampleGenesisSpec = UnsafeGenesisSpec
   exampleGenesisAvvmBalances
   exampleGenesisDelegation
   exampleProtocolParameters

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Gen.hs
@@ -12,7 +12,6 @@ module Test.Cardano.Chain.Genesis.Gen
   , genGenesisKeyHashes
   , genSignatureEpochNumber
   , genTestnetBalanceOptions
-  , genStaticConfig
   )
 where
 
@@ -39,7 +38,6 @@ import Cardano.Chain.Genesis
   , GenesisNonAvvmBalances(..)
   , GenesisSpec(..)
   , GenesisKeyHashes(..)
-  , StaticConfig(..)
   , TestnetBalanceOptions(..)
   , mkGenesisDelegation
   , mkGenesisSpec
@@ -55,8 +53,7 @@ import Test.Cardano.Chain.Delegation.Gen
 import Test.Cardano.Chain.Update.Gen
   (genCanonicalProtocolParameters, genProtocolParameters)
 import Test.Cardano.Crypto.Gen
-  ( genHashRaw
-  , genProtocolMagic
+  ( genProtocolMagic
   , genProtocolMagicId
   , genRedeemVerificationKey
   , genTextHash
@@ -98,12 +95,6 @@ genGenesisData pm =
 
 genGenesisHash :: Gen GenesisHash
 genGenesisHash = GenesisHash . coerce <$> genTextHash
-
-genStaticConfig :: ProtocolMagicId -> Gen StaticConfig
-genStaticConfig pm = Gen.choice
-  [ GCSrc <$> Gen.string (Range.constant 10 25) Gen.alphaNum <*> genHashRaw
-  , GCSpec <$> genGenesisSpec pm
-  ]
 
 genFakeAvvmOptions :: Gen FakeAvvmOptions
 genFakeAvvmOptions =


### PR DESCRIPTION
The idea was that you could construct a config from either an external genesis file or a genesis spec. This was a relic of a bad idea from the `cardano-sl` implementation.
    
The bad idea was that a node could generate a genesis config on the fly from a config file with the genesis specification. The idea was this made it easier to run dev clusters.
    
It was always a confusing approach however. It meant that all the config needed to make a genesis file needed to be included in the config used for running the node. Nobody could keep track of which config items were used directly by the node and which were only used to make a genesis file.

It's much better to very clearly separate these stages: the node always runs given a pre-generated genesis file; and separately there's a tool to generate new genesis files for dev nets.

Once this PR is in `cardano-node` will need a slight simplification: (cc @deepfire)
```
diff --git a/app/genesis-tool/Run.hs b/app/genesis-tool/Run.hs
index d22e85c..faa28c5 100644
--- a/app/genesis-tool/Run.hs
+++ b/app/genesis-tool/Run.hs
@@ -129,9 +129,7 @@ runCommand kmo (MigrateDelegateKeyFrom
 runCommand kmo (DumpHardcodedGenesis outDir) =
     dumpGenesis kmo outDir
                 (configGenesisData Dummy.dummyConfig)
-                generatedSecrets
-  where
-    Just generatedSecrets = configGeneratedSecrets Dummy.dummyConfig
+                Dummy.dummyGeneratedSecrets
 
 runCommand KeyMaterialOps{..} (PrintGenesisHash secretPath) =
     putStrLn . F.format CCr.hashHexF
```