### PR TITLE
Loading the mainnet Genesis.Config takes 40 MiB

### DIFF
--- a/cardano-ledger/cardano-ledger.cabal
+++ b/cardano-ledger/cardano-ledger.cabal
@@ -328,3 +328,19 @@ test-suite epoch-validation-normal-form-test
 
   if (!flag(development))
     ghc-options:         -Werror
+
+executable memory
+  hs-source-dirs:      memory
+  main-is:             Main.hs
+  build-depends:       base
+                     , cardano-crypto-wrapper
+                     , cardano-ledger
+                     , cardano-prelude
+                     , filepath
+  default-language:    Haskell2010
+  default-extensions:  NoImplicitPrelude
+  ghc-options:         -Weverything
+                       -fno-warn-all-missed-specialisations
+                       -fno-warn-missing-import-lists
+                       -fno-warn-safe
+                       -fno-warn-unsafe

--- a/cardano-ledger/memory/Main.hs
+++ b/cardano-ledger/memory/Main.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Main (main) where
+
+import           Cardano.Prelude
+
+import           System.FilePath       ((</>))
+import           System.Mem            (performGC)
+
+import qualified Cardano.Chain.Genesis as Genesis
+import qualified Cardano.Chain.UTxO    as UTxO
+import           Cardano.Crypto        (RequiresNetworkMagic (..),
+                                        decodeAbstractHash)
+
+main :: IO ()
+main = do
+    -- Load the Genesis Config
+    !cfg <- fmap (either (panic . show) identity) $ runExceptT $
+      Genesis.mkConfigFromFile RequiresNoMagic genesisFile $
+      either panic identity $ decodeAbstractHash genesisHash
+
+    -- It is /not/ in normal form
+    print =<< (isNormalForm $! cfg)
+
+    sleepSeconds 2
+
+    -- Force it so that it is (hopefully?) in normal form
+    !_ <- evaluate $! force $! cfg
+    performGC
+
+    -- It is in normal form, at least according to 'isNormalForm'
+    print =<< (isNormalForm $! cfg)
+
+    sleepSeconds 2
+
+    -- Just make sure we hold on to the Genesis Config until the end of the
+    -- program
+    print =<< (isNormalForm $! cfg)
+  where
+    sleepSeconds :: Int -> IO ()
+    sleepSeconds s = threadDelay (s * 1000 * 1000)
+
+    genesisFile :: FilePath
+    genesisFile = "cardano-ledger" </> "mainnet-genesis.json"
+
+    genesisHash :: Text
+    genesisHash =
+        "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
+
+
+deriving instance NFData  UTxO.UTxOConfiguration
+deriving instance Generic Genesis.GenesisAvvmBalances
+deriving instance NFData  Genesis.GenesisAvvmBalances
+deriving instance Generic Genesis.GenesisNonAvvmBalances
+deriving instance NFData  Genesis.GenesisNonAvvmBalances
+deriving instance Generic Genesis.GenesisDelegation
+deriving instance NFData  Genesis.GenesisDelegation
+deriving instance Generic Genesis.GenesisKeyHashes
+deriving instance NFData  Genesis.GenesisKeyHashes
+deriving instance Generic Genesis.GenesisData
+deriving instance NFData  Genesis.GenesisData
+deriving instance Generic Genesis.Config
+deriving instance NFData  Genesis.Config


### PR DESCRIPTION
While profiling the ChainDB, I noticed that just loading the mainnet `Genesis.Config` takes 40 MiB! The `mainnet-genesis.json` file is 1.1 MiB, but loading it in memory shouldn't take 40 times as much memory (what is acceptable? 5x?).

I have a suspicion the code is holding on to some bytestrings, see the graphs below.

The `Genesis.Config` type doesn't have an `NFData` instance, so I derived one.

![memory_c](https://user-images.githubusercontent.com/373460/63014999-1cd80d00-be90-11e9-9799-9fa489b71f12.png)
![memory_y](https://user-images.githubusercontent.com/373460/63015000-1cd80d00-be90-11e9-8fe2-f5c6fab980ab.png)

Steps to reproduce these results with stack:
```
stack build --work-dir=.stack-work-profiling --profile cardano-ledger:exe:memory
stack exec  --work-dir=.stack-work-profiling --profile memory -- +RTS -h && hp2ps -c memory.hp -m 30
```
