### PR TITLE
TxValidationInvalidWitness: split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ stack-local.yaml.lock
 # Editors
 TAGS
 *~
+\#*
+\.#*
 
 # Vim swap files
 *.sw[a-p]

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/ValidationMode.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/ValidationMode.hs
@@ -138,7 +138,8 @@ ts_prop_updateUTxO_InvalidWit =
  where
   isInvalidWitnessError :: UTxOValidationError -> Bool
   isInvalidWitnessError (UTxOValidationTxValidationError err) = case err of
-    TxValidationInvalidWitness _ -> True
+    TxValidationWitnessWrongSignature{} -> True
+    TxValidationWitnessWrongKey{}       -> True
     _ -> False
   isInvalidWitnessError _ = False
 


### PR DESCRIPTION
The `TxValidationInvalidWitness` case of `TxValidationError` is insufficiently specific for debugging purposes, so we split it in two parts:

1. Wrong signature
2. Key not corresponding to address