### PR TITLE
Add CBOR serialization instances for UTxO, update, and delegation error types

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
@@ -9,7 +9,7 @@
 
 module Cardano.Chain.UTxO.UTxO
   ( UTxO(..)
-  , UTxOError
+  , UTxOError(..)
   , empty
   , fromList
   , fromBalances

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
@@ -63,6 +63,7 @@ import Test.Cardano.Chain.Common.Gen
   , genBlockCount
   , genChainDifficulty
   , genLovelace
+  , genLovelaceError
   , genLovelacePortion
   , genMerkleTree
   , genMerkleRoot
@@ -184,6 +185,13 @@ golden_Lovelace = goldenTestCBOR c "test/golden/cbor/common/Lovelace"
 
 ts_roundTripLovelaceCBOR :: TSProperty
 ts_roundTripLovelaceCBOR = eachOfTS 1000 genLovelace roundTripsCBORBuildable
+
+--------------------------------------------------------------------------------
+-- LovelaceError
+--------------------------------------------------------------------------------
+ts_roundTripLovelaceErrorCBOR :: TSProperty
+ts_roundTripLovelaceErrorCBOR =
+  eachOfTS 1000 genLovelaceError roundTripsCBORBuildable
 
 --------------------------------------------------------------------------------
 -- LovelacePortion

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/CBOR.hs
@@ -15,9 +15,10 @@ import Hedgehog (Property)
 import Cardano.Chain.Delegation (unsafePayload)
 
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBOR, roundTripsCBORBuildable)
+  (goldenTestCBOR, roundTripsCBORBuildable, roundTripsCBORShow)
 import Test.Cardano.Chain.Delegation.Example (exampleCertificates)
-import Test.Cardano.Chain.Delegation.Gen (genCertificate, genPayload)
+import Test.Cardano.Chain.Delegation.Gen
+  (genCertificate, genError, genPayload)
 import Test.Cardano.Crypto.Gen (feedPM)
 import Test.Options (TSGroup, TSProperty, concatTSGroups, eachOfTS)
 
@@ -48,6 +49,15 @@ goldenDlgPayload = goldenTestCBOR dp "test/golden/cbor/delegation/DlgPayload"
 ts_roundTripDlgPayloadCBOR :: TSProperty
 ts_roundTripDlgPayloadCBOR =
   eachOfTS 100 (feedPM genPayload) roundTripsCBORBuildable
+
+
+--------------------------------------------------------------------------------
+-- Error
+--------------------------------------------------------------------------------
+
+ts_roundTripErrorCBOR :: TSProperty
+ts_roundTripErrorCBOR =
+  eachOfTS 100 genError roundTripsCBORShow
 
 
 tests :: TSGroup

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/Gen.hs
@@ -3,6 +3,7 @@ module Test.Cardano.Chain.Delegation.Gen
   , genCertificate
   , genCanonicalCertificateDistinctList
   , genCertificateDistinctList
+  , genError
   , genPayload
   )
 where
@@ -20,11 +21,13 @@ import Cardano.Chain.Delegation
   , signCertificate
   , unsafePayload
   )
+import Cardano.Chain.Delegation.Validation.Scheduling (Error(..))
 import Cardano.Chain.Slotting (EpochNumber(..))
 import Cardano.Crypto (ProtocolMagicId)
 import Data.List (nub)
 
-import Test.Cardano.Chain.Slotting.Gen (genEpochNumber)
+import Test.Cardano.Chain.Common.Gen (genKeyHash)
+import Test.Cardano.Chain.Slotting.Gen (genEpochNumber, genSlotNumber)
 import Test.Cardano.Crypto.Gen (genVerificationKey, genSafeSigner)
 
 
@@ -62,6 +65,15 @@ genCertificateDistinctList pm =
 
   noSelfSigningCerts :: [Certificate] -> [Certificate]
   noSelfSigningCerts = filter (\x -> issuerVK x /= delegateVK x)
+
+genError :: Gen Error
+genError = Gen.choice
+  [ pure InvalidCertificate
+  , MultipleDelegationsForEpoch <$> genEpochNumber <*> genKeyHash
+  , MultipleDelegationsForSlot <$> genSlotNumber <*> genKeyHash
+  , NonGenesisDelegator <$> genKeyHash
+  , WrongEpoch <$> genEpochNumber <*> genEpochNumber
+  ]
 
 genPayload :: ProtocolMagicId -> Gen Payload
 genPayload pm =

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
@@ -58,6 +58,7 @@ import Test.Cardano.Chain.UTxO.Gen
   , genTxSigData
   , genTxValidationError
   , genTxWitness
+  , genUTxOError
   )
 import Test.Cardano.Crypto.Example
   (exampleVerificationKey, exampleRedeemVerificationKey, exampleSigningKey)
@@ -261,6 +262,15 @@ goldenTxWitness =
 
 ts_roundTripTxWitness :: TSProperty
 ts_roundTripTxWitness = eachOfTS 20 (feedPM genTxWitness) roundTripsCBORShow
+
+
+--------------------------------------------------------------------------------
+-- UtxOError
+--------------------------------------------------------------------------------
+
+ts_roundTripUTxOError :: TSProperty
+ts_roundTripUTxOError =
+  eachOfTS 50 genUTxOError roundTripsCBORShow
 
 
 --------------------------------------------------------------------------------

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
@@ -56,6 +56,7 @@ import Test.Cardano.Chain.UTxO.Gen
   , genTxProof
   , genTxSig
   , genTxSigData
+  , genTxValidationError
   , genTxWitness
   )
 import Test.Cardano.Crypto.Example
@@ -239,6 +240,15 @@ goldenTxSigData =
 
 ts_roundTripTxSigData :: TSProperty
 ts_roundTripTxSigData = eachOfTS 50 genTxSigData roundTripsCBORShow
+
+
+--------------------------------------------------------------------------------
+-- TxValidationError
+--------------------------------------------------------------------------------
+
+ts_roundTripTxValidationError :: TSProperty
+ts_roundTripTxValidationError =
+  eachOfTS 50 genTxValidationError roundTripsCBORShow
 
 
 --------------------------------------------------------------------------------

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
@@ -59,6 +59,7 @@ import Test.Cardano.Chain.UTxO.Gen
   , genTxValidationError
   , genTxWitness
   , genUTxOError
+  , genUTxOValidationError
   )
 import Test.Cardano.Crypto.Example
   (exampleVerificationKey, exampleRedeemVerificationKey, exampleSigningKey)
@@ -271,6 +272,15 @@ ts_roundTripTxWitness = eachOfTS 20 (feedPM genTxWitness) roundTripsCBORShow
 ts_roundTripUTxOError :: TSProperty
 ts_roundTripUTxOError =
   eachOfTS 50 genUTxOError roundTripsCBORShow
+
+
+--------------------------------------------------------------------------------
+-- UTxOValidationError
+--------------------------------------------------------------------------------
+
+ts_roundTripUTxOValidationError :: TSProperty
+ts_roundTripUTxOValidationError =
+  eachOfTS 50 genUTxOValidationError roundTripsCBORShow
 
 
 --------------------------------------------------------------------------------

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
@@ -22,6 +22,7 @@ module Test.Cardano.Chain.UTxO.Gen
   , genTxValidationError
   , genTxWitness
   , genUTxO
+  , genUTxOError
   )
 where
 
@@ -56,6 +57,7 @@ import Cardano.Chain.UTxO
   , TxWitness
   , UTxOConfiguration(..)
   , UTxO
+  , UTxOError(..)
   , fromList
   , mkTxAux
   , mkTxPayload
@@ -182,3 +184,9 @@ genUTxO = fromList <$> Gen.list (Range.constant 0 1000) genTxInTxOut
   where
     genTxInTxOut :: Gen (TxIn, TxOut)
     genTxInTxOut = (,) <$> genTxIn <*> genTxOut
+
+genUTxOError :: Gen UTxOError
+genUTxOError = Gen.choice
+  [ UTxOMissingInput <$> genTxIn
+  , pure UTxOOverlappingUnion
+  ]

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
@@ -23,6 +23,7 @@ module Test.Cardano.Chain.UTxO.Gen
   , genTxWitness
   , genUTxO
   , genUTxOError
+  , genUTxOValidationError
   )
 where
 
@@ -58,6 +59,7 @@ import Cardano.Chain.UTxO
   , UTxOConfiguration(..)
   , UTxO
   , UTxOError(..)
+  , UTxOValidationError(..)
   , fromList
   , mkTxAux
   , mkTxPayload
@@ -189,4 +191,10 @@ genUTxOError :: Gen UTxOError
 genUTxOError = Gen.choice
   [ UTxOMissingInput <$> genTxIn
   , pure UTxOOverlappingUnion
+  ]
+
+genUTxOValidationError :: Gen UTxOValidationError
+genUTxOValidationError = Gen.choice
+  [ UTxOValidationTxValidationError <$> genTxValidationError
+  , UTxOValidationUTxOError <$> genUTxOError
   ]


### PR DESCRIPTION
Required as part of https://github.com/input-output-hk/ouroboros-network/issues/592 since the `LocalTxSubmission` `Codec` requires the ability to CBOR encode and decode `ApplyTxErr`s (which can be either transaction, update, or delegation errors).

I'll be adding golden tests in follow-up PRs (I believe there are around 40 golden tests required as a result of this PR). Also, I still need to add generators or round-trip tests for `Update`-related error types.