### PR TITLE
Redxaxder/new annotations

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Block/Block.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Block.hs
@@ -102,8 +102,8 @@ import Cardano.Chain.Block.Body
 import Cardano.Chain.Block.Boundary
   (dropBoundaryBody, dropBoundaryExtraBodyData)
 import Cardano.Chain.Block.Header
-  ( ABlockSignature
-  , AHeader(..)
+  ( BlockSignature
+  , Header(..)
   , ABoundaryHeader(..)
   , Header
   , HeaderHash
@@ -150,7 +150,7 @@ import Cardano.Crypto (ProtocolMagicId, SigningKey, VerificationKey)
 --------------------------------------------------------------------------------
 
 data Block = Block
-  { blockHeader     :: AHeader ByteString
+  { blockHeader     :: Header
   , blockBody       :: Body
   , blockSerialized :: ByteString
   } deriving (Eq, Show, Generic, NFData)
@@ -248,7 +248,7 @@ blockDifficulty = headerDifficulty . blockHeader
 blockToSign :: EpochSlots -> Block -> ToSign
 blockToSign epochSlots = headerToSign epochSlots . blockHeader
 
-blockSignature :: Block -> ABlockSignature ByteString
+blockSignature :: Block -> BlockSignature
 blockSignature = headerSignature . blockHeader
 
 blockProtocolVersion :: Block -> ProtocolVersion

--- a/cardano-ledger/src/Cardano/Chain/Block/Block.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Block.hs
@@ -12,7 +12,7 @@
 module Cardano.Chain.Block.Block
   (
   -- * Block
-    Block (..)
+    Block (blockHeader, blockBody, blockSerialized)
 
   -- * Block Constructors
   , mkBlock

--- a/cardano-ledger/src/Cardano/Chain/Block/Block.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Block.hs
@@ -124,7 +124,6 @@ import Cardano.Chain.Block.Header
   , headerSoftwareVersion
   , headerToSign
   , mkHeaderExplicit
-  , toCBORHeader
   , toCBORABoundaryHeader
   )
 import Cardano.Chain.Block.Proof (Proof(..))
@@ -161,11 +160,10 @@ data Block = Block
 
 -- | Smart constructor for 'Block'
 mkBlock
-  :: EpochSlots
-  -> Header
+  :: Header
   -> Body
   -> Block
-mkBlock epochSlots header body =
+mkBlock header body =
   let bytes = serializeEncoding' $ encodeListLen 3
               <> toCBOR header
               <> toCBOR body
@@ -202,7 +200,7 @@ mkBlockExplicit pm pv sv prevHash difficulty epochSlots slotNumber sk dlgCert bo
           body
           pv
           sv
-    in mkBlock epochSlots header body
+    in mkBlock header body
 
 
 --------------------------------------------------------------------------------

--- a/cardano-ledger/src/Cardano/Chain/Block/Body.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Body.hs
@@ -66,8 +66,8 @@ instance FromCBOR (ABody ByteSpan) where
       <*> fromCBOR
       <*> fromCBOR
 
-bodyTxs :: Body -> [Tx]
+bodyTxs :: ABody a -> [Tx]
 bodyTxs = txpTxs . bodyTxPayload
 
-bodyWitnesses :: Body -> [TxWitness]
+bodyWitnesses :: ABody a -> [TxWitness]
 bodyWitnesses = txpWitnesses . bodyTxPayload

--- a/cardano-ledger/src/Cardano/Chain/Block/Body.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Body.hs
@@ -1,16 +1,15 @@
 {-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module Cardano.Chain.Block.Body
-  ( Body
+  ( Body(..)
   , pattern Body
-  , ABody(..)
   , bodyTxs
   , bodyWitnesses
   )
@@ -19,7 +18,9 @@ where
 import Cardano.Prelude
 
 import Cardano.Binary
-  (ByteSpan, FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize)
+  (FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize,
+  FromCBORAnnotated(..), serializeEncoding', encodePreEncoded, serialize',
+  liftByteSpanDecoder, withSlice')
 import qualified Cardano.Chain.Delegation.Payload as Delegation
 import Cardano.Chain.Ssc (SscPayload(..))
 import Cardano.Chain.UTxO.Tx (Tx)
@@ -27,47 +28,57 @@ import Cardano.Chain.UTxO.TxPayload (ATxPayload, TxPayload, txpTxs, txpWitnesses
 import Cardano.Chain.UTxO.TxWitness (TxWitness)
 import qualified Cardano.Chain.Update.Payload as Update
 
--- | 'Body' consists of payloads of all block components
-type Body = ABody ()
-
 -- | Constructor for 'Body'
 pattern Body :: TxPayload -> SscPayload -> Delegation.Payload -> Update.Payload -> Body
-pattern Body tx ssc dlg upd = ABody tx ssc dlg upd
+pattern Body bodyTxPayload bodySscPayload bodyDlgPayload bodyUpdatePayload <-
+  Body'
+    (void -> bodyTxPayload)
+    bodySscPayload
+    (void -> bodyDlgPayload)
+    (void -> bodyUpdatePayload)
+    _
+  where
+  Body tx ssc dlg upd =
+    let bytes = serializeEncoding' $ encodeListLen 4
+          <> encodePreEncoded txBytes
+          <> encodePreEncoded sscBytes
+          <> encodePreEncoded dlgBytes
+          <> encodePreEncoded updBytes
+        txBytes = serialize' tx
+        sscBytes = serialize' ssc
+        dlgBytes = serialize' dlg
+        updBytes = serialize' upd
+    -- FIXME: This constructs the members of members of the body with incorrect
+    -- bytestring references. We'd need to make the same change we made to body
+    -- all the way down to correct this problem.
+    in Body' (txBytes <$ tx) ssc (dlgBytes <$ dlg) (updBytes <$ upd) bytes
 
 -- | 'Body' consists of payloads of all block components
-data ABody a = ABody
-  { bodyTxPayload     :: !(ATxPayload a)
+data Body = Body'
+  { bodyTxPayload     :: !(ATxPayload ByteString)
   -- ^ UTxO payload
   , bodySscPayload    :: !SscPayload
   -- ^ Ssc payload
-  , bodyDlgPayload    :: !(Delegation.APayload a)
+  , bodyDlgPayload    :: !(Delegation.APayload ByteString)
   -- ^ Heavyweight delegation payload (no-ttl certificates)
-  , bodyUpdatePayload :: !(Update.APayload a)
+  , bodyUpdatePayload :: !(Update.APayload ByteString)
   -- ^ Additional update information for the update system
-  } deriving (Eq, Show, Generic, Functor, NFData)
+  , bodySerialized    :: ByteString
+  } deriving (Eq, Show, Generic, NFData)
 
 instance ToCBOR Body where
-  toCBOR bc =
-    encodeListLen 4
-      <> toCBOR (bodyTxPayload bc)
-      <> toCBOR (bodySscPayload bc)
-      <> toCBOR (bodyDlgPayload bc)
-      <> toCBOR (bodyUpdatePayload bc)
+  toCBOR = encodePreEncoded . bodySerialized
 
-instance FromCBOR Body where
-  fromCBOR = void <$> fromCBOR @(ABody ByteSpan)
+instance FromCBORAnnotated Body where
+  fromCBORAnnotated' = withSlice' $
+    Body' <$ lift (enforceSize "Body" 4)
+      <*> liftByteSpanDecoder fromCBOR
+      <*> lift fromCBOR
+      <*> liftByteSpanDecoder fromCBOR
+      <*> liftByteSpanDecoder fromCBOR
 
-instance FromCBOR (ABody ByteSpan) where
-  fromCBOR = do
-    enforceSize "Body" 4
-    ABody
-      <$> fromCBOR
-      <*> fromCBOR
-      <*> fromCBOR
-      <*> fromCBOR
-
-bodyTxs :: ABody a -> [Tx]
+bodyTxs :: Body -> [Tx]
 bodyTxs = txpTxs . bodyTxPayload
 
-bodyWitnesses :: ABody a -> [TxWitness]
+bodyWitnesses :: Body -> [TxWitness]
 bodyWitnesses = txpWitnesses . bodyTxPayload

--- a/cardano-ledger/src/Cardano/Chain/Block/Body.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Body.hs
@@ -34,7 +34,7 @@ pattern Body bodyTxPayload bodySscPayload bodyDlgPayload bodyUpdatePayload <-
   Body'
     bodyTxPayload
     bodySscPayload
-    (void -> bodyDlgPayload)
+    bodyDlgPayload
     (void -> bodyUpdatePayload)
     _
   where
@@ -50,7 +50,7 @@ pattern Body bodyTxPayload bodySscPayload bodyDlgPayload bodyUpdatePayload <-
     -- FIXME: This constructs the members of members of the body with incorrect
     -- bytestring references. We'd need to make the same change we made to body
     -- all the way down to correct this problem.
-    in Body' tx ssc (dlgBytes <$ dlg) (updBytes <$ upd) bytes
+    in Body' tx ssc dlg (updBytes <$ upd) bytes
 
 -- | 'Body' consists of payloads of all block components
 data Body = Body'
@@ -58,7 +58,7 @@ data Body = Body'
   -- ^ UTxO payload
   , bodySscPayload    :: !SscPayload
   -- ^ Ssc payload
-  , bodyDlgPayload    :: !(Delegation.APayload ByteString)
+  , bodyDlgPayload    :: !Delegation.Payload
   -- ^ Heavyweight delegation payload (no-ttl certificates)
   , bodyUpdatePayload :: !(Update.APayload ByteString)
   -- ^ Additional update information for the update system
@@ -73,7 +73,7 @@ instance FromCBORAnnotated Body where
     Body' <$ lift (enforceSize "Body" 4)
       <*> fromCBORAnnotated'
       <*> lift fromCBOR
-      <*> liftByteSpanDecoder fromCBOR
+      <*> fromCBORAnnotated'
       <*> liftByteSpanDecoder fromCBOR
 
 bodyTxs :: Body -> [Tx]

--- a/cardano-ledger/src/Cardano/Chain/Block/Body.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Body.hs
@@ -20,7 +20,7 @@ import Cardano.Prelude
 import Cardano.Binary
   (FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize,
   FromCBORAnnotated(..), serializeEncoding', encodePreEncoded, serialize',
-  liftByteSpanDecoder, withSlice')
+  withSlice')
 import qualified Cardano.Chain.Delegation.Payload as Delegation
 import Cardano.Chain.Ssc (SscPayload(..))
 import Cardano.Chain.UTxO.Tx (Tx)

--- a/cardano-ledger/src/Cardano/Chain/Block/Body.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Body.hs
@@ -35,7 +35,7 @@ pattern Body bodyTxPayload bodySscPayload bodyDlgPayload bodyUpdatePayload <-
     bodyTxPayload
     bodySscPayload
     bodyDlgPayload
-    (void -> bodyUpdatePayload)
+    bodyUpdatePayload
     _
   where
   Body tx ssc dlg upd =
@@ -50,7 +50,7 @@ pattern Body bodyTxPayload bodySscPayload bodyDlgPayload bodyUpdatePayload <-
     -- FIXME: This constructs the members of members of the body with incorrect
     -- bytestring references. We'd need to make the same change we made to body
     -- all the way down to correct this problem.
-    in Body' tx ssc dlg (updBytes <$ upd) bytes
+    in Body' tx ssc dlg upd bytes
 
 -- | 'Body' consists of payloads of all block components
 data Body = Body'
@@ -60,7 +60,7 @@ data Body = Body'
   -- ^ Ssc payload
   , bodyDlgPayload    :: !Delegation.Payload
   -- ^ Heavyweight delegation payload (no-ttl certificates)
-  , bodyUpdatePayload :: !(Update.APayload ByteString)
+  , bodyUpdatePayload :: !Update.Payload
   -- ^ Additional update information for the update system
   , bodySerialized    :: ByteString
   } deriving (Eq, Show, Generic, NFData)
@@ -74,7 +74,7 @@ instance FromCBORAnnotated Body where
       <*> fromCBORAnnotated'
       <*> lift fromCBOR
       <*> fromCBORAnnotated'
-      <*> liftByteSpanDecoder fromCBOR
+      <*> fromCBORAnnotated'
 
 bodyTxs :: Body -> [Tx]
 bodyTxs = txpTxs . bodyTxPayload

--- a/cardano-ledger/src/Cardano/Chain/Block/Body.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Body.hs
@@ -47,9 +47,6 @@ pattern Body bodyTxPayload bodySscPayload bodyDlgPayload bodyUpdatePayload <-
         sscBytes = serialize' ssc
         dlgBytes = serialize' dlg
         updBytes = serialize' upd
-    -- FIXME: This constructs the members of members of the body with incorrect
-    -- bytestring references. We'd need to make the same change we made to body
-    -- all the way down to correct this problem.
     in Body' tx ssc dlg upd bytes
 
 -- | 'Body' consists of payloads of all block components

--- a/cardano-ledger/src/Cardano/Chain/Block/Header.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Header.hs
@@ -14,7 +14,19 @@
 module Cardano.Chain.Block.Header
   (
   -- * Header
-  Header(..)
+  Header
+    ( aHeaderProtocolMagicId
+    , aHeaderPrevHash
+    , aHeaderSlot
+    , aHeaderDifficulty
+    , headerProtocolVersion
+    , headerSoftwareVersion
+    , headerProof
+    , headerGenesisKey
+    , headerSignature
+    , headerExtraAnnotation
+    , headerAnnotation
+    )
 
   -- * Header Constructors
   , mkHeader

--- a/cardano-ledger/src/Cardano/Chain/Block/Header.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Header.hs
@@ -23,7 +23,6 @@ module Cardano.Chain.Block.Header
   -- * Header Accessors
   , headerProtocolMagicId
   , headerPrevHash
-  , headerProof
   , headerSlot
   , headerIssuer
   , headerLength
@@ -83,7 +82,6 @@ import Cardano.Binary
   , FromCBORAnnotated(..)
   , ToCBOR(..)
   , annotatedDecoder
-  , fromCBORAnnotated
   , dropBytes
   , dropInt32
   , encodeListLen
@@ -293,8 +291,8 @@ instance ToCBOR Header where
 
 -- | Encode a header, without taking in to account deprecated epoch boundary
 -- blocks.
-toCBORHeader :: EpochSlots -> Header -> Encoding
-toCBORHeader es h = toCBOR h
+toCBORHeader :: Header -> Encoding
+toCBORHeader h = toCBOR h
 
 toCBORBlockVersions :: ProtocolVersion -> SoftwareVersion -> Encoding
 toCBORBlockVersions pv sv =
@@ -407,10 +405,10 @@ fromCBORHeaderToHash epochSlots = do
 --------------------------------------------------------------------------------
 
 instance B.Buildable (WithEpochSlots Header) where
-  build (WithEpochSlots es header) = renderHeader es header
+  build (WithEpochSlots _ header) = renderHeader header
 
-renderHeader :: EpochSlots -> Header -> Builder
-renderHeader es header = bprint
+renderHeader :: Header -> Builder
+renderHeader header = bprint
   ( "Header:\n"
   . "    hash: " . hashHexF . "\n"
   . "    previous block: " . hashHexF . "\n"
@@ -641,7 +639,7 @@ instance FromCBORAnnotated ToSign where
     lift $ enforceSize "ToSign" 5
     headerHash <- lift fromCBOR
     bodyProof <- fromCBORAnnotated'
-    slotCount <- lift fromCBOR
+    slotCount' <- lift fromCBOR
     difficulty <- lift fromCBOR
     (protocolVersion, softwareVersion) <- lift fromCBORBlockVersions
-    pure $ ToSign headerHash bodyProof slotCount difficulty protocolVersion softwareVersion
+    pure $ ToSign headerHash bodyProof slotCount' difficulty protocolVersion softwareVersion

--- a/cardano-ledger/src/Cardano/Chain/Block/Header.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Header.hs
@@ -30,7 +30,6 @@ module Cardano.Chain.Block.Header
   , headerToSign
 
   -- * Header Binary Serialization
-  , toCBORHeader
   , toCBORHeaderToHash
   , fromCBORHeader
   , fromCBORHeaderToHash
@@ -288,12 +287,6 @@ headerLength = fromIntegral . BS.length . headerAnnotation
 instance ToCBOR Header where
   toCBOR = encodePreEncoded . headerAnnotation
 
-
--- | Encode a header, without taking in to account deprecated epoch boundary
--- blocks.
-toCBORHeader :: Header -> Encoding
-toCBORHeader h = toCBOR h
-
 toCBORBlockVersions :: ProtocolVersion -> SoftwareVersion -> Encoding
 toCBORBlockVersions pv sv =
   encodeListLen 4
@@ -329,48 +322,6 @@ fromCBORHeader epochSlots = withSlice' $ do
     sig
     extraBytes
 
-{-
-
-fromCBORAHeader :: EpochSlots -> Decoder s (AHeader ByteSpan)
-fromCBORAHeader epochSlots = do
-  Annotated
-    ( pm
-    , prevHash
-    , proof
-    , (slot, genesisKey, difficulty, sig)
-    , Annotated (protocolVersion, softwareVersion) extraByteSpan
-    )
-    byteSpan <-
-    annotatedDecoder $ do
-      enforceSize "Header" 5
-      (,,,,)
-        <$> fromCBORAnnotated
-        <*> fromCBORAnnotated
-        <*> fromCBORAnnotated'
-        <*> do
-              enforceSize "ConsensusData" 4
-              (,,,)
-                -- Next, we decode a 'EpochAndSlotCount' into a 'SlotNumber': the `EpochAndSlotCount`
-                -- used in 'AConsensusData' is encoded as a epoch and slot-count
-                -- pair.
-                <$> fmap (first (toSlotNumber epochSlots)) fromCBORAnnotated
-                <*> fromCBOR
-                <*> fromCBORAnnotated
-                <*> fromCBOR
-        <*> annotatedDecoder fromCBORBlockVersions
-  pure $ AHeader
-    pm
-    prevHash
-    slot
-    difficulty
-    protocolVersion
-    softwareVersion
-    proof
-    genesisKey
-    sig
-    byteSpan
-    extraByteSpan
--}
 fromCBORBlockVersions :: Decoder s (ProtocolVersion, SoftwareVersion)
 fromCBORBlockVersions = do
   enforceSize "BlockVersions" 4

--- a/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
@@ -18,7 +18,7 @@ import qualified Formatting.Buildable as B
 
 import Cardano.Binary (FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize)
 import Cardano.Chain.Block.Body
-  (ABody(..), Body, bodyDlgPayload, bodyTxPayload, bodyUpdatePayload)
+  (Body(..), bodyDlgPayload, bodyTxPayload, bodyUpdatePayload)
 import qualified Cardano.Chain.Delegation.Payload as Delegation
 import Cardano.Chain.Ssc (SscProof(..))
 import Cardano.Chain.UTxO.TxProof (TxProof, mkTxProof, recoverTxProof)
@@ -57,16 +57,16 @@ instance FromCBOR Proof where
 
 mkProof :: Body -> Proof
 mkProof body = Proof
-  { proofUTxO        = mkTxProof $ bodyTxPayload body
+  { proofUTxO        = mkTxProof $ void $ bodyTxPayload body
   , proofSsc        = SscProof
-  , proofDelegation = hash $ bodyDlgPayload body
-  , proofUpdate     = Update.mkProof $ bodyUpdatePayload body
+  , proofDelegation = hash $ void $ bodyDlgPayload body
+  , proofUpdate     = Update.mkProof $ void $ bodyUpdatePayload body
   }
 
 -- TODO: Should we be using this somewhere?
-recoverProof :: ABody ByteString -> Proof
+recoverProof :: Body -> Proof
 recoverProof body = Proof
-  { proofUTxO        = recoverTxProof $ bodyTxPayload body
+  { proofUTxO       = recoverTxProof $ bodyTxPayload body
   , proofSsc        = SscProof
   , proofDelegation = hashDecoded $ bodyDlgPayload body
   , proofUpdate     = Update.recoverProof $ bodyUpdatePayload body

--- a/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
@@ -5,7 +5,13 @@
 {-# LANGUAGE PatternSynonyms   #-}
 
 module Cardano.Chain.Block.Proof
-  ( Proof(..)
+  ( Proof
+    ( proofUTxO
+    , proofSsc
+    , proofDelegation
+    , proofUpdate
+    , proofSerialized
+    )
   , pattern Proof
   , ProofValidationError (..)
   , mkProof
@@ -34,7 +40,7 @@ import qualified Cardano.Chain.Delegation.Payload as Delegation
 import Cardano.Chain.Ssc (SscProof(..))
 import Cardano.Chain.UTxO.TxProof (TxProof, mkTxProof, recoverTxProof)
 import qualified Cardano.Chain.Update.Proof as Update
-import Cardano.Crypto (Hash, hash, hashDecoded)
+import Cardano.Crypto (Hash, hash)
 
 
 -- | Proof of everything contained in the payload
@@ -91,7 +97,7 @@ recoverProof :: Body -> Proof
 recoverProof body = Proof
    (recoverTxProof $ bodyTxPayload body)
    SscProof
-   (hashDecoded $ bodyDlgPayload body)
+   (hash $ bodyDlgPayload body)
    (Update.recoverProof $ bodyUpdatePayload body)
 
 -- | Error which can result from attempting to validate an invalid payload

--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -41,8 +41,6 @@ where
 import Cardano.Prelude
 
 import Control.Monad.Trans.Resource (ResIO)
-import qualified Data.ByteString.Lazy as BSL
-import Data.Coerce (coerce)
 import qualified Data.Map.Strict as M
 import Data.Sequence (Seq(..), (<|))
 import qualified Data.Sequence as Seq
@@ -78,12 +76,12 @@ import Cardano.Chain.Block.Block
   )
 import Cardano.Chain.Block.Header
   ( Header (..)
-  , ABoundaryHeader (..)
+  , BoundaryHeader (..)
+  , boundaryHeaderHashAnnotated
   , BlockSignature
   , HeaderHash
   , headerLength
   , headerProof
-  , wrapBoundaryBytes
   )
 import Cardano.Chain.Block.Proof (Proof(..), ProofValidationError (..))
 import Cardano.Chain.Common
@@ -118,7 +116,6 @@ import Cardano.Crypto
   ( AProtocolMagic(..)
   , ProtocolMagicId
   , VerificationKey
-  , hashRaw
   , hashDecoded
   )
 import Cardano.Chain.ValidationMode
@@ -375,11 +372,7 @@ updateChainBoundary cvs bvd = do
   pure $ cvs
     { cvsPreviousHash =
       Right
-      . coerce
-      . hashRaw
-      . BSL.fromStrict
-      . wrapBoundaryBytes
-      $ boundaryHeaderAnnotation (boundaryHeader bvd)
+      $ boundaryHeaderHashAnnotated (boundaryHeader bvd)
     }
 
 

--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -60,8 +60,8 @@ import Cardano.Binary
   )
 import Cardano.Chain.Block.Body (ABody (..))
 import Cardano.Chain.Block.Block
-  ( ABlock(..)
-  , ABlockOrBoundary(..)
+  ( Block(..)
+  , BlockOrBoundary(..)
   , ABoundaryBlock(..)
   , blockAProtocolMagicId
   , blockDlgPayload
@@ -340,11 +340,11 @@ updateChainBlockOrBoundary
   :: (MonadError ChainValidationError m, MonadReader ValidationMode m)
   => Genesis.Config
   -> ChainValidationState
-  -> ABlockOrBoundary ByteString
+  -> BlockOrBoundary
   -> m ChainValidationState
 updateChainBlockOrBoundary config c b = case b of
-  ABOBBoundary bvd   -> updateChainBoundary c bvd
-  ABOBBlock    block -> updateBlock config c block
+  BOBBoundary bvd   -> updateChainBoundary c bvd
+  BOBBlock    block -> updateBlock config c block
 
 
 updateChainBoundary
@@ -404,12 +404,12 @@ validateHeaderMatchesBody hdr body = do
 
 validateBlockProofs
   :: MonadError ProofValidationError m
-  => ABlock ByteString
+  => Block
   -> m ()
 validateBlockProofs b =
   validateHeaderMatchesBody blockHeader blockBody
  where
-  ABlock
+  Block
     { blockHeader
     , blockBody
     } = b
@@ -439,7 +439,7 @@ updateBody
   :: (MonadError ChainValidationError m, MonadReader ValidationMode m)
   => BodyEnvironment
   -> BodyState
-  -> ABlock ByteString
+  -> Block
   -> m BodyState
 updateBody env bs b = do
   -- Validate the block size
@@ -584,7 +584,7 @@ updateBlock
   :: (MonadError ChainValidationError m, MonadReader ValidationMode m)
   => Genesis.Config
   -> ChainValidationState
-  -> ABlock ByteString
+  -> Block
   -> m ChainValidationState
 updateBlock config cvs b = do
 
@@ -657,7 +657,7 @@ data Error
 foldUTxO
   :: UTxO.Environment
   -> UTxO
-  -> Stream (Of (ABlock ByteString)) (ExceptT ParseError ResIO) ()
+  -> Stream (Of Block) (ExceptT ParseError ResIO) ()
   -> ExceptT Error (ReaderT ValidationMode ResIO) UTxO
 foldUTxO env utxo blocks = S.foldM_
   (foldUTxOBlock env)
@@ -669,7 +669,7 @@ foldUTxO env utxo blocks = S.foldM_
 foldUTxOBlock
   :: UTxO.Environment
   -> UTxO
-  -> ABlock ByteString
+  -> Block
   -> ExceptT Error (ReaderT ValidationMode ResIO) UTxO
 foldUTxOBlock env utxo block =
   withExceptT

--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE NumDecimals                #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PatternSynonyms            #-}
 
 module Cardano.Chain.Block.Validation
   ( updateBody
@@ -76,7 +77,7 @@ import Cardano.Chain.Block.Block
   , blockUpdatePayload
   )
 import Cardano.Chain.Block.Header
-  ( AHeader (..)
+  ( Header (..)
   , ABoundaryHeader (..)
   , BlockSignature
   , HeaderHash
@@ -107,7 +108,7 @@ import Cardano.Chain.Genesis as Genesis
 import Cardano.Chain.ProtocolConstants (kEpochSlots)
 import Cardano.Chain.Slotting
   (EpochNumber(..), SlotNumber(..), EpochAndSlotCount(..), slotNumberEpoch, fromSlotNumber)
-import Cardano.Chain.UTxO (ATxPayload(..), UTxO(..), genesisUtxo, recoverTxProof)
+import Cardano.Chain.UTxO (TxPayload(..), UTxO(..), genesisUtxo, recoverTxProof)
 import qualified Cardano.Chain.UTxO.Validation as UTxO
 import Cardano.Chain.UTxO.UTxOConfiguration (UTxOConfiguration)
 import qualified Cardano.Chain.Update as Update
@@ -384,7 +385,7 @@ updateChainBoundary cvs bvd = do
 
 validateHeaderMatchesBody
   :: MonadError ProofValidationError m
-  => AHeader ByteString
+  => Header
   -> Body
   -> m ()
 validateHeaderMatchesBody hdr body = do
@@ -484,7 +485,7 @@ updateBody env bs b = do
 
   certificates  = Delegation.getPayload $ blockDlgPayload b
 
-  txs           = aUnTxPayload $ blockTxPayload b
+  txs           = unTxPayload $ blockTxPayload b
 
   delegationEnv = DI.Environment
     { DI.protocolMagic = getAProtocolMagicId protocolMagic
@@ -526,7 +527,7 @@ toNumGenKeys n
 headerIsValid
   :: (MonadError ChainValidationError m, MonadReader ValidationMode m)
   => UPI.State
-  -> AHeader ByteString
+  -> Header
   -> m ()
 headerIsValid updateState h =
   -- Validate the header size
@@ -676,7 +677,7 @@ foldUTxOBlock env utxo block =
     (ErrorUTxOValidationError . fromSlotNumber mainnetEpochSlots $ blockSlot
       block
     )
-  $ UTxO.updateUTxO env utxo (aUnTxPayload $ blockTxPayload block)
+  $ UTxO.updateUTxO env utxo (unTxPayload $ blockTxPayload block)
 
 -- | Size of a heap value, in words
 newtype HeapSize a =

--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -61,7 +61,7 @@ import Cardano.Chain.Block.Body (Body (..))
 import Cardano.Chain.Block.Block
   ( Block(..)
   , BlockOrBoundary(..)
-  , ABoundaryBlock(..)
+  , BoundaryBlock(..)
   , blockAProtocolMagicId
   , blockDlgPayload
   , blockHashAnnotated
@@ -348,7 +348,7 @@ updateChainBlockOrBoundary config c b = case b of
 updateChainBoundary
   :: MonadError ChainValidationError m
   => ChainValidationState
-  -> ABoundaryBlock ByteString
+  -> BoundaryBlock
   -> m ChainValidationState
 updateChainBoundary cvs bvd = do
   case (cvsPreviousHash cvs, boundaryPrevHash (boundaryHeader bvd)) of

--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -58,7 +58,7 @@ import Cardano.Binary
   , enforceSize
   , serialize'
   )
-import Cardano.Chain.Block.Body (ABody (..))
+import Cardano.Chain.Block.Body (Body (..))
 import Cardano.Chain.Block.Block
   ( Block(..)
   , BlockOrBoundary(..)
@@ -385,7 +385,7 @@ updateChainBoundary cvs bvd = do
 validateHeaderMatchesBody
   :: MonadError ProofValidationError m
   => AHeader ByteString
-  -> ABody ByteString
+  -> Body
   -> m ()
 validateHeaderMatchesBody hdr body = do
   let hdrProof = headerProof hdr

--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -408,13 +408,7 @@ validateBlockProofs
   => Block
   -> m ()
 validateBlockProofs b =
-  validateHeaderMatchesBody blockHeader blockBody
- where
-  Block
-    { blockHeader
-    , blockBody
-    } = b
-
+  validateHeaderMatchesBody (blockHeader b) (blockBody b)
 
 data BodyEnvironment = BodyEnvironment
   { protocolMagic      :: !(AProtocolMagic ByteString)

--- a/cardano-ledger/src/Cardano/Chain/Common/Merkle.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Merkle.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE UndecidableInstances       #-}
@@ -48,8 +47,7 @@ import qualified Data.Foldable as Foldable
 import Formatting.Buildable (Buildable(..))
 import qualified Prelude
 
-import Cardano.Binary
-  (Annotated(..), FromCBOR(..), Raw, ToCBOR(..), serializeBuilder)
+import Cardano.Binary (Annotated(..), FromCBOR(..), Raw, ToCBOR(..), serializeBuilder)
 import Cardano.Crypto (AbstractHash(..), Hash, hashDecoded, hashRaw)
 
 
@@ -70,7 +68,7 @@ instance Buildable (MerkleRoot a) where
 instance ToCBOR a => ToCBOR (MerkleRoot a) where
   toCBOR = toCBOR . getMerkleRoot
 
-instance FromCBOR a => FromCBOR (MerkleRoot a) where
+instance Typeable a => FromCBOR (MerkleRoot a) where
   fromCBOR = MerkleRoot <$> fromCBOR
 
 merkleRootToBuilder :: MerkleRoot a -> Builder

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
@@ -41,14 +41,12 @@ import Text.JSON.Canonical
 
 import Cardano.Binary
   ( Annotated(..)
-  , ByteSpan
   , FromCBOR(..)
   , ToCBOR(..)
   , FromCBORAnnotated (..)
   , encodeListLen
   , enforceSize
   , serialize'
-  , withSlice
   , encodePreEncoded
   , serializeEncoding'
   , withSlice'
@@ -104,7 +102,7 @@ signCertificate protocolMagicId delegateVK epochNumber safeSigner =
   unsafeCertificate epochNumber issuerVK delegateVK signature
   where
   issuerVK   = safeToVerification safeSigner
-  signature  = coerce sig
+  signature  = coerce sig :: Signature EpochNumber
   sig = safeSign protocolMagicId SignCertificate safeSigner
     $ mconcat [ "00"
               , CC.unXPub (unVerificationKey delegateVK)

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
@@ -162,12 +162,7 @@ isValid pm UnsafeCertificate { aEpoch, issuerVK, delegateVK, signature } =
 --------------------------------------------------------------------------------
 
 instance ToCBOR Certificate where
-  toCBOR cert =
-    encodeListLen 4
-      <> toCBOR (epoch cert)
-      <> toCBOR (issuerVK cert)
-      <> toCBOR (delegateVK cert)
-      <> toCBOR (signature cert)
+  toCBOR = encodePreEncoded . serialize
 
 instance FromCBORAnnotated Certificate where
   fromCBORAnnotated' = withSlice' $

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Payload.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Payload.hs
@@ -20,12 +20,8 @@ import Formatting (bprint, int)
 import Formatting.Buildable (Buildable(..))
 
 import Cardano.Binary
-  ( Annotated(..)
-  , ByteSpan
-  , Decoded(..)
-  , FromCBOR(..)
+  ( Decoded(..)
   , ToCBOR(..)
-  , annotatedDecoder
   , FromCBORAnnotated (..)
   , serialize'
   , encodePreEncoded

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Payload.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Payload.hs
@@ -9,8 +9,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 
 module Cardano.Chain.Delegation.Payload
-  ( APayload(..)
-  , Payload
+  ( Payload(..)
   , unsafePayload
   )
 where
@@ -27,39 +26,36 @@ import Cardano.Binary
   , FromCBOR(..)
   , ToCBOR(..)
   , annotatedDecoder
+  , FromCBORAnnotated (..)
+  , serialize'
+  , encodePreEncoded
+  , withSlice'
   )
 import qualified Cardano.Chain.Delegation.Certificate as Delegation
 
 
 -- | The delegation 'Payload' contains a list of delegation 'Certificate's
-data APayload a = UnsafeAPayload
-  { getPayload    :: [Delegation.ACertificate a]
-  , getAnnotation :: a
-  } deriving (Show, Eq, Generic, Functor)
+data Payload = UnsafePayload
+  { getPayload       :: ![Delegation.Certificate]
+  , serializePayload :: ByteString
+  } deriving (Show, Eq, Generic)
     deriving anyclass NFData
 
-type Payload = APayload ()
-
 unsafePayload :: [Delegation.Certificate] -> Payload
-unsafePayload sks = UnsafeAPayload sks ()
+unsafePayload sks = UnsafePayload sks (serialize' sks)
 
-instance Decoded (APayload ByteString) where
-  type BaseType (APayload ByteString)  = Payload
-  recoverBytes = getAnnotation
+instance Decoded Payload where
+  type BaseType Payload = Payload
+  recoverBytes = serializePayload
 
-instance Buildable (APayload a) where
-  build (UnsafeAPayload psks _) = bprint
+instance Buildable Payload where
+  build (UnsafePayload psks _) = bprint
     ("proxy signing keys (" . int . " items): " . listJson . "\n")
     (length psks)
     psks
 
 instance ToCBOR Payload where
-  toCBOR = toCBOR . getPayload
+  toCBOR = encodePreEncoded . serializePayload
 
-instance FromCBOR Payload where
-  fromCBOR = void <$> fromCBOR @(APayload ByteSpan)
-
-instance FromCBOR (APayload ByteSpan) where
-  fromCBOR = do
-    (Annotated p a) <- annotatedDecoder fromCBOR
-    pure (UnsafeAPayload p a)
+instance FromCBORAnnotated Payload where
+  fromCBORAnnotated' = withSlice' $ UnsafePayload <$> fromCBORAnnotated'

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Interface.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Interface.hs
@@ -33,7 +33,7 @@ import Cardano.Binary
   )
 import Cardano.Chain.Common (BlockCount(..), KeyHash, hashKey)
 import qualified Cardano.Chain.Delegation as Delegation
-import Cardano.Chain.Delegation.Certificate (ACertificate, Certificate)
+import Cardano.Chain.Delegation.Certificate (Certificate)
 import qualified Cardano.Chain.Delegation.Validation.Activation as Activation
 import qualified Cardano.Chain.Delegation.Validation.Scheduling as Scheduling
 import Cardano.Chain.Genesis (GenesisDelegation(..))
@@ -109,15 +109,7 @@ initialState env genesisDelegation = updateDelegation env' is certificates
       }
     }
 
-  certificates =
-    fmap annotateCertificate . M.elems $ unGenesisDelegation genesisDelegation
-
-  annotateCertificate :: Certificate -> ACertificate ByteString
-  annotateCertificate c = c
-    { Delegation.aEpoch = Annotated
-      (Delegation.epoch c)
-      (serialize' $ Delegation.epoch c)
-    }
+  certificates = M.elems $ unGenesisDelegation genesisDelegation
 
 
 -- | Check whether a delegation is valid in the 'State'

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Interface.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Interface.hs
@@ -126,7 +126,7 @@ updateDelegation
   :: MonadError Scheduling.Error m
   => Environment
   -> State
-  -> [ACertificate ByteString]
+  -> [Certificate]
   -> m State
 updateDelegation env is certificates = do
   -- Schedule new certificates

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Interface.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Interface.hs
@@ -29,7 +29,6 @@ import Cardano.Binary
   , ToCBOR(..)
   , encodeListLen
   , enforceSize
-  , serialize'
   )
 import Cardano.Chain.Common (BlockCount(..), KeyHash, hashKey)
 import qualified Cardano.Chain.Delegation as Delegation

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Scheduling.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Scheduling.hs
@@ -29,7 +29,7 @@ import Cardano.Binary
   , enforceSize
   )
 import Cardano.Chain.Common (BlockCount, KeyHash, hashKey)
-import Cardano.Chain.Delegation.Certificate (ACertificate)
+import Cardano.Chain.Delegation.Certificate (Certificate)
 import qualified Cardano.Chain.Delegation.Certificate as Certificate
 import Cardano.Chain.ProtocolConstants (kSlotSecurityParam)
 import Cardano.Chain.Slotting
@@ -118,7 +118,7 @@ scheduleCertificate
   :: MonadError Error m
   => Environment
   -> State
-  -> ACertificate ByteString
+  -> Certificate
   -> m State
 scheduleCertificate env st cert = do
   -- Check that the delegator is a genesis key

--- a/cardano-ledger/src/Cardano/Chain/Epoch/File.hs
+++ b/cardano-ledger/src/Cardano/Chain/Epoch/File.hs
@@ -28,9 +28,9 @@ import qualified Streaming.Prelude as S
 import System.Directory (doesFileExist)
 import System.FilePath ((-<.>))
 
-import Cardano.Binary (DecoderError, decodeFullDecoder, slice)
+import Cardano.Binary (DecoderError, decodeAnnotatedDecoder)
 import Cardano.Chain.Block.Block
-  (ABlockOrBoundary(..), fromCBORABlockOrBoundary)
+  (BlockOrBoundary(..), fromCBORBlockOrBoundary)
 import Cardano.Chain.Slotting (EpochSlots(..))
 
 
@@ -78,7 +78,7 @@ parseEpochFileWithBoundary
   :: EpochSlots
   -> FilePath
   -> Stream
-       (Of (ABlockOrBoundary ByteString))
+       (Of BlockOrBoundary)
        (ExceptT ParseError ResIO)
        ()
 parseEpochFileWithBoundary epochSlots file = do
@@ -101,10 +101,7 @@ parseEpochFileWithBoundary epochSlots file = do
 
   liftBinaryError
     :: (a, B.ByteOffset, Either String ())
-    -> Stream
-         (Of (ABlockOrBoundary ByteString))
-         (ExceptT ParseError ResIO)
-         ()
+    -> Stream (Of BlockOrBoundary) (ExceptT ParseError ResIO) ()
   liftBinaryError = \case
     (_, _, Right ()) -> pure ()
     (_, offset, Left message) ->
@@ -113,17 +110,14 @@ parseEpochFileWithBoundary epochSlots file = do
 parseEpochFilesWithBoundary
   :: EpochSlots
   -> [FilePath]
-  -> Stream
-       (Of (ABlockOrBoundary ByteString))
-       (ExceptT ParseError ResIO)
-       ()
+  -> Stream (Of BlockOrBoundary) (ExceptT ParseError ResIO) ()
 parseEpochFilesWithBoundary epochSlots fs =
   foldr (<>) mempty (parseEpochFileWithBoundary epochSlots <$> fs)
 
 slotDataHeader :: LBS.ByteString
 slotDataHeader = "blnd"
 
-getSlotData :: EpochSlots -> B.Get (Either DecoderError (ABlockOrBoundary ByteString))
+getSlotData :: EpochSlots -> B.Get (Either DecoderError BlockOrBoundary)
 getSlotData epochSlots = runExceptT $ do
   header <- lift $ B.getLazyByteString (LBS.length slotDataHeader)
   lift $ guard (header == slotDataHeader)
@@ -131,11 +125,10 @@ getSlotData epochSlots = runExceptT $ do
   undoSize  <- lift getWord32be
   block     <- do
     blockBytes <- lift $ B.getLazyByteString (fromIntegral blockSize)
-    bb         <- ExceptT . pure $ decodeFullDecoder
-      "ABlockOrBoundary"
-      (fromCBORABlockOrBoundary epochSlots)
+    ExceptT . pure $ decodeAnnotatedDecoder
+      "BlockOrBoundary"
+      (fromCBORBlockOrBoundary epochSlots)
       blockBytes
-    pure $ map (LBS.toStrict . slice blockBytes) bb
   -- Drop the Undo bytes as we no longer use these
   void . lift $ B.getLazyByteString (fromIntegral undoSize)
   pure block

--- a/cardano-ledger/src/Cardano/Chain/Epoch/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Epoch/Validation.hs
@@ -18,7 +18,7 @@ import Streaming (Of(..), Stream, hoist)
 import qualified Streaming.Prelude as S
 
 import Cardano.Chain.Block
-  ( ABlockOrBoundary(..)
+  ( BlockOrBoundary(..)
   , ChainValidationError
   , ChainValidationState(..)
   , blockSlot
@@ -84,7 +84,7 @@ validateEpochFiles vMode config cvs fps =
 foldChainValidationState
   :: Genesis.Config
   -> ChainValidationState
-  -> Stream (Of (ABlockOrBoundary ByteString)) (ExceptT ParseError ResIO) ()
+  -> Stream (Of BlockOrBoundary) (ExceptT ParseError ResIO) ()
   -> ExceptT EpochError (ReaderT ValidationMode ResIO) ChainValidationState
 foldChainValidationState config chainValState blocks = S.foldM_
   (\cvs block ->
@@ -94,7 +94,7 @@ foldChainValidationState config chainValState blocks = S.foldM_
   (pure chainValState)
   pure (pure (hoist (withExceptT EpochParseError) blocks))
  where
-  blockOrBoundarySlot :: ABlockOrBoundary a -> Maybe EpochAndSlotCount
+  blockOrBoundarySlot :: BlockOrBoundary -> Maybe EpochAndSlotCount
   blockOrBoundarySlot = \case
-    ABOBBoundary _     -> Nothing
-    ABOBBlock    block -> Just . fromSlotNumber mainnetEpochSlots $ blockSlot block
+    BOBBoundary _     -> Nothing
+    BOBBlock    block -> Just . fromSlotNumber mainnetEpochSlots $ blockSlot block

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Data.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Data.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE PatternSynonyms  #-}
 
 module Cardano.Chain.Genesis.Data
   ( GenesisData(..)
@@ -43,7 +44,8 @@ import Cardano.Chain.Genesis.NonAvvmBalances (GenesisNonAvvmBalances)
 import Cardano.Chain.Genesis.KeyHashes (GenesisKeyHashes)
 import Cardano.Chain.Update.ProtocolParameters (ProtocolParameters)
 import Cardano.Crypto
-  ( ProtocolMagicId(..)
+  ( ProtocolMagicId (..)
+  , pattern ProtocolMagicId
   , hashRaw
   )
 

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Delegation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Delegation.hs
@@ -25,8 +25,7 @@ import Text.JSON.Canonical (FromJSON(..), ReportSchemaErrors(..), ToJSON(..))
 
 import Cardano.Chain.Common (KeyHash, hashKey)
 import Cardano.Chain.Delegation.Certificate
-  ( ACertificate(delegateVK, issuerVK)
-  , Certificate
+  ( Certificate(delegateVK, issuerVK)
   )
 
 

--- a/cardano-ledger/src/Cardano/Chain/MempoolPayload.hs
+++ b/cardano-ledger/src/Cardano/Chain/MempoolPayload.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.Chain.MempoolPayload
-  ( MempoolPayload
-  , AMempoolPayload (..)
+  ( MempoolPayload (..)
   )
 where
 
@@ -18,6 +17,8 @@ import Cardano.Binary
   , decodeWord8
   , encodeListLen
   , enforceSize
+  , decodeListLen
+  , matchSize
   )
 import qualified Cardano.Chain.Delegation.Payload as Delegation
 import Cardano.Chain.UTxO.TxPayload (TxPayload)
@@ -25,16 +26,12 @@ import qualified Cardano.Chain.Update.Payload as Update
 
 -- | A payload which can be submitted into or between mempools via the
 -- transaction submission protocol.
-type MempoolPayload = AMempoolPayload ()
-
--- | A payload which can be submitted into or between mempools via the
--- transaction submission protocol.
-data AMempoolPayload a
+data MempoolPayload
   = MempoolTxPayload !TxPayload
   -- ^ A transaction payload.
   | MempoolDlgPayload !Delegation.Payload
   -- ^ A delegation payload.
-  | MempoolUpdatePayload !(Update.APayload a)
+  | MempoolUpdatePayload !Update.Payload
   -- ^ An update payload.
   deriving (Eq, Show)
 
@@ -53,5 +50,5 @@ instance FromCBORAnnotated MempoolPayload where
     lift decodeWord8 >>= \case
       0   -> MempoolTxPayload <$> fromCBORAnnotated'
       1   -> MempoolDlgPayload <$> fromCBORAnnotated'
-      2   -> MempoolUpdatePayload <$> lift fromCBOR
+      2   -> MempoolUpdatePayload <$> fromCBORAnnotated'
       tag -> lift $ cborError $ DecoderErrorUnknownTag "MempoolPayload" tag

--- a/cardano-ledger/src/Cardano/Chain/MempoolPayload.hs
+++ b/cardano-ledger/src/Cardano/Chain/MempoolPayload.hs
@@ -11,12 +11,10 @@ import Cardano.Prelude
 
 import Cardano.Binary
   ( DecoderError(..)
-  , FromCBOR(..)
   , FromCBORAnnotated(..)
   , ToCBOR(..)
   , decodeWord8
   , encodeListLen
-  , enforceSize
   , decodeListLen
   , matchSize
   )

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxPayload.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxPayload.hs
@@ -56,7 +56,7 @@ txpAnnotatedTxs = fmap aTaTx . aUnTxPayload
 txpTxs :: ATxPayload a -> [Tx]
 txpTxs = fmap taTx . unTxPayload
 
-txpWitnesses :: TxPayload -> [TxWitness]
+txpWitnesses :: ATxPayload a -> [TxWitness]
 txpWitnesses = fmap taWitness . unTxPayload
 
 recoverHashedBytes :: ATxPayload ByteString -> Annotated [TxWitness] ByteString

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxPayload.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxPayload.hs
@@ -1,73 +1,53 @@
 {-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveFunctor      #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE TypeApplications   #-}
 
 module Cardano.Chain.UTxO.TxPayload
-  ( TxPayload
-  , ATxPayload(..)
-  , mkTxPayload
+  ( TxPayload(..)
   , recoverHashedBytes
-  , txpAnnotatedTxs
   , txpTxs
   , txpWitnesses
-  , unTxPayload
   )
 where
 
 import Cardano.Prelude
 
-import Cardano.Binary (Annotated(..), ByteSpan, FromCBOR(..), ToCBOR(..))
+import Cardano.Binary (Annotated(..), FromCBORAnnotated(..), ToCBOR(..))
 import Cardano.Chain.UTxO.Tx (Tx)
-import Cardano.Chain.UTxO.TxAux (ATxAux(..), TxAux, taTx, taWitness)
-import Cardano.Chain.UTxO.TxWitness (TxWitness)
+import Cardano.Chain.UTxO.TxAux (TxAux(..))
+import Cardano.Chain.UTxO.TxWitness (TxWitness(..))
 
 
 -- | Payload of UTxO component which is part of the block body
-type TxPayload = ATxPayload ()
-
-mkTxPayload :: [TxAux] -> TxPayload
-mkTxPayload = ATxPayload
-
-newtype ATxPayload a = ATxPayload
-  { aUnTxPayload :: [ATxAux a]
-  } deriving (Show, Eq, Generic, Functor)
+newtype TxPayload = TxPayload
+  { unTxPayload :: [TxAux]
+  } deriving (Show, Eq, Generic)
     deriving anyclass NFData
-
-unTxPayload :: ATxPayload a -> [TxAux]
-unTxPayload = fmap void . aUnTxPayload
 
 instance ToCBOR TxPayload where
   toCBOR = toCBOR . unTxPayload
 
-instance FromCBOR TxPayload where
-  fromCBOR = void <$> fromCBOR @(ATxPayload ByteSpan)
+instance FromCBORAnnotated TxPayload where
+  fromCBORAnnotated' = TxPayload <$> fromCBORAnnotated'
 
-instance FromCBOR (ATxPayload ByteSpan) where
-  fromCBOR = ATxPayload <$> fromCBOR
-
-txpAnnotatedTxs :: ATxPayload a -> [Annotated Tx a]
-txpAnnotatedTxs = fmap aTaTx . aUnTxPayload
-
-txpTxs :: ATxPayload a -> [Tx]
+txpTxs :: TxPayload -> [Tx]
 txpTxs = fmap taTx . unTxPayload
 
-txpWitnesses :: ATxPayload a -> [TxWitness]
+txpWitnesses :: TxPayload -> [TxWitness]
 txpWitnesses = fmap taWitness . unTxPayload
 
-recoverHashedBytes :: ATxPayload ByteString -> Annotated [TxWitness] ByteString
-recoverHashedBytes (ATxPayload auxs) =
+recoverHashedBytes :: TxPayload -> Annotated [TxWitness] ByteString
+recoverHashedBytes (TxPayload auxs) =
   let
-    aWitnesses  = aTaWitness <$> auxs
+    witnesses  = taWitness <$> auxs
     prefix      = "\159" :: ByteString
     -- This is the value of Codec.CBOR.Write.toLazyByteString encodeListLenIndef
     suffix      = "\255" :: ByteString
     -- This is the value of Codec.CBOR.Write.toLazyByteString encodeBreak
     -- They are hard coded here because the hashed bytes included them as an
     -- implementation artifact
-    hashedByted = prefix <> mconcat (annotation <$> aWitnesses) <> suffix
-  in Annotated (unAnnotated <$> aWitnesses) hashedByted
+    hashedByted = prefix <> mconcat (txWitnessSerialized <$> witnesses) <> suffix
+  in Annotated witnesses hashedByted

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
@@ -4,11 +4,10 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
 
 module Cardano.Chain.UTxO.TxWitness
-  ( TxWitness
+  ( TxWitness(..)
   , TxInWitness(..)
   , TxSigData(..)
   , TxSig
@@ -27,12 +26,15 @@ import Cardano.Binary
   , Case(..)
   , DecoderError(DecoderErrorUnknownTag)
   , FromCBOR(..)
+  , FromCBORAnnotated(..)
   , ToCBOR(..)
   , decodeListLen
   , encodeListLen
+  , encodePreEncoded
   , matchSize
   , serialize'
   , szCases
+  , withSlice'
   )
 import Cardano.Chain.Common.CBOR
   (encodeKnownCborDataItem, knownCborDataItemSizeExpr, decodeKnownCborDataItem)
@@ -44,7 +46,7 @@ import Cardano.Crypto
   , RedeemVerificationKey
   , RedeemSignature
   , Signature
-  , hashDecoded
+  , hash
   , shortHashF
   )
 
@@ -52,7 +54,18 @@ import Cardano.Crypto
 -- | A witness is a proof that a transaction is allowed to spend the funds it
 --   spends (by providing signatures, redeeming scripts, etc). A separate proof
 --   is provided for each input.
-type TxWitness = Vector TxInWitness
+data TxWitness = TxWitness
+  { txInWitnesses :: Vector TxInWitness
+  , txWitnessSerialized :: ByteString
+  } deriving (Eq, Show, Generic)
+    deriving anyclass NFData
+
+instance ToCBOR TxWitness where
+  toCBOR = encodePreEncoded . txWitnessSerialized
+
+instance FromCBORAnnotated TxWitness where
+  fromCBORAnnotated' = withSlice' . lift $
+    TxWitness <$> fromCBOR
 
 -- | A witness for a single input
 data TxInWitness
@@ -116,10 +129,10 @@ newtype TxSigData = TxSigData
   { txSigTxHash :: Hash Tx
   } deriving (Eq, Show, Generic)
 
-recoverSigData :: Annotated Tx ByteString -> Annotated TxSigData ByteString
-recoverSigData atx =
+recoverSigData :: Tx -> Annotated TxSigData ByteString
+recoverSigData tx =
   let
-    txHash      = hashDecoded atx
+    txHash      = hash tx
     signedBytes = serialize' txHash --TODO: make the prefix bytes explicit
   in Annotated (TxSigData txHash) signedBytes
 
@@ -132,4 +145,3 @@ instance FromCBOR TxSigData where
 
 -- | 'Signature' of addrId
 type TxSig = Signature TxSigData
-

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
@@ -5,9 +5,11 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE PatternSynonyms     #-}
 
 module Cardano.Chain.UTxO.TxWitness
   ( TxWitness(..)
+  , pattern TxWitness
   , TxInWitness(..)
   , TxSigData(..)
   , TxSig
@@ -15,7 +17,7 @@ module Cardano.Chain.UTxO.TxWitness
   )
 where
 
-import Cardano.Prelude
+import Cardano.Prelude as P
 
 import Data.Vector (Vector)
 import Formatting (bprint, build)
@@ -35,6 +37,7 @@ import Cardano.Binary
   , serialize'
   , szCases
   , withSlice'
+  , serializeEncoding'
   )
 import Cardano.Chain.Common.CBOR
   (encodeKnownCborDataItem, knownCborDataItemSizeExpr, decodeKnownCborDataItem)
@@ -54,8 +57,8 @@ import Cardano.Crypto
 -- | A witness is a proof that a transaction is allowed to spend the funds it
 --   spends (by providing signatures, redeeming scripts, etc). A separate proof
 --   is provided for each input.
-data TxWitness = TxWitness
-  { txInWitnesses :: Vector TxInWitness
+data TxWitness = TxWitness'
+  { txInWitnesses :: !(Vector TxInWitness)
   , txWitnessSerialized :: ByteString
   } deriving (Eq, Show, Generic)
     deriving anyclass NFData
@@ -63,9 +66,14 @@ data TxWitness = TxWitness
 instance ToCBOR TxWitness where
   toCBOR = encodePreEncoded . txWitnessSerialized
 
+pattern TxWitness :: Vector TxInWitness -> TxWitness
+pattern TxWitness wits <- TxWitness' wits _
+  where
+  TxWitness wits = TxWitness' wits (serializeEncoding' $ toCBOR wits)
+
 instance FromCBORAnnotated TxWitness where
   fromCBORAnnotated' = withSlice' . lift $
-    TxWitness <$> fromCBOR
+    TxWitness' <$> fromCBOR
 
 -- | A witness for a single input
 data TxInWitness

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
@@ -66,6 +66,8 @@ data TxWitness = TxWitness'
 instance ToCBOR TxWitness where
   toCBOR = encodePreEncoded . txWitnessSerialized
 
+  encodedSizeExpr size _ = encodedSizeExpr size (Proxy :: Proxy (Vector TxInWitness))
+
 pattern TxWitness :: Vector TxInWitness -> TxWitness
 pattern TxWitness wits <- TxWitness' wits _
   where

--- a/cardano-ledger/src/Cardano/Chain/Update/Payload.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Payload.hs
@@ -20,13 +20,9 @@ import Formatting (bprint)
 import qualified Formatting.Buildable as B
 
 import Cardano.Binary
-  ( Annotated(..)
-  , ByteSpan
-  , Decoded(..)
-  , FromCBOR(..)
+  ( Decoded(..)
   , FromCBORAnnotated(..)
   , ToCBOR(..)
-  , annotatedDecoder
   , encodeListLen
   , encodePreEncoded
   , enforceSize

--- a/cardano-ledger/src/Cardano/Chain/Update/Proof.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Proof.hs
@@ -5,7 +5,7 @@ module Cardano.Chain.Update.Proof
   )
 where
 
-import Cardano.Chain.Update.Payload (APayload(..), Payload)
+import Cardano.Chain.Update.Payload (Payload(..))
 import Cardano.Crypto (Hash, hash, hashDecoded)
 import Cardano.Prelude
 
@@ -16,5 +16,5 @@ type Proof = Hash Payload
 mkProof :: Payload -> Proof
 mkProof = hash
 
-recoverProof :: APayload ByteString -> Proof
+recoverProof :: Payload -> Proof
 recoverProof = hashDecoded

--- a/cardano-ledger/src/Cardano/Chain/Update/Proof.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Proof.hs
@@ -6,8 +6,7 @@ module Cardano.Chain.Update.Proof
 where
 
 import Cardano.Chain.Update.Payload (Payload(..))
-import Cardano.Crypto (Hash, hash, hashDecoded)
-import Cardano.Prelude
+import Cardano.Crypto (Hash, hash)
 
 
 -- | Proof that body of update message contains 'Update.Payload'
@@ -17,4 +16,4 @@ mkProof :: Payload -> Proof
 mkProof = hash
 
 recoverProof :: Payload -> Proof
-recoverProof = hashDecoded
+recoverProof = hash

--- a/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
@@ -1,37 +1,30 @@
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveFunctor         #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE PatternSynonyms       #-}
 {-# LANGUAGE TypeFamilies          #-}
 
 module Cardano.Chain.Update.Proposal
   (
   -- * Proposal
-    AProposal(..)
-  , Proposal
+    Proposal(..)
+  , pattern Proposal
   , UpId
 
   -- * Proposal Constructors
-  , unsafeProposal
   , signProposal
   , signatureForProposal
-
-  -- * Proposal Accessors
-  , body
-  , recoverUpId
 
   -- * Proposal Formatting
   , formatMaybeProposal
 
   -- * ProposalBody
   , ProposalBody(..)
-
-  -- * ProposalBody Binary Serialization
-  , recoverProposalSignedBytes
+  , pattern ProposalBody
   )
 where
 
@@ -43,14 +36,16 @@ import Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
 import Cardano.Binary
-  ( Annotated(..)
-  , ByteSpan
-  , Decoded(..)
+  ( Decoded(..)
+  , Decoder
   , FromCBOR(..)
+  , FromCBORAnnotated(..)
   , ToCBOR(..)
-  , annotatedDecoder
   , encodeListLen
+  , encodePreEncoded
   , enforceSize
+  , serializeEncoding'
+  , withSlice'
   )
 import Cardano.Chain.Common.Attributes (dropEmptyAttributes)
 import Cardano.Chain.Update.InstallerHash (InstallerHash)
@@ -66,7 +61,6 @@ import Cardano.Crypto
   , SignTag(SignUSProposal)
   , Signature
   , hash
-  , hashDecoded
   , safeSign
   , safeToVerification
   )
@@ -79,32 +73,48 @@ import Cardano.Crypto
 -- | ID of software update proposal
 type UpId = Hash Proposal
 
--- | Proposal for software update
-data AProposal a = AProposal
-  { aBody      :: !(Annotated ProposalBody a)
-  , issuer     :: !VerificationKey
-  -- ^ Who proposed this UP.
-  , signature  :: !(Signature ProposalBody)
-  , annotation :: !a
-  } deriving (Eq, Show, Generic, Functor)
-    deriving anyclass NFData
+-- | Create an update 'Proposal' using the provided signature.
+pattern Proposal
+  :: ProposalBody
+  -> VerificationKey
+  -> Signature ProposalBody
+  -> Proposal
+pattern Proposal body issuer signature <- Proposal' {body, issuer, signature}
+  where
+    Proposal body issuer signature =
+      let bytes = serializeEncoding' $
+            encodeListLen 7
+              <> toCBOR (protocolVersion body)
+              <> toCBOR (protocolParametersUpdate body)
+              <> toCBOR (softwareVersion body)
+              <> toCBOR (metadata body)
+              <> toCBOR (mempty :: Map Word8 LByteString)
+              <> toCBOR issuer
+              <> toCBOR signature
+      in Proposal' body issuer signature bytes
 
-type Proposal = AProposal ()
+-- | Proposal for software update
+data Proposal = Proposal'
+  { body               :: !ProposalBody
+  , issuer             :: !VerificationKey
+  -- ^ Who proposed this UP.
+  , signature          :: !(Signature ProposalBody)
+  , proposalSerialized :: ByteString
+  } deriving (Eq, Show, Generic)
+    deriving anyclass NFData
 
 
 --------------------------------------------------------------------------------
 -- Proposal Constructors
 --------------------------------------------------------------------------------
 
-
 -- | Create an update 'Proposal', signing it with the provided safe signer.
 signProposal :: ProtocolMagicId -> ProposalBody -> SafeSigner -> Proposal
 signProposal protocolMagicId proposalBody safeSigner =
-  unsafeProposal
+  Proposal
     proposalBody
     (safeToVerification safeSigner)
     (signatureForProposal protocolMagicId proposalBody safeSigner)
-
 
 signatureForProposal
   :: ProtocolMagicId
@@ -115,68 +125,41 @@ signatureForProposal protocolMagicId proposalBody safeSigner =
   safeSign protocolMagicId SignUSProposal safeSigner proposalBody
 
 
--- | Create an update 'Proposal' using the provided signature.
-unsafeProposal :: ProposalBody -> VerificationKey -> Signature ProposalBody -> Proposal
-unsafeProposal b k s = AProposal (Annotated b ()) k s ()
-
-
---------------------------------------------------------------------------------
--- Proposal Accessors
---------------------------------------------------------------------------------
-
-body :: AProposal a -> ProposalBody
-body = unAnnotated . aBody
-
-recoverUpId :: AProposal ByteString -> UpId
-recoverUpId = hashDecoded
-
-
 --------------------------------------------------------------------------------
 -- Proposal Binary Serialization
 --------------------------------------------------------------------------------
 
 instance ToCBOR Proposal where
-  toCBOR proposal =
-    encodeListLen 7
-      <> toCBOR (protocolVersion body')
-      <> toCBOR (protocolParametersUpdate body')
-      <> toCBOR (softwareVersion body')
-      <> toCBOR (metadata body')
-      <> toCBOR (mempty :: Map Word8 LByteString)
-      <> toCBOR (issuer proposal)
-      <> toCBOR (signature proposal)
-    where body' = body proposal
+  toCBOR = encodePreEncoded . proposalSerialized
 
-instance FromCBOR Proposal where
-  fromCBOR = void <$> fromCBOR @(AProposal ByteSpan)
-
-instance FromCBOR (AProposal ByteSpan) where
-  fromCBOR = do
-    Annotated (pb, vk, sig) byteSpan <- annotatedDecoder $ do
-      enforceSize "Proposal" 7
-      pb <- annotatedDecoder
-        (   ProposalBody
+instance FromCBORAnnotated Proposal where
+  fromCBORAnnotated' = withSlice' $
+    Proposal' <$ lift (enforceSize "Proposal" 7)
+      <*> withSlice' (lift fromCBORProposalBody)
+      <*> lift fromCBOR
+      <*> lift fromCBOR
+   where
+    -- Prepend byte corresponding to `encodeListLen 5`, which was used during
+    -- signing
+    fromCBORProposalBody :: Decoder s (ByteString -> ProposalBody)
+    fromCBORProposalBody = fmap (. ("\133" <>)) $
+      ProposalBody'
         <$> fromCBOR
         <*> fromCBOR
         <*> fromCBOR
         <*> fromCBOR
         <*  dropEmptyAttributes
-        )
-      vk  <- fromCBOR
-      sig <- fromCBOR
-      pure (pb, vk, sig)
-    pure $ AProposal pb vk sig byteSpan
 
-instance Decoded (AProposal ByteString) where
-  type BaseType (AProposal ByteString) = Proposal
-  recoverBytes = annotation
+instance Decoded Proposal where
+  type BaseType Proposal = Proposal
+  recoverBytes = proposalSerialized
 
 
 --------------------------------------------------------------------------------
 -- Proposal Formatting
 --------------------------------------------------------------------------------
 
-instance B.Buildable (AProposal ()) where
+instance B.Buildable Proposal where
   build proposal = bprint
     ( build
     . " { block v"
@@ -205,12 +188,33 @@ formatMaybeProposal = maybe "no proposal" B.build
 -- ProposalBody
 --------------------------------------------------------------------------------
 
-data ProposalBody = ProposalBody
+pattern ProposalBody
+  :: ProtocolVersion
+  -> ProtocolParametersUpdate
+  -> SoftwareVersion
+  -> Map SystemTag InstallerHash
+  -> ProposalBody
+pattern ProposalBody protocolVersion protocolParametersUpdate softwareVersion metadata <-
+  ProposalBody' {protocolVersion, protocolParametersUpdate, softwareVersion, metadata}
+  where
+    ProposalBody protocolVersion protocolParametersUpdate softwareVersion metadata =
+      let bytes = serializeEncoding' $
+            encodeListLen 5
+              <> toCBOR protocolVersion
+              <> toCBOR protocolParametersUpdate
+              <> toCBOR softwareVersion
+              <> toCBOR metadata
+              -- Encode empty Attributes
+              <> toCBOR (mempty :: Map Word8 LByteString)
+      in ProposalBody' protocolVersion protocolParametersUpdate softwareVersion metadata bytes
+
+data ProposalBody = ProposalBody'
   { protocolVersion          :: !ProtocolVersion
   , protocolParametersUpdate :: !ProtocolParametersUpdate
   , softwareVersion          :: !SoftwareVersion
   , metadata                 :: !(Map SystemTag InstallerHash)
   -- ^ InstallerHash for each system which this update affects
+  , proposalBodySerialized   :: ByteString
   } deriving (Eq, Show, Generic)
     deriving anyclass NFData
 
@@ -220,27 +224,18 @@ data ProposalBody = ProposalBody
 --------------------------------------------------------------------------------
 
 instance ToCBOR ProposalBody where
-  toCBOR pb =
-    encodeListLen 5
-      <> toCBOR (protocolVersion pb)
-      <> toCBOR (protocolParametersUpdate pb)
-      <> toCBOR (softwareVersion pb)
-      <> toCBOR (metadata pb)
-      -- Encode empty Attributes
-      <> toCBOR (mempty :: Map Word8 LByteString)
+  toCBOR = encodePreEncoded . proposalBodySerialized
 
-instance FromCBOR ProposalBody where
-  fromCBOR = do
+instance FromCBORAnnotated ProposalBody where
+  fromCBORAnnotated' = withSlice' . lift $ do
     enforceSize "ProposalBody" 5
-    ProposalBody
+    ProposalBody'
       <$> fromCBOR
       <*> fromCBOR
       <*> fromCBOR
       <*> fromCBOR
       <*  dropEmptyAttributes
 
--- | Prepend byte corresponding to `encodeListLen 5`, which was used during
---   signing
-recoverProposalSignedBytes
-  :: Annotated ProposalBody ByteString -> Annotated ProposalBody ByteString
-recoverProposalSignedBytes = fmap ("\133" <>)
+instance Decoded ProposalBody where
+  type BaseType ProposalBody = ProposalBody
+  recoverBytes = proposalBodySerialized

--- a/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
@@ -12,7 +12,7 @@ module Cardano.Chain.Update.Proposal
   (
   -- * Proposal
     Proposal(..)
-  , pattern Proposal
+  , pattern UnsafeProposal
   , UpId
 
   -- * Proposal Constructors
@@ -74,14 +74,14 @@ import Cardano.Crypto
 type UpId = Hash Proposal
 
 -- | Create an update 'Proposal' using the provided signature.
-pattern Proposal
+pattern UnsafeProposal
   :: ProposalBody
   -> VerificationKey
   -> Signature ProposalBody
   -> Proposal
-pattern Proposal body issuer signature <- Proposal' {body, issuer, signature}
+pattern UnsafeProposal body issuer signature <- Proposal' {body, issuer, signature}
   where
-    Proposal body issuer signature =
+    UnsafeProposal body issuer signature =
       let bytes = serializeEncoding' $
             encodeListLen 7
               <> toCBOR (protocolVersion body)
@@ -111,7 +111,7 @@ data Proposal = Proposal'
 -- | Create an update 'Proposal', signing it with the provided safe signer.
 signProposal :: ProtocolMagicId -> ProposalBody -> SafeSigner -> Proposal
 signProposal protocolMagicId proposalBody safeSigner =
-  Proposal
+  UnsafeProposal
     proposalBody
     (safeToVerification safeSigner)
     (signatureForProposal protocolMagicId proposalBody safeSigner)

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Voting.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Voting.hs
@@ -28,7 +28,7 @@ import qualified Cardano.Chain.Delegation as Delegation
 import Cardano.Chain.Slotting (SlotNumber)
 import Cardano.Chain.Update.Proposal (UpId)
 import Cardano.Chain.Update.Vote
-  ( AVote(..)
+  ( Vote(..)
   , recoverSignedBytes
   , proposalId
   )
@@ -77,7 +77,7 @@ registerVoteWithConfirmation
   => Annotated ProtocolMagicId ByteString
   -> Environment
   -> State
-  -> AVote ByteString
+  -> Vote
   -> m State
 registerVoteWithConfirmation pm votingEnv vs vote = do
 
@@ -122,7 +122,7 @@ registerVote
   => Annotated ProtocolMagicId ByteString
   -> RegistrationEnvironment
   -> RegisteredVotes
-  -> AVote ByteString
+  -> Vote
   -> m RegisteredVotes
 registerVote pm vre votes vote = do
   -- Check that the proposal being voted on is registered

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -25,7 +25,7 @@ import Data.Maybe (fromJust)
 import Hedgehog (Property)
 import qualified Hedgehog as H
 
-import Cardano.Binary (decodeFullDecoder, dropBytes, serializeEncoding)
+import Cardano.Binary (decodeFullDecoder, dropBytes, serializeEncoding, decodeAnnotatedDecoder)
 import Cardano.Chain.Block
   ( ABlockSignature(..)
   , Block
@@ -41,11 +41,11 @@ import Cardano.Chain.Block
   , fromCBORABoundaryBlock
   , fromCBORBoundaryConsensusData
   , fromCBORABoundaryHeader
-  , fromCBORABOBBlock
+  , fromCBORBOBBlock
   , fromCBORHeader
   , fromCBORHeaderToHash
   , mkHeaderExplicit
-  , toCBORABOBBlock
+  , toCBORBOBBlock
   , toCBORABoundaryBlock
   , toCBORHeader
   , toCBORHeaderToHash
@@ -133,9 +133,9 @@ ts_roundTripBlockCompat = eachOfTS
   roundTripsBlockCompat :: WithEpochSlots Block -> H.PropertyT IO ()
   roundTripsBlockCompat esb@(WithEpochSlots es _) = trippingBuildable
     esb
-    (serializeEncoding . toCBORABOBBlock es . unWithEpochSlots)
+    (serializeEncoding . toCBORBOBBlock es . unWithEpochSlots)
     ( fmap (WithEpochSlots es . fromJust)
-    . decodeFullDecoder "Block" (fromCBORABOBBlock es)
+    . decodeAnnotatedDecoder "Block" (fromCBORBOBBlock es)
     )
 
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 
-{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns -fno-warn-orphans #-}
 
 module Test.Cardano.Chain.Block.CBOR
   ( tests
@@ -72,6 +72,7 @@ import Test.Cardano.Binary.Helpers.GoldenRoundTrip
   ( deprecatedGoldenDecode
   , goldenTestCBOR
   , goldenTestCBORExplicit
+  , roundTripsCBORAnnotatedShow
   , roundTripsCBORBuildable
   , roundTripsCBORShow
   )
@@ -133,7 +134,7 @@ ts_roundTripBlockCompat = eachOfTS
   roundTripsBlockCompat :: WithEpochSlots Block -> H.PropertyT IO ()
   roundTripsBlockCompat esb@(WithEpochSlots es _) = trippingBuildable
     esb
-    (serializeEncoding . toCBORBOBBlock es . unWithEpochSlots)
+    (serializeEncoding . toCBORBOBBlock . unWithEpochSlots)
     ( fmap (WithEpochSlots es . fromJust)
     . decodeAnnotatedDecoder "Block" (fromCBORBOBBlock es)
     )
@@ -232,11 +233,11 @@ goldenDeprecatedBoundaryProof = deprecatedGoldenDecode
 -- Body
 --------------------------------------------------------------------------------
 
-goldenBody :: Property
-goldenBody = goldenTestCBOR exampleBody "test/golden/cbor/block/Body"
+--goldenBody :: Property
+--goldenBody = goldenTestCBOR exampleBody "test/golden/cbor/block/Body"
 
 ts_roundTripBodyCBOR :: TSProperty
-ts_roundTripBodyCBOR = eachOfTS 20 (feedPM genBody) roundTripsCBORShow
+ts_roundTripBodyCBOR = eachOfTS 20 (feedPM genBody) roundTripsCBORAnnotatedShow
 
 
 --------------------------------------------------------------------------------

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -25,7 +25,7 @@ import Data.Maybe (fromJust)
 import Hedgehog (Property)
 import qualified Hedgehog as H
 
-import Cardano.Binary (decodeFullDecoder, dropBytes, serializeEncoding, decodeAnnotatedDecoder, goldenTestExplicit)
+import Cardano.Binary (decodeFullDecoder, dropBytes, serializeEncoding, decodeAnnotatedDecoder, toCBOR)
 import Cardano.Chain.Block
   ( BlockSignature(..)
   , Block
@@ -42,6 +42,7 @@ import Cardano.Chain.Block
   , fromCBORBoundaryConsensusData
   , fromCBORABoundaryHeader
   , fromCBORBOBBlock
+  , fromCBORHeader
   , fromCBORHeaderToHash
   , mkHeaderExplicit
   , toCBORBOBBlock
@@ -69,6 +70,8 @@ import Cardano.Crypto
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
   ( deprecatedGoldenDecode
   , goldenTestCBOR
+  , goldenTestCBORAnnotated
+  , goldenTestExplicit
   , roundTripsCBORAnnotatedShow
   , roundTripsCBORAnnotatedBuildable
   , roundTripsCBORBuildable
@@ -97,9 +100,8 @@ exampleEs = EpochSlots 50
 
 goldenHeader :: Property
 goldenHeader = goldenTestExplicit
-  "Header"
-  (toCBORHeader exampleEs)
-  (fromCBORHeader exampleEs)
+  (serializeEncoding . toCBOR)
+  (decodeAnnotatedDecoder "header" $ fromCBORHeader exampleEs)
   exampleHeader
   "test/golden/cbor/block/Header"
 
@@ -141,11 +143,9 @@ ts_roundTripBlockCompat = eachOfTS
 --------------------------------------------------------------------------------
 -- BlockSignature
 --------------------------------------------------------------------------------
-{-- TODO!
 goldenBlockSignature :: Property
 goldenBlockSignature =
-  goldenTestCBOR exampleBlockSignature "test/golden/cbor/block/BlockSignature"
---}
+  goldenTestCBORAnnotated exampleBlockSignature "test/golden/cbor/block/BlockSignature"
 
 ts_roundTripBlockSignatureCBOR :: TSProperty
 ts_roundTripBlockSignatureCBOR =
@@ -232,8 +232,8 @@ goldenDeprecatedBoundaryProof = deprecatedGoldenDecode
 -- Body
 --------------------------------------------------------------------------------
 
---goldenBody :: Property
---goldenBody = goldenTestCBOR exampleBody "test/golden/cbor/block/Body"
+goldenBody :: Property
+goldenBody = goldenTestCBORAnnotated exampleBody "test/golden/cbor/block/Body"
 
 ts_roundTripBodyCBOR :: TSProperty
 ts_roundTripBodyCBOR = eachOfTS 20 (feedPM genBody) roundTripsCBORAnnotatedShow
@@ -243,10 +243,8 @@ ts_roundTripBodyCBOR = eachOfTS 20 (feedPM genBody) roundTripsCBORAnnotatedShow
 -- Proof
 --------------------------------------------------------------------------------
 
-{-- TODO!
 goldenProof :: Property
-goldenProof = goldenTestCBOR exampleProof "test/golden/cbor/block/Proof"
---}
+goldenProof = goldenTestCBORAnnotated exampleProof "test/golden/cbor/block/Proof"
 
 ts_roundTripProofCBOR :: TSProperty
 ts_roundTripProofCBOR = eachOfTS 20 (feedPM genProof) roundTripsCBORAnnotatedBuildable
@@ -270,10 +268,8 @@ ts_roundTripSigningHistoryCBOR =
 -- ToSign
 --------------------------------------------------------------------------------
 
-{-- TODO!
 goldenToSign :: Property
-goldenToSign = goldenTestCBOR exampleToSign "test/golden/cbor/block/ToSign"
---}
+goldenToSign = goldenTestCBORAnnotated exampleToSign "test/golden/cbor/block/ToSign"
 
 ts_roundTripToSignCBOR :: TSProperty
 ts_roundTripToSignCBOR =

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -27,9 +27,8 @@ import qualified Hedgehog as H
 
 import Cardano.Binary (decodeFullDecoder, dropBytes, serializeEncoding, decodeAnnotatedDecoder)
 import Cardano.Chain.Block
-  ( ABlockSignature(..)
+  ( BlockSignature(..)
   , Block
-  , BlockSignature
   , Body
   , ABoundaryBlock(boundaryBlockLength)
   , pattern Body
@@ -303,7 +302,7 @@ exampleHeader = mkHeaderExplicit
     (noPassSafeSigner issuerSk)
 
 exampleBlockSignature :: BlockSignature
-exampleBlockSignature = ABlockSignature cert sig
+exampleBlockSignature = BlockSignature cert sig
  where
   cert = Delegation.signCertificate
     pm

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -25,7 +25,7 @@ import Data.Maybe (fromJust)
 import Hedgehog (Property)
 import qualified Hedgehog as H
 
-import Cardano.Binary (decodeFullDecoder, dropBytes, serializeEncoding, decodeAnnotatedDecoder)
+import Cardano.Binary (decodeFullDecoder, dropBytes, serializeEncoding, decodeAnnotatedDecoder, goldenTestExplicit)
 import Cardano.Chain.Block
   ( BlockSignature(..)
   , Block
@@ -35,18 +35,17 @@ import Cardano.Chain.Block
   , Header
   , HeaderHash
   , Proof(..)
+  , pattern Proof
   , ToSign(..)
   , dropBoundaryBody
   , fromCBORABoundaryBlock
   , fromCBORBoundaryConsensusData
   , fromCBORABoundaryHeader
   , fromCBORBOBBlock
-  , fromCBORHeader
   , fromCBORHeaderToHash
   , mkHeaderExplicit
   , toCBORBOBBlock
   , toCBORABoundaryBlock
-  , toCBORHeader
   , toCBORHeaderToHash
   )
 import qualified Cardano.Chain.Delegation as Delegation
@@ -70,8 +69,8 @@ import Cardano.Crypto
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
   ( deprecatedGoldenDecode
   , goldenTestCBOR
-  , goldenTestCBORExplicit
   , roundTripsCBORAnnotatedShow
+  , roundTripsCBORAnnotatedBuildable
   , roundTripsCBORBuildable
   , roundTripsCBORShow
   )
@@ -97,7 +96,7 @@ exampleEs :: EpochSlots
 exampleEs = EpochSlots 50
 
 goldenHeader :: Property
-goldenHeader = goldenTestCBORExplicit
+goldenHeader = goldenTestExplicit
   "Header"
   (toCBORHeader exampleEs)
   (fromCBORHeader exampleEs)
@@ -114,9 +113,9 @@ ts_roundTripHeaderCompat = eachOfTS
   roundTripsHeaderCompat :: WithEpochSlots Header -> H.PropertyT IO ()
   roundTripsHeaderCompat esh@(WithEpochSlots es _) = trippingBuildable
     esh
-    (serializeEncoding . toCBORHeaderToHash es . unWithEpochSlots)
+    (serializeEncoding . toCBORHeaderToHash . unWithEpochSlots)
     ( fmap (WithEpochSlots es . fromJust)
-    . decodeFullDecoder "Header" (fromCBORHeaderToHash es)
+    . decodeAnnotatedDecoder "Header" (fromCBORHeaderToHash es)
     )
 
 --------------------------------------------------------------------------------
@@ -142,14 +141,15 @@ ts_roundTripBlockCompat = eachOfTS
 --------------------------------------------------------------------------------
 -- BlockSignature
 --------------------------------------------------------------------------------
-
+{-- TODO!
 goldenBlockSignature :: Property
 goldenBlockSignature =
   goldenTestCBOR exampleBlockSignature "test/golden/cbor/block/BlockSignature"
+--}
 
 ts_roundTripBlockSignatureCBOR :: TSProperty
 ts_roundTripBlockSignatureCBOR =
-  eachOfTS 10 (feedPMEpochSlots genBlockSignature) roundTripsCBORBuildable
+  eachOfTS 10 (feedPMEpochSlots genBlockSignature) roundTripsCBORAnnotatedBuildable
 
 
 --------------------------------------------------------------------------------
@@ -243,11 +243,13 @@ ts_roundTripBodyCBOR = eachOfTS 20 (feedPM genBody) roundTripsCBORAnnotatedShow
 -- Proof
 --------------------------------------------------------------------------------
 
+{-- TODO!
 goldenProof :: Property
 goldenProof = goldenTestCBOR exampleProof "test/golden/cbor/block/Proof"
+--}
 
 ts_roundTripProofCBOR :: TSProperty
-ts_roundTripProofCBOR = eachOfTS 20 (feedPM genProof) roundTripsCBORBuildable
+ts_roundTripProofCBOR = eachOfTS 20 (feedPM genProof) roundTripsCBORAnnotatedBuildable
 
 
 --------------------------------------------------------------------------------
@@ -268,12 +270,14 @@ ts_roundTripSigningHistoryCBOR =
 -- ToSign
 --------------------------------------------------------------------------------
 
+{-- TODO!
 goldenToSign :: Property
 goldenToSign = goldenTestCBOR exampleToSign "test/golden/cbor/block/ToSign"
+--}
 
 ts_roundTripToSignCBOR :: TSProperty
 ts_roundTripToSignCBOR =
-  eachOfTS 20 (feedPMEpochSlots genToSign) roundTripsCBORShow
+  eachOfTS 20 (feedPMEpochSlots genToSign) roundTripsCBORAnnotatedShow
 
 
 --------------------------------------------------------------------------------

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
@@ -26,8 +26,9 @@ import Cardano.Chain.Block
   ( BlockSignature(..)
   , Block
   , Body
-  , ABoundaryBlock(..)
-  , ABoundaryBody(..)
+  , BoundaryBlock(..)
+  , pattern BoundaryBlock
+  , pattern BoundaryBody
   , BoundaryHeader(..)
   , mkBoundaryHeader
   , pattern Body
@@ -203,13 +204,11 @@ genBlock protocolMagicId epochSlots =
         )
         body
 
-genBoundaryBlock :: ProtocolMagicId -> Gen (ABoundaryBlock ())
+genBoundaryBlock :: ProtocolMagicId -> Gen BoundaryBlock
 genBoundaryBlock pm =
-  ABoundaryBlock
-    <$> pure 0
-    <*> genBoundaryHeader pm
-    <*> pure (ABoundaryBody ())
-    <*> pure ()
+  BoundaryBlock
+    <$> genBoundaryHeader pm
+    <*> pure BoundaryBody
 
 genBoundaryHeader :: ProtocolMagicId -> Gen BoundaryHeader
 genBoundaryHeader pm =

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
@@ -23,9 +23,8 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import Cardano.Chain.Block
-  ( ABlockSignature(..)
+  ( BlockSignature(..)
   , Block
-  , BlockSignature
   , Body
   , ABoundaryBlock(..)
   , ABoundaryBody(..)
@@ -34,6 +33,7 @@ import Cardano.Chain.Block
   , Header
   , HeaderHash
   , Proof(..)
+  , pattern Proof
   , SigningHistory(..)
   , ToSign(..)
   , hashHeader
@@ -84,7 +84,7 @@ genBlockSignature pm epochSlots =
         signCertificate pm (toVerification delegateSK) epoch issuerSafeSigner
       issuerVK = safeToVerification issuerSafeSigner
       sig      = sign pm (SignBlock issuerVK) delegateSK toSign
-    in ABlockSignature cert sig
+    in BlockSignature cert sig
 
 genHeaderHash :: Gen HeaderHash
 genHeaderHash = coerce <$> genTextHash
@@ -154,15 +154,12 @@ genSigningHistory =
 genToSign :: ProtocolMagicId -> EpochSlots -> Gen ToSign
 genToSign pm epochSlots =
   ToSign
-    <$> (mkAbstractHash <$> genHeader pm epochSlots)
+    <$> (hashHeader <$> genHeader pm epochSlots)
     <*> genProof pm
     <*> genEpochAndSlotCount epochSlots
     <*> genChainDifficulty
     <*> Update.genProtocolVersion
     <*> Update.genSoftwareVersion
- where
-  mkAbstractHash :: Header -> HeaderHash
-  mkAbstractHash = hashHeader epochSlots
 
 genBlockWithEpochSlots :: ProtocolMagicId -> Gen (WithEpochSlots Block)
 genBlockWithEpochSlots pm = do

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
@@ -28,7 +28,8 @@ import Cardano.Chain.Block
   , Body
   , ABoundaryBlock(..)
   , ABoundaryBody(..)
-  , ABoundaryHeader(..)
+  , BoundaryHeader(..)
+  , mkBoundaryHeader
   , pattern Body
   , Header
   , HeaderHash
@@ -202,18 +203,18 @@ genBlock protocolMagicId epochSlots =
         )
         body
 
-genBoundaryBlock :: Gen (ABoundaryBlock ())
-genBoundaryBlock =
+genBoundaryBlock :: ProtocolMagicId -> Gen (ABoundaryBlock ())
+genBoundaryBlock pm =
   ABoundaryBlock
     <$> pure 0
-    <*> genBoundaryHeader
+    <*> genBoundaryHeader pm
     <*> pure (ABoundaryBody ())
     <*> pure ()
 
-genBoundaryHeader :: Gen (ABoundaryHeader ())
-genBoundaryHeader =
-  ABoundaryHeader
-    <$> (Gen.choice [Right <$> genHeaderHash, Left . GenesisHash . coerce <$> genTextHash])
+genBoundaryHeader :: ProtocolMagicId -> Gen BoundaryHeader
+genBoundaryHeader pm =
+  mkBoundaryHeader
+    <$> pure pm
+    <*> (Gen.choice [Right <$> genHeaderHash, Left . GenesisHash . coerce <$> genTextHash])
     <*> (Gen.word64 (Range.constantFrom 10 0 1000))
     <*> genChainDifficulty
-    <*> pure ()

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Model.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Model.hs
@@ -92,7 +92,7 @@ import qualified Ledger.Update.Test as Update.Test
 import Test.Cardano.Chain.Elaboration.Block
   ( AbstractToConcreteIdMaps
   , abEnvToCfg
-  , elaborateBS
+  , elaborate
   , rcDCert
   , transactionIds
   )
@@ -144,7 +144,7 @@ elaborateAndUpdate
 elaborateAndUpdate config (cvs, abstractToConcreteIdMaps) (ast, ab) =
   (, abstractToConcreteIdMaps') <$> runReaderT (updateBlock config cvs concreteBlock) vMode
  where
-  (concreteBlock, abstractToConcreteIdMaps') = elaborateBS abstractToConcreteIdMaps config dCert cvs ab
+  (concreteBlock, abstractToConcreteIdMaps') = elaborate abstractToConcreteIdMaps config dCert cvs ab
 
   dCert = rcDCert (ab ^. Abstract.bHeader . Abstract.bhIssuer) stableAfter ast
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/ValidationMode.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/ValidationMode.hs
@@ -20,7 +20,7 @@ import Data.Word (Word64)
 import Cardano.Binary (Annotated (..))
 import Cardano.Chain.Block
   ( Block (..)
-  , AHeader (..)
+  , Header (..)
   , BlockValidationMode (..)
   , Proof (..)
   , blockProof
@@ -213,21 +213,21 @@ createInitialDIState dState =
     , _dIStateKeyEpochDelegations = S.empty
     }
 
-modifyAHeader
-  :: (AHeader ByteString -> AHeader ByteString)
+modifyHeader
+  :: (Header ByteString -> Header)
   -> Block
   -> Block
-modifyAHeader ahModifier ab =
+modifyHeader ahModifier ab =
   ab { blockHeader = ahModifier (blockHeader ab) }
 
-modifyAProof
+modifyProof
   :: (Annotated Proof ByteString -> Annotated Proof ByteString)
   -> Block
   -> Block
-modifyAProof apModifier ab =
-  modifyAHeader ahModifier ab
+modifyProof apModifier ab =
+  modifyHeader ahModifier ab
  where
-  ahModifier :: AHeader ByteString -> AHeader ByteString
+  ahModifier :: Header -> Header
   ahModifier ah = ah { aHeaderProof = apModifier (aHeaderProof ah) }
 
 modifyDelegationProof
@@ -235,7 +235,7 @@ modifyDelegationProof
   -> Block
   -> Block
 modifyDelegationProof dpModifier ab =
-  modifyAProof apModifier ab
+  modifyProof apModifier ab
  where
   apModifier :: Annotated Proof ByteString -> Annotated Proof ByteString
   apModifier (Annotated p bs) = Annotated
@@ -247,7 +247,7 @@ modifyTxProof
   -> Block
   -> Block
 modifyTxProof tpModifier ab =
-  modifyAProof apModifier ab
+  modifyProof apModifier ab
  where
   apModifier :: Annotated Proof ByteString -> Annotated Proof ByteString
   apModifier (Annotated p bs) = Annotated
@@ -272,7 +272,7 @@ invalidateABlockProof ab =
       [ pure $ proofUpdate (blockProof ab)
       , feedPM Update.genProof
       ]
-    pure $ modifyAProof
+    pure $ modifyProof
       (\(Annotated p bs) -> Annotated
         (p
           { proofUTxO = txProof

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/CBOR.hs
@@ -15,7 +15,7 @@ import Hedgehog (Property)
 import Cardano.Chain.Delegation (unsafePayload)
 
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBOR, roundTripsCBORBuildable)
+  (goldenTestCBOR, roundTripsCBORAnnotatedBuildable)
 import Test.Cardano.Chain.Delegation.Example (exampleCertificates)
 import Test.Cardano.Chain.Delegation.Gen (genCertificate, genPayload)
 import Test.Cardano.Crypto.Gen (feedPM)
@@ -26,28 +26,32 @@ import Test.Options (TSGroup, TSProperty, concatTSGroups, eachOfTS)
 -- Certificate
 --------------------------------------------------------------------------------
 
+{- TODO!
 goldenCertificate :: Property
 goldenCertificate = goldenTestCBOR
   cert
   "test/golden/cbor/delegation/Certificate"
   where cert = exampleCertificates !! 0
+-}
 
 ts_roundTripCertificateCBOR :: TSProperty
 ts_roundTripCertificateCBOR =
-  eachOfTS 200 (feedPM genCertificate) roundTripsCBORBuildable
+  eachOfTS 200 (feedPM genCertificate) roundTripsCBORAnnotatedBuildable
 
 
 --------------------------------------------------------------------------------
 -- DlgPayload
 --------------------------------------------------------------------------------
 
+{- TODO!
 goldenDlgPayload :: Property
 goldenDlgPayload = goldenTestCBOR dp "test/golden/cbor/delegation/DlgPayload"
   where dp = unsafePayload (take 4 exampleCertificates)
+-}
 
 ts_roundTripDlgPayloadCBOR :: TSProperty
 ts_roundTripDlgPayloadCBOR =
-  eachOfTS 100 (feedPM genPayload) roundTripsCBORBuildable
+  eachOfTS 100 (feedPM genPayload) roundTripsCBORAnnotatedBuildable
 
 
 tests :: TSGroup

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/CBOR.hs
@@ -15,7 +15,7 @@ import Hedgehog (Property)
 import Cardano.Chain.Delegation (unsafePayload)
 
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBOR, roundTripsCBORAnnotatedBuildable)
+  (goldenTestCBORAnnotated, roundTripsCBORAnnotatedBuildable)
 import Test.Cardano.Chain.Delegation.Example (exampleCertificates)
 import Test.Cardano.Chain.Delegation.Gen (genCertificate, genPayload)
 import Test.Cardano.Crypto.Gen (feedPM)
@@ -26,13 +26,11 @@ import Test.Options (TSGroup, TSProperty, concatTSGroups, eachOfTS)
 -- Certificate
 --------------------------------------------------------------------------------
 
-{- TODO!
 goldenCertificate :: Property
-goldenCertificate = goldenTestCBOR
+goldenCertificate = goldenTestCBORAnnotated
   cert
   "test/golden/cbor/delegation/Certificate"
   where cert = exampleCertificates !! 0
--}
 
 ts_roundTripCertificateCBOR :: TSProperty
 ts_roundTripCertificateCBOR =
@@ -43,11 +41,9 @@ ts_roundTripCertificateCBOR =
 -- DlgPayload
 --------------------------------------------------------------------------------
 
-{- TODO!
 goldenDlgPayload :: Property
-goldenDlgPayload = goldenTestCBOR dp "test/golden/cbor/delegation/DlgPayload"
+goldenDlgPayload = goldenTestCBORAnnotated dp "test/golden/cbor/delegation/DlgPayload"
   where dp = unsafePayload (take 4 exampleCertificates)
--}
 
 ts_roundTripDlgPayloadCBOR :: TSProperty
 ts_roundTripDlgPayloadCBOR =

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/Certificate.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/Certificate.hs
@@ -8,12 +8,10 @@ where
 
 import Cardano.Prelude
 
-import qualified Data.ByteString.Lazy as BSL
 
 import Hedgehog (Group, Property, assert, discover, forAll, property)
 import qualified Hedgehog.Gen as Gen
 
-import Cardano.Binary (decodeFull, serialize, slice)
 import Cardano.Chain.Delegation
   (Certificate(delegateVK), isValid, signCertificate)
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/Certificate.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/Certificate.hs
@@ -15,7 +15,7 @@ import qualified Hedgehog.Gen as Gen
 
 import Cardano.Binary (decodeFull, serialize, slice)
 import Cardano.Chain.Delegation
-  (ACertificate(delegateVK), Certificate, isValid, signCertificate)
+  (Certificate(delegateVK), isValid, signCertificate)
 
 import Test.Cardano.Chain.Slotting.Gen (genEpochNumber)
 import qualified Test.Cardano.Crypto.Dummy as Dummy
@@ -43,9 +43,7 @@ prop_certificateCorrect = property $ do
     <*> genEpochNumber
     <*> genSafeSigner
 
-  let aCert = annotateCert cert
-
-  assert $ isValid Dummy.annotatedProtocolMagicId aCert
+  assert $ isValid Dummy.annotatedProtocolMagicId cert
 
 -- | Cannot validate 'Certificate's with incorrect verification keys
 prop_certificateIncorrect :: Property
@@ -60,14 +58,5 @@ prop_certificateIncorrect = property $ do
 
   let
     badCert  = cert { delegateVK = badDelegateVK }
-    aBadCert = annotateCert badCert
 
-  assert . not $ isValid Dummy.annotatedProtocolMagicId aBadCert
-
-annotateCert :: Certificate -> ACertificate ByteString
-annotateCert cert =
-  fmap (BSL.toStrict . slice bytes)
-    . fromRight
-        (panic "prop_certificateCorrect: Round trip broken for Certificate")
-    $ decodeFull bytes
-  where bytes = serialize cert
+  assert . not $ isValid Dummy.annotatedProtocolMagicId badCert

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/Gen.hs
@@ -14,8 +14,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import Cardano.Chain.Delegation
-  ( ACertificate(delegateVK, issuerVK)
-  , Certificate
+  ( Certificate(delegateVK, issuerVK)
   , Payload
   , signCertificate
   , unsafePayload

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/Model.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/Model.hs
@@ -118,7 +118,7 @@ commandSDELEG concreteRef abstractEnv = Command gen execute callbacks
       result = Scheduling.scheduleCertificate
         (E.elaborateDSEnv abstractEnv)
         concreteState
-        (E.elaborateDCertAnnotated Dummy.protocolMagicId cert)
+        (E.elaborateDCert Dummy.protocolMagicId cert)
 
     liftIO . writeIORef concreteRef $ fromRight concreteState result
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -131,12 +131,11 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
   cDCert :: Delegation.Certificate
   cDCert = elaborateDCert pm dCert
 
-  bb0    = Concrete.ABody
-    { Concrete.bodyTxPayload     = UTxO.ATxPayload txPayload
-    , Concrete.bodySscPayload    = Ssc.SscPayload
-    , Concrete.bodyDlgPayload    = Delegation.UnsafeAPayload dcerts ()
-    , Concrete.bodyUpdatePayload = updatePayload
-    }
+  bb0    = Concrete.Body
+             (UTxO.ATxPayload txPayload)
+             Ssc.SscPayload
+             (Delegation.UnsafeAPayload dcerts ())
+             updatePayload
 
   dcerts =
     abstractBlock

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -13,7 +13,6 @@
 module Test.Cardano.Chain.Elaboration.Block
   ( abEnvToCfg
   , elaborate
-  , elaborateBS
   , rcDCert
   , AbstractToConcreteIdMaps
     ( AbstractToConcreteIdMaps
@@ -28,7 +27,6 @@ import Cardano.Prelude hiding (to)
 import Control.Arrow ((&&&))
 import Control.Lens ((^.), to, (^..))
 import Data.Bimap (Bimap)
-import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce (coerce)
 import qualified Data.Map as Map
 import Data.Monoid.Generic (GenericSemigroup (GenericSemigroup), GenericMonoid (GenericMonoid))
@@ -36,7 +34,6 @@ import qualified Data.Set as Set
 import Data.Time (Day(ModifiedJulianDay), UTCTime(UTCTime))
 import GHC.Generics (Generic)
 
-import qualified Cardano.Binary as Binary
 import qualified Cardano.Crypto.Hashing as H
 import Cardano.Crypto.ProtocolMagic (AProtocolMagic(..))
 
@@ -94,11 +91,7 @@ elaborate
   -> Abstract.Block
   -> (Concrete.Block, AbstractToConcreteIdMaps)
 elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
-  ( Concrete.ABlock
-    { Concrete.blockHeader     = bh0
-    , Concrete.blockBody       = bb0
-    , Concrete.blockAnnotation = ()
-    }
+  ( Concrete.mkBlock epochSlots bh0 bb0
   , AbstractToConcreteIdMaps
     { transactionIds = txIdMap'
     , proposalIds = proposalsIdMap'
@@ -109,11 +102,13 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
 
   pm = Genesis.configProtocolMagicId config
 
+  epochSlots = Genesis.configEpochSlots config
+
   bh0 = Concrete.mkHeaderExplicit
     pm
     prevHash
     (ChainDifficulty 0)
-    (Genesis.configEpochSlots config)
+    epochSlots
     sid
     ssk
     cDCert
@@ -177,42 +172,6 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
           (Abstract.Update._upId abstractProposal)
           (H.hash concreteProposal)
           proposalsIdMap
-
-
-elaborateBS
-  :: AbstractToConcreteIdMaps
-  -> Genesis.Config -- TODO: Do we want this to come from the abstract
-                    -- environment? (in such case we wouldn't need this
-                    -- parameter)
-  -> DCert
-  -> Concrete.ChainValidationState
-  -> Abstract.Block
-  -> (Concrete.ABlock ByteString, AbstractToConcreteIdMaps)
-elaborateBS txIdMap config dCert st ab =
-  first (annotateBlock (Genesis.configEpochSlots config))
-    $ elaborate txIdMap config dCert st ab
-
-annotateBlock :: Slotting.EpochSlots -> Concrete.Block -> Concrete.ABlock ByteString
-annotateBlock epochSlots block =
-  let
-    decodedABlockOrBoundary =
-      case
-          Binary.decodeFullDecoder
-            "Block"
-            (Concrete.fromCBORABlockOrBoundary epochSlots) bytes
-        of
-          Left err ->
-            panic
-              $  "This function should be able to decode the block it encoded"
-              <> ". Instead I got: "
-              <> show err
-          Right abobb -> map (LBS.toStrict . Binary.slice bytes) abobb
-  in
-    case decodedABlockOrBoundary of
-      Concrete.ABOBBlock bk -> bk
-      Concrete.ABOBBoundary _ ->
-        panic "This function should have decoded a block."
-  where bytes = Binary.serializeEncoding (Concrete.toCBORABOBBlock epochSlots block)
 
 -- | Re-construct an abstract delegation certificate from the abstract state.
 --

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -132,9 +132,9 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
   cDCert = elaborateDCert pm dCert
 
   bb0    = Concrete.Body
-             (UTxO.ATxPayload txPayload)
+             (UTxO.TxPayload txPayload)
              Ssc.SscPayload
-             (Delegation.UnsafeAPayload dcerts ())
+             (Delegation.unsafePayload dcerts)
              updatePayload
 
   dcerts =
@@ -143,19 +143,18 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
             (elaborateDCert pm)
           )
 
-  (txPayload, txIdMap') = first (fmap void) $ elaborateTxWitnesses
+  (txPayload, txIdMap') = elaborateTxWitnesses
     txIdMap
     (abstractBlock ^. Abstract.bBody . Abstract.bUtxo)
 
-  updatePayload :: Update.APayload ()
+  updatePayload :: Update.Payload
   updatePayload =
-    Update.APayload
+    Update.Payload
       (fmap snd maybeProposals)
       (fmap (elaborateVote pm proposalsIdMap')
       $ Abstract._bUpdVotes
       $ Abstract._bBody abstractBlock
       )
-      () -- Update payload annotation
 
   maybeProposals :: Maybe (Abstract.Update.UProp, Update.Proposal)
   maybeProposals

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -91,7 +91,7 @@ elaborate
   -> Abstract.Block
   -> (Concrete.Block, AbstractToConcreteIdMaps)
 elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
-  ( Concrete.mkBlock epochSlots bh0 bb0
+  ( Concrete.mkBlock bh0 bb0
   , AbstractToConcreteIdMaps
     { transactionIds = txIdMap'
     , proposalIds = proposalsIdMap'

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Delegation.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Delegation.hs
@@ -3,7 +3,6 @@
 
 module Test.Cardano.Chain.Elaboration.Delegation
   ( elaborateDCert
-  , elaborateDCertAnnotated
   , elaborateDSEnv
   , tests
   )
@@ -69,7 +68,7 @@ ts_prop_elaboratedCertsValid =
                     -- fails. Coverage testing ensures we will not generate a
                     -- large portion of 'Nothing'.
           Just cert ->
-            let concreteCert = elaborateDCertAnnotated pm cert in
+            let concreteCert = elaborateDCert pm cert in
             assert
               $ Concrete.Certificate.isValid (Annotated pm (serialize' pm)) concreteCert
  where
@@ -98,18 +97,6 @@ elaborateDCert pm cert = Concrete.signCertificate
 
   epochNo :: Concrete.EpochNumber
   epochNo = fromIntegral e
-
-
-elaborateDCertAnnotated
-  :: ProtocolMagicId -> DCert -> Concrete.ACertificate ByteString
-elaborateDCertAnnotated pm = annotateDCert . elaborateDCert pm
- where
-  annotateDCert :: Concrete.Certificate -> Concrete.ACertificate ByteString
-  annotateDCert cert = cert
-    { Concrete.Certificate.aEpoch = Annotated omega (serialize' omega)
-    }
-    where omega = Concrete.Certificate.epoch cert
-
 
 elaborateDSEnv :: DSEnv -> Scheduling.Environment
 elaborateDSEnv abstractEnv = Scheduling.Environment

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
@@ -8,8 +8,8 @@ module Test.Cardano.Chain.Elaboration.UTxO
   ( elaborateUTxOEnv
   , elaborateUTxO
   , elaborateTx
-  , elaborateTxWitsBS
   , elaborateTxOut
+  , elaborateTxWits
   )
 where
 
@@ -70,36 +70,21 @@ elaborateUTxOEntry elaborateTxId (abstractTxIn, abstractTxOut) =
   concreteTxOut = elaborateTxOut abstractTxOut
   concreteTxIn  = elaborateTxIn elaborateTxId abstractTxIn
 
-elaborateTxWitsBS
-  :: (Abstract.TxId -> Concrete.TxId)
-  -> Abstract.TxWits
-  -> Concrete.ATxAux ByteString
-elaborateTxWitsBS elaborateTxId =
-  annotateTxAux . elaborateTxWits elaborateTxId
- where
-  annotateTxAux :: Concrete.TxAux -> Concrete.ATxAux ByteString
-  annotateTxAux txAux =
-    map (LBS.toStrict . CBOR.slice bytes)
-      . fromRight (panic "elaborateTxWitsBS: Error decoding TxAux")
-      $ CBOR.decodeFull bytes
-    where bytes = CBOR.serialize txAux
-
 elaborateTxWits
   :: (Abstract.TxId -> Concrete.TxId) -> Abstract.TxWits -> Concrete.TxAux
 elaborateTxWits elaborateTxId (Abstract.TxWits tx witnesses) =
-  Concrete.mkTxAux concreteTx (elaborateWitnesses concreteTx witnesses)
+  Concrete.TxAux concreteTx (elaborateWitnesses concreteTx witnesses)
   where concreteTx = elaborateTx elaborateTxId tx
 
 elaborateTx :: (Abstract.TxId -> Concrete.TxId) -> Abstract.Tx -> Concrete.Tx
 elaborateTx elaborateTxId (Abstract.Tx inputs outputs) =
-  Concrete.UnsafeTx
-    { Concrete.txInputs     = elaborateTxIns elaborateTxId inputs
-    , Concrete.txOutputs    = elaborateTxOuts outputs
-    , Concrete.txAttributes = Concrete.mkAttributes ()
-    }
+  Concrete.Tx
+    (elaborateTxIns elaborateTxId inputs)
+    (elaborateTxOuts outputs)
+    (Concrete.mkAttributes ())
 
 elaborateWitnesses :: Concrete.Tx -> [Abstract.Wit] -> Concrete.TxWitness
-elaborateWitnesses concreteTx = V.fromList . fmap (elaborateWitness concreteTx)
+elaborateWitnesses concreteTx = Concrete.TxWitness . V.fromList . fmap (elaborateWitness concreteTx)
 
 elaborateWitness :: Concrete.Tx -> Abstract.Wit -> Concrete.TxInWitness
 elaborateWitness concreteTx (Abstract.Wit key _) = Concrete.VKWitness

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
@@ -15,13 +15,11 @@ where
 
 import Cardano.Prelude
 
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Vector as V
 import Formatting hiding (bytes)
 
-import qualified Cardano.Binary as CBOR
 import qualified Cardano.Chain.Common as Concrete
 import qualified Cardano.Chain.UTxO as Concrete
 import qualified Cardano.Chain.UTxO.UTxO as Concrete.UTxO

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
@@ -118,9 +118,9 @@ elaborateSoftwareVersion abstractVersion =
 elaborateUpdateProposal
   :: ProtocolMagicId
   -> Abstract.UProp
-  -> Concrete.AProposal ()
+  -> Concrete.Proposal
 elaborateUpdateProposal protocolMagicId abstractProposal =
-  Concrete.unsafeProposal
+  Concrete.UnsafeProposal
     body
     issuer
     proposalSignature
@@ -159,15 +159,10 @@ elaborateUpSD ( protocolVersion
               , systemTags
               , _metadata) =
   Proposal.ProposalBody
-  { Proposal.protocolVersion =
-      elaborateProtocolVersion protocolVersion
-  , Proposal.protocolParametersUpdate =
-      justifyProtocolParameters $ elaboratePParams protocolParameters
-  , Proposal.softwareVersion =
-      elaborateSoftwareVersion softwareVersion
-  , Proposal.metadata =
-      Map.fromList $ zip concreteSystemTags concreteSystemHashes
-  }
+      (elaborateProtocolVersion protocolVersion)
+      (justifyProtocolParameters $ elaboratePParams protocolParameters)
+      (elaborateSoftwareVersion softwareVersion)
+      (Map.fromList $ zip concreteSystemTags concreteSystemHashes)
   where
     concreteSystemTags =
       fmap elaborateSystemTag $ Set.toList systemTags
@@ -209,7 +204,7 @@ elaborateVote
   :: ProtocolMagicId
   -> Map Abstract.UpId Concrete.UpId
   -> Abstract.Vote
-  -> Concrete.AVote ()
+  -> Concrete.Vote
 elaborateVote protocolMagicId proposalsIdMap abstractVote =
   Concrete.mkVoteSafe
     protocolMagicId

--- a/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/CBOR.hs
@@ -11,7 +11,7 @@ import Test.Cardano.Prelude
 import Hedgehog (Property)
 
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBOR, roundTripsCBORAnnotatedShow)
+  (goldenTestCBORAnnotated, roundTripsCBORAnnotatedShow)
 import Test.Cardano.Chain.MempoolPayload.Example
     (exampleMempoolPayload, exampleMempoolPayload1, exampleMempoolPayload2)
 import Test.Cardano.Chain.MempoolPayload.Gen (genMempoolPayload)
@@ -23,22 +23,20 @@ import Test.Options (TSGroup, TSProperty, concatTSGroups, eachOfTS)
 -- MempoolPayload
 --------------------------------------------------------------------------------
 
-{- TODO!
 goldenMempoolPayload :: Property
-goldenMempoolPayload = goldenTestCBOR
+goldenMempoolPayload = goldenTestCBORAnnotated
   exampleMempoolPayload
   "test/golden/cbor/MempoolPayload"
 
 goldenMempoolPayload1 :: Property
-goldenMempoolPayload1 = goldenTestCBOR
+goldenMempoolPayload1 = goldenTestCBORAnnotated
   exampleMempoolPayload1
   "test/golden/cbor/MempoolPayload1"
 
 goldenMempoolPayload2 :: Property
-goldenMempoolPayload2 = goldenTestCBOR
+goldenMempoolPayload2 = goldenTestCBORAnnotated
   exampleMempoolPayload2
   "test/golden/cbor/MempoolPayload2"
--}
 
 ts_roundTripMempoolPayload :: TSProperty
 ts_roundTripMempoolPayload =

--- a/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/CBOR.hs
@@ -11,7 +11,7 @@ import Test.Cardano.Prelude
 import Hedgehog (Property)
 
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBOR, roundTripsCBORShow)
+  (goldenTestCBOR, roundTripsCBORAnnotatedShow)
 import Test.Cardano.Chain.MempoolPayload.Example
     (exampleMempoolPayload, exampleMempoolPayload1, exampleMempoolPayload2)
 import Test.Cardano.Chain.MempoolPayload.Gen (genMempoolPayload)
@@ -23,6 +23,7 @@ import Test.Options (TSGroup, TSProperty, concatTSGroups, eachOfTS)
 -- MempoolPayload
 --------------------------------------------------------------------------------
 
+{- TODO!
 goldenMempoolPayload :: Property
 goldenMempoolPayload = goldenTestCBOR
   exampleMempoolPayload
@@ -37,10 +38,11 @@ goldenMempoolPayload2 :: Property
 goldenMempoolPayload2 = goldenTestCBOR
   exampleMempoolPayload2
   "test/golden/cbor/MempoolPayload2"
+-}
 
 ts_roundTripMempoolPayload :: TSProperty
 ts_roundTripMempoolPayload =
-  eachOfTS 200 (feedPM genMempoolPayload) roundTripsCBORShow
+  eachOfTS 200 (feedPM genMempoolPayload) roundTripsCBORAnnotatedShow
 
 tests :: TSGroup
 tests = concatTSGroups [const $$discoverGolden, $$discoverRoundTripArg]

--- a/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/Example.hs
@@ -10,7 +10,7 @@ where
 import Cardano.Prelude
 
 import Cardano.Chain.Delegation as Delegation (unsafePayload)
-import Cardano.Chain.MempoolPayload (AMempoolPayload (..), MempoolPayload)
+import Cardano.Chain.MempoolPayload (MempoolPayload (..), MempoolPayload)
 
 import Test.Cardano.Chain.Delegation.Example as Delegation
     (exampleCertificates)

--- a/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/Gen.hs
@@ -8,7 +8,7 @@ import Cardano.Prelude
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 
-import Cardano.Chain.MempoolPayload (AMempoolPayload (..), MempoolPayload)
+import Cardano.Chain.MempoolPayload (MempoolPayload (..))
 import Cardano.Crypto (ProtocolMagicId)
 
 import Test.Cardano.Chain.Delegation.Gen as Delegation (genPayload)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
@@ -20,12 +20,12 @@ import qualified Hedgehog as H
 import Cardano.Binary (ToCBOR, Case(..), LengthOf, SizeOverride(..), szCases)
 import Cardano.Chain.Common (AddrAttributes(..), Attributes(..), mkAttributes)
 import Cardano.Chain.UTxO
-  (Tx(..), TxIn(..), TxInWitness(..), TxOut(..), TxSigData(..), taTx, taWitness)
+  (Tx(..), TxIn(..), TxInWitness(..), TxOut(..), TxSigData(..), taTx, taWitness, txInWitnesses)
 import Cardano.Crypto (ProtocolMagicId(..), SignTag(..), Signature, sign)
 
 import Test.Cardano.Binary.Helpers (SizeTestConfig(..), scfg, sizeTest)
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBOR, roundTripsCBORBuildable, roundTripsCBORShow)
+  (goldenTestCBOR, roundTripsCBORBuildable, roundTripsCBORAnnotatedBuildable, roundTripsCBORShow, roundTripsCBORAnnotatedShow)
 import Test.Cardano.Chain.UTxO.Example
   ( exampleHashTx
   , exampleRedeemSignature
@@ -68,12 +68,14 @@ import Test.Options (TSGroup, TSProperty, concatTSGroups, eachOfTS)
 -- Tx
 --------------------------------------------------------------------------------
 
+{- TODO!
 goldenTx :: Property
 goldenTx = goldenTestCBOR tx "test/golden/cbor/utxo/Tx"
   where tx = UnsafeTx exampleTxInList exampleTxOutList (mkAttributes ())
+-}
 
 ts_roundTripTx :: TSProperty
-ts_roundTripTx = eachOfTS 50 genTx roundTripsCBORBuildable
+ts_roundTripTx = eachOfTS 50 genTx roundTripsCBORAnnotatedBuildable
 
 
 --------------------------------------------------------------------------------
@@ -93,7 +95,7 @@ ts_roundTripTxAttributes = eachOfTS 10 genTxAttributes roundTripsCBORBuildable
 --------------------------------------------------------------------------------
 
 ts_roundTripTxAux :: TSProperty
-ts_roundTripTxAux = eachOfTS 100 (feedPM genTxAux) roundTripsCBORBuildable
+ts_roundTripTxAux = eachOfTS 100 (feedPM genTxAux) roundTripsCBORAnnotatedBuildable
 
 
 --------------------------------------------------------------------------------
@@ -193,23 +195,27 @@ ts_roundTripTxOut = eachOfTS 50 genTxOut roundTripsCBORBuildable
 -- TxPayload
 --------------------------------------------------------------------------------
 
+{- TODO!
 goldenTxPayload1 :: Property
 goldenTxPayload1 =
   goldenTestCBOR exampleTxPayload1 "test/golden/cbor/utxo/TxPayload1"
+-}
 
 ts_roundTripTxPayload :: TSProperty
-ts_roundTripTxPayload = eachOfTS 50 (feedPM genTxPayload) roundTripsCBORShow
+ts_roundTripTxPayload = eachOfTS 50 (feedPM genTxPayload) roundTripsCBORAnnotatedShow
 
 
 --------------------------------------------------------------------------------
 -- TxProof
 --------------------------------------------------------------------------------
 
+{- TODO!
 goldenTxProof :: Property
 goldenTxProof = goldenTestCBOR exampleTxProof "test/golden/cbor/utxo/TxProof"
+-}
 
 ts_roundTripTxProof :: TSProperty
-ts_roundTripTxProof = eachOfTS 50 (feedPM genTxProof) roundTripsCBORBuildable
+ts_roundTripTxProof = eachOfTS 50 (feedPM genTxProof) roundTripsCBORAnnotatedBuildable
 
 
 --------------------------------------------------------------------------------
@@ -245,12 +251,14 @@ ts_roundTripTxSigData = eachOfTS 50 genTxSigData roundTripsCBORShow
 -- TxWitness
 --------------------------------------------------------------------------------
 
+{- TODO!
 goldenTxWitness :: Property
 goldenTxWitness =
   goldenTestCBOR exampleTxWitness "test/golden/cbor/utxo/TxWitness"
+-}
 
 ts_roundTripTxWitness :: TSProperty
-ts_roundTripTxWitness = eachOfTS 20 (feedPM genTxWitness) roundTripsCBORShow
+ts_roundTripTxWitness = eachOfTS 20 (feedPM genTxWitness) roundTripsCBORAnnotatedShow
 
 
 --------------------------------------------------------------------------------
@@ -302,7 +310,7 @@ sizeEstimates
               , SizeConstant (fromIntegral $ length $ txInputs $ taTx ta)
               )
             , ( typeRep (Proxy @(LengthOf (Vector TxInWitness)))
-              , SizeConstant (fromIntegral $ length $ taWitness ta)
+              , SizeConstant (fromIntegral $ length $ txInWitnesses $ taWitness ta)
               )
             , ( typeRep (Proxy @(LengthOf [TxOut]))
               , SizeConstant (fromIntegral $ length $ txOutputs $ taTx ta)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE PatternSynonyms   #-}
 
 module Test.Cardano.Chain.UTxO.CBOR
   ( tests
@@ -20,12 +21,12 @@ import qualified Hedgehog as H
 import Cardano.Binary (ToCBOR, Case(..), LengthOf, SizeOverride(..), szCases)
 import Cardano.Chain.Common (AddrAttributes(..), Attributes(..), mkAttributes)
 import Cardano.Chain.UTxO
-  (Tx(..), TxIn(..), TxInWitness(..), TxOut(..), TxSigData(..), taTx, taWitness, txInWitnesses)
+  (Tx(..), pattern Tx,  TxIn(..), TxInWitness(..), TxOut(..), TxSigData(..), taTx, taWitness, txInWitnesses)
 import Cardano.Crypto (ProtocolMagicId(..), SignTag(..), Signature, sign)
 
 import Test.Cardano.Binary.Helpers (SizeTestConfig(..), scfg, sizeTest)
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBOR, roundTripsCBORBuildable, roundTripsCBORAnnotatedBuildable, roundTripsCBORShow, roundTripsCBORAnnotatedShow)
+  (goldenTestCBOR, goldenTestCBORAnnotated, roundTripsCBORBuildable, roundTripsCBORAnnotatedBuildable, roundTripsCBORShow, roundTripsCBORAnnotatedShow)
 import Test.Cardano.Chain.UTxO.Example
   ( exampleHashTx
   , exampleRedeemSignature
@@ -68,11 +69,9 @@ import Test.Options (TSGroup, TSProperty, concatTSGroups, eachOfTS)
 -- Tx
 --------------------------------------------------------------------------------
 
-{- TODO!
 goldenTx :: Property
-goldenTx = goldenTestCBOR tx "test/golden/cbor/utxo/Tx"
-  where tx = UnsafeTx exampleTxInList exampleTxOutList (mkAttributes ())
--}
+goldenTx = goldenTestCBORAnnotated tx "test/golden/cbor/utxo/Tx"
+  where tx = Tx exampleTxInList exampleTxOutList (mkAttributes ())
 
 ts_roundTripTx :: TSProperty
 ts_roundTripTx = eachOfTS 50 genTx roundTripsCBORAnnotatedBuildable
@@ -195,11 +194,9 @@ ts_roundTripTxOut = eachOfTS 50 genTxOut roundTripsCBORBuildable
 -- TxPayload
 --------------------------------------------------------------------------------
 
-{- TODO!
 goldenTxPayload1 :: Property
 goldenTxPayload1 =
-  goldenTestCBOR exampleTxPayload1 "test/golden/cbor/utxo/TxPayload1"
--}
+  goldenTestCBORAnnotated exampleTxPayload1 "test/golden/cbor/utxo/TxPayload1"
 
 ts_roundTripTxPayload :: TSProperty
 ts_roundTripTxPayload = eachOfTS 50 (feedPM genTxPayload) roundTripsCBORAnnotatedShow
@@ -209,10 +206,8 @@ ts_roundTripTxPayload = eachOfTS 50 (feedPM genTxPayload) roundTripsCBORAnnotate
 -- TxProof
 --------------------------------------------------------------------------------
 
-{- TODO!
 goldenTxProof :: Property
-goldenTxProof = goldenTestCBOR exampleTxProof "test/golden/cbor/utxo/TxProof"
--}
+goldenTxProof = goldenTestCBORAnnotated exampleTxProof "test/golden/cbor/utxo/TxProof"
 
 ts_roundTripTxProof :: TSProperty
 ts_roundTripTxProof = eachOfTS 50 (feedPM genTxProof) roundTripsCBORAnnotatedBuildable
@@ -251,11 +246,9 @@ ts_roundTripTxSigData = eachOfTS 50 genTxSigData roundTripsCBORShow
 -- TxWitness
 --------------------------------------------------------------------------------
 
-{- TODO!
 goldenTxWitness :: Property
 goldenTxWitness =
-  goldenTestCBOR exampleTxWitness "test/golden/cbor/utxo/TxWitness"
--}
+  goldenTestCBORAnnotated exampleTxWitness "test/golden/cbor/utxo/TxWitness"
 
 ts_roundTripTxWitness :: TSProperty
 ts_roundTripTxWitness = eachOfTS 20 (feedPM genTxWitness) roundTripsCBORAnnotatedShow

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE PatternSynonyms  #-}
 
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 
@@ -38,19 +39,19 @@ import Cardano.Chain.Common
   , mtRoot
   )
 import Cardano.Chain.UTxO
-  ( Tx(..)
-  , TxAux
+  ( Tx
+  , pattern Tx
+  , TxAux(..)
   , TxId
   , TxIn(..)
   , TxInWitness(..)
   , TxOut(..)
-  , TxPayload
+  , TxPayload(..)
   , TxProof(..)
   , TxSig
   , TxSigData(..)
   , TxWitness
-  , mkTxAux
-  , mkTxPayload
+  , pattern TxWitness
   )
 import Cardano.Crypto
   ( AbstractHash(..)
@@ -71,12 +72,12 @@ import Test.Cardano.Crypto.Example (exampleVerificationKey, exampleSigningKey)
 
 
 exampleTxAux :: TxAux
-exampleTxAux = mkTxAux tx exampleTxWitness
-  where tx = UnsafeTx exampleTxInList exampleTxOutList (mkAttributes ())
+exampleTxAux = TxAux tx exampleTxWitness
+  where tx = Tx exampleTxInList exampleTxOutList (mkAttributes ())
 
 exampleTxAux1 :: TxAux
-exampleTxAux1 = mkTxAux tx exampleTxWitness
-  where tx = UnsafeTx exampleTxInList1 exampleTxOutList1 (mkAttributes ())
+exampleTxAux1 = TxAux tx exampleTxWitness
+  where tx = Tx exampleTxInList1 exampleTxOutList1 (mkAttributes ())
 
 exampleTxId :: TxId
 exampleTxId = exampleHashTx
@@ -109,17 +110,17 @@ exampleTxOutList1 :: (NonEmpty TxOut)
 exampleTxOutList1 = fromList [exampleTxOut, exampleTxOut1]
 
 exampleTxPayload :: TxPayload
-exampleTxPayload = mkTxPayload [exampleTxAux]
+exampleTxPayload = TxPayload [exampleTxAux]
 
 exampleTxPayload1 :: TxPayload
-exampleTxPayload1 = mkTxPayload [exampleTxAux, exampleTxAux1]
+exampleTxPayload1 = TxPayload [exampleTxAux, exampleTxAux1]
 
 exampleTxProof :: TxProof
 exampleTxProof = TxProof 32 mroot hashWit
  where
   mroot = mtRoot $ mkMerkleTree
-    [(UnsafeTx exampleTxInList exampleTxOutList (mkAttributes ()))]
-  hashWit = hash $ [(V.fromList [(VKWitness exampleVerificationKey exampleTxSig)])]
+    [(Tx exampleTxInList exampleTxOutList (mkAttributes ()))]
+  hashWit = hash $ TxWitness <$> [(V.fromList [(VKWitness exampleVerificationKey exampleTxSig)])]
 
 exampleTxSig :: TxSig
 exampleTxSig =
@@ -129,7 +130,7 @@ exampleTxSigData :: TxSigData
 exampleTxSigData = TxSigData exampleHashTx
 
 exampleTxWitness :: TxWitness
-exampleTxWitness = V.fromList [(VKWitness exampleVerificationKey exampleTxSig)]
+exampleTxWitness = TxWitness $ V.fromList [(VKWitness exampleVerificationKey exampleTxSig)]
 
 exampleRedeemSignature :: RedeemSignature TxSigData
 exampleRedeemSignature = redeemSign

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Test.Cardano.Chain.UTxO.Gen
   ( genCompactTxId
   , genCompactTxIn
@@ -40,23 +42,23 @@ import Cardano.Chain.UTxO
   ( CompactTxId
   , CompactTxIn
   , CompactTxOut
-  , Tx(..)
+  , Tx
+  , pattern Tx
   , TxAttributes
-  , TxAux
+  , TxAux(..)
   , TxId
   , TxIn(..)
   , TxInWitness(..)
   , TxOut(..)
-  , TxPayload
+  , TxPayload(..)
   , TxProof(..)
   , TxSig
   , TxSigData(..)
   , TxWitness
+  , pattern TxWitness
   , UTxOConfiguration(..)
   , UTxO
   , fromList
-  , mkTxAux
-  , mkTxPayload
   , mkUTxOConfiguration
   , toCompactTxId
   , toCompactTxIn
@@ -92,13 +94,13 @@ genRedeemWitness pm =
   RedeemWitness <$> genRedeemVerificationKey <*> genRedeemSignature pm genTxSigData
 
 genTx :: Gen Tx
-genTx = UnsafeTx <$> genTxInList <*> genTxOutList <*> genTxAttributes
+genTx = Tx <$> genTxInList <*> genTxOutList <*> genTxAttributes
 
 genTxAttributes :: Gen TxAttributes
 genTxAttributes = pure $ mkAttributes ()
 
 genTxAux :: ProtocolMagicId -> Gen TxAux
-genTxAux pm = mkTxAux <$> genTx <*> (genTxWitness pm)
+genTxAux pm = TxAux <$> genTx <*> (genTxWitness pm)
 
 genTxHash :: Gen (Hash Tx)
 genTxHash = coerce <$> genTextHash
@@ -128,7 +130,7 @@ genUTxOConfiguration =
     <$> Gen.list (Range.linear 0 50) genAddress
 
 genTxPayload :: ProtocolMagicId -> Gen TxPayload
-genTxPayload pm = mkTxPayload <$> Gen.list (Range.linear 0 10) (genTxAux pm)
+genTxPayload pm = TxPayload <$> Gen.list (Range.linear 0 10) (genTxAux pm)
 
 genTxProof :: ProtocolMagicId -> Gen TxProof
 genTxProof pm =
@@ -146,7 +148,7 @@ genTxInWitness pm = Gen.choice [genVKWitness pm, genRedeemWitness pm]
 
 genTxWitness :: ProtocolMagicId -> Gen TxWitness
 genTxWitness pm =
-  V.fromList <$> Gen.list (Range.linear 1 10) (genTxInWitness pm)
+  TxWitness . V.fromList <$> Gen.list (Range.linear 1 10) (genTxInWitness pm)
 
 genUTxO :: Gen UTxO
 genUTxO = fromList <$> Gen.list (Range.constant 0 1000) genTxInTxOut

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Model.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Model.hs
@@ -27,7 +27,7 @@ import Cardano.Chain.UTxO
 import qualified Cardano.Chain.UTxO as Concrete
 import qualified Cardano.Chain.UTxO.UTxO as Concrete.UTxO
 import Cardano.Chain.ValidationMode (ValidationMode (..))
-import Cardano.Crypto (hashDecoded)
+import Cardano.Crypto (hash)
 
 import qualified Cardano.Ledger.Spec.STS.UTXO as Abstract
 import Cardano.Ledger.Spec.STS.UTXOW (UTXOW)
@@ -120,17 +120,17 @@ elaborateAndUpdate abstractEnv (utxo, txIdMap) abstractTxWits =
 elaborateTxWitnesses
   :: Map Abstract.TxId Concrete.TxId
   -> [Abstract.TxWits]
-  -> ([Concrete.ATxAux ByteString], Map Abstract.TxId Concrete.TxId)
+  -> ([Concrete.TxAux], Map Abstract.TxId Concrete.TxId)
 elaborateTxWitnesses txIdMap = first reverse . foldl' step ([], txIdMap)
   where step (acc, m) = first (: acc) . elaborateTxWitsBSWithMap m
 
 elaborateTxWitsBSWithMap
   :: Map Abstract.TxId Concrete.TxId
   -> Abstract.TxWits
-  -> (Concrete.ATxAux ByteString, Map Abstract.TxId Concrete.TxId)
+  -> (Concrete.TxAux, Map Abstract.TxId Concrete.TxId)
 elaborateTxWitsBSWithMap txIdMap abstractTxWits = (concreteTxWitness, txIdMap')
  where
-  concreteTxWitness = E.elaborateTxWitsBS
+  concreteTxWitness = E.elaborateTxWits
     ( fromMaybe
         (panic
           "elaborateTxWitsBSWithMap: Missing abstract TxId during elaboration"
@@ -139,7 +139,7 @@ elaborateTxWitsBSWithMap txIdMap abstractTxWits = (concreteTxWitness, txIdMap')
     )
     abstractTxWits
 
-  concreteTxId = hashDecoded $ Concrete.aTaTx concreteTxWitness
+  concreteTxId = hash $ Concrete.taTx concreteTxWitness
 
   txIdMap'     = M.insert
     (Abstract.txid $ Abstract.body abstractTxWits)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/ValidationMode.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/ValidationMode.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE PatternSynonyms   #-}
 
 module Test.Cardano.Chain.UTxO.ValidationMode
   ( tests
@@ -14,7 +15,7 @@ import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as M
 import qualified Data.Vector as V
 
-import Cardano.Binary (Annotated (..))
+import Cardano.Binary (Annotated (..), serialize')
 import Cardano.Chain.Block (BlockValidationMode (..))
 import Cardano.Chain.Common
   ( TxFeePolicy (..)
@@ -23,9 +24,11 @@ import Cardano.Chain.Common
   )
 import Cardano.Chain.Update (ProtocolParameters (..))
 import Cardano.Chain.UTxO
-  ( ATxAux (..)
+  ( TxAux (..)
   , Environment (..)
   , TxId
+  , TxWitness
+  , pattern TxWitness
   , TxValidationError (..)
   , TxValidationMode (..)
   , UTxOValidationError (..)
@@ -46,7 +49,7 @@ import qualified Ledger.UTxO as Abstract
 import qualified Ledger.UTxO.Generators as Abstract
 
 import Test.Cardano.Chain.Elaboration.Update (elaboratePParams)
-import Test.Cardano.Chain.Elaboration.UTxO (elaborateTxWitsBS)
+import Test.Cardano.Chain.Elaboration.UTxO (elaborateTxWits)
 import Test.Cardano.Chain.UTxO.Gen (genVKWitness)
 import Test.Cardano.Chain.UTxO.Model (elaborateInitialUTxO)
 import qualified Test.Cardano.Crypto.Dummy as Dummy
@@ -73,7 +76,7 @@ ts_prop_updateUTxO_Valid =
 
       -- Generate abstract transaction and elaborate.
       abstractTxWits <- forAll $ genValidTxWits ppau txIdMap
-      let tx = elaborateTxWitsBS
+      let tx = elaborateTxWits
             (elaborateTxId txIdMap)
             abstractTxWits
 
@@ -106,7 +109,7 @@ ts_prop_updateUTxO_InvalidWit =
 
       -- Generate abstract transaction and elaborate.
       abstractTxWits <- forAll $ genValidTxWits ppau txIdMap
-      let tx = elaborateTxWitsBS
+      let tx = elaborateTxWits
             (elaborateTxId txIdMap)
             abstractTxWits
 
@@ -114,13 +117,11 @@ ts_prop_updateUTxO_InvalidWit =
       -- transaction generated above.
       let pm = Dummy.aProtocolMagic
       invalidWitness <- forAll $
-        Annotated
-          <$> (V.fromList
+        TxWitness
+          <$> V.fromList
                 <$> Gen.list (Range.linear 1 10)
                              (genVKWitness (getProtocolMagicId pm))
-              )
-          <*> genBytes 32
-      let txInvalidWit = tx { aTaWitness = invalidWitness }
+      let txInvalidWit = tx { taWitness = invalidWitness }
 
       -- Validate the generated concrete transaction
       let env = Environment pm pparams UTxO.defaultUTxOConfiguration
@@ -212,10 +213,10 @@ abstractTxFee
   -> Abstract.Tx
   -> Abstract.Lovelace
 abstractTxFee txIdMap tfp aUtxo aTx = do
-  let aTxWits = Abstract.makeTxWits aUtxo aTx
-      ATxAux (Annotated _ txBytes) _ = elaborateTxWitsBS
+  let txWits = Abstract.makeTxWits aUtxo aTx
+      txBytes = serialize' $ elaborateTxWits
         (elaborateTxId txIdMap)
-        aTxWits
+        txWits
       cLovelace = case tfp of
         TxFeePolicyTxSizeLinear txSizeLinear ->
           either (panic . show)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/ValidationMode.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/ValidationMode.hs
@@ -15,7 +15,7 @@ import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as M
 import qualified Data.Vector as V
 
-import Cardano.Binary (Annotated (..), serialize')
+import Cardano.Binary (serialize')
 import Cardano.Chain.Block (BlockValidationMode (..))
 import Cardano.Chain.Common
   ( TxFeePolicy (..)
@@ -27,7 +27,6 @@ import Cardano.Chain.UTxO
   ( TxAux (..)
   , Environment (..)
   , TxId
-  , TxWitness
   , pattern TxWitness
   , TxValidationError (..)
   , TxValidationMode (..)

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/CBOR.hs
@@ -17,7 +17,7 @@ import Cardano.Chain.Update (ApplicationName(..), SoftforkRule(..))
 import Cardano.Crypto (Hash, abstractHash)
 
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBOR, roundTripsCBORBuildable, roundTripsCBORShow, roundTripsCBORAnnotatedShow, roundTripsCBORAnnotatedBuildable)
+  (goldenTestCBOR, goldenTestCBORAnnotated, roundTripsCBORBuildable, roundTripsCBORShow, roundTripsCBORAnnotatedShow, roundTripsCBORAnnotatedBuildable)
 import Test.Cardano.Chain.Update.Example
   ( exampleProtocolParametersUpdate
   , examplePayload
@@ -182,11 +182,9 @@ ts_roundTripInstallerHash = eachOfTS 20 genInstallerHash roundTripsCBORBuildable
 -- UpdatePayload
 --------------------------------------------------------------------------------
 
-{- TODO!
 goldenUpdatePayload :: Property
 goldenUpdatePayload =
-  goldenTestCBOR examplePayload "test/golden/cbor/update/Payload"
--}
+  goldenTestCBORAnnotated examplePayload "test/golden/cbor/update/Payload"
 
 ts_roundTripUpdatePayload :: TSProperty
 ts_roundTripUpdatePayload =
@@ -208,11 +206,9 @@ ts_roundTripUpdateProof = eachOfTS 20 (feedPM genProof) roundTripsCBORBuildable
 -- UpdateProposal
 --------------------------------------------------------------------------------
 
-{- TODO!
 goldenUpdateProposal :: Property
 goldenUpdateProposal =
-  goldenTestCBOR exampleProposal "test/golden/cbor/update/Proposal"
--}
+  goldenTestCBORAnnotated exampleProposal "test/golden/cbor/update/Proposal"
 
 ts_roundTripUpdateProposal :: TSProperty
 ts_roundTripUpdateProposal =
@@ -223,11 +219,9 @@ ts_roundTripUpdateProposal =
 -- ProposalBody
 --------------------------------------------------------------------------------
 
-{- TODO!
 goldenProposalBody :: Property
 goldenProposalBody =
-  goldenTestCBOR exampleProposalBody "test/golden/cbor/update/ProposalBody"
--}
+  goldenTestCBORAnnotated exampleProposalBody "test/golden/cbor/update/ProposalBody"
 
 ts_roundTripProposalBody :: TSProperty
 ts_roundTripProposalBody = eachOfTS 20 genProposalBody roundTripsCBORAnnotatedShow
@@ -237,10 +231,8 @@ ts_roundTripProposalBody = eachOfTS 20 genProposalBody roundTripsCBORAnnotatedSh
 -- UpdateVote
 --------------------------------------------------------------------------------
 
-{- TODO!
 goldenUpdateVote :: Property
-goldenUpdateVote = goldenTestCBOR exampleVote "test/golden/cbor/update/Vote"
--}
+goldenUpdateVote = goldenTestCBORAnnotated exampleVote "test/golden/cbor/update/Vote"
 
 ts_roundTripUpdateVote :: TSProperty
 ts_roundTripUpdateVote = eachOfTS 20 (feedPM genVote) roundTripsCBORAnnotatedBuildable

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/CBOR.hs
@@ -17,7 +17,7 @@ import Cardano.Chain.Update (ApplicationName(..), SoftforkRule(..))
 import Cardano.Crypto (Hash, abstractHash)
 
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBOR, roundTripsCBORBuildable, roundTripsCBORShow)
+  (goldenTestCBOR, roundTripsCBORBuildable, roundTripsCBORShow, roundTripsCBORAnnotatedShow, roundTripsCBORAnnotatedBuildable)
 import Test.Cardano.Chain.Update.Example
   ( exampleProtocolParametersUpdate
   , examplePayload
@@ -182,13 +182,15 @@ ts_roundTripInstallerHash = eachOfTS 20 genInstallerHash roundTripsCBORBuildable
 -- UpdatePayload
 --------------------------------------------------------------------------------
 
+{- TODO!
 goldenUpdatePayload :: Property
 goldenUpdatePayload =
   goldenTestCBOR examplePayload "test/golden/cbor/update/Payload"
+-}
 
 ts_roundTripUpdatePayload :: TSProperty
 ts_roundTripUpdatePayload =
-  eachOfTS 20 (feedPM genPayload) roundTripsCBORBuildable
+  eachOfTS 20 (feedPM genPayload) roundTripsCBORAnnotatedBuildable
 
 
 --------------------------------------------------------------------------------
@@ -206,36 +208,42 @@ ts_roundTripUpdateProof = eachOfTS 20 (feedPM genProof) roundTripsCBORBuildable
 -- UpdateProposal
 --------------------------------------------------------------------------------
 
+{- TODO!
 goldenUpdateProposal :: Property
 goldenUpdateProposal =
   goldenTestCBOR exampleProposal "test/golden/cbor/update/Proposal"
+-}
 
 ts_roundTripUpdateProposal :: TSProperty
 ts_roundTripUpdateProposal =
-  eachOfTS 20 (feedPM genProposal) roundTripsCBORBuildable
+  eachOfTS 20 (feedPM genProposal) roundTripsCBORAnnotatedBuildable
 
 
 --------------------------------------------------------------------------------
 -- ProposalBody
 --------------------------------------------------------------------------------
 
+{- TODO!
 goldenProposalBody :: Property
 goldenProposalBody =
   goldenTestCBOR exampleProposalBody "test/golden/cbor/update/ProposalBody"
+-}
 
 ts_roundTripProposalBody :: TSProperty
-ts_roundTripProposalBody = eachOfTS 20 genProposalBody roundTripsCBORShow
+ts_roundTripProposalBody = eachOfTS 20 genProposalBody roundTripsCBORAnnotatedShow
 
 
 --------------------------------------------------------------------------------
 -- UpdateVote
 --------------------------------------------------------------------------------
 
+{- TODO!
 goldenUpdateVote :: Property
 goldenUpdateVote = goldenTestCBOR exampleVote "test/golden/cbor/update/Vote"
+-}
 
 ts_roundTripUpdateVote :: TSProperty
-ts_roundTripUpdateVote = eachOfTS 20 (feedPM genVote) roundTripsCBORBuildable
+ts_roundTripUpdateVote = eachOfTS 20 (feedPM genVote) roundTripsCBORAnnotatedBuildable
 
 
 --------------------------------------------------------------------------------

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE PatternSynonyms  #-}
 
 module Test.Cardano.Chain.Update.Example
   ( exampleApplicationName
@@ -32,9 +33,11 @@ import Cardano.Chain.Slotting (EpochNumber(..), SlotNumber(..))
 import Cardano.Chain.Update
   ( ApplicationName(..)
   , Payload
+  , pattern Payload
   , Proof
   , Proposal
   , ProposalBody(..)
+  , pattern ProposalBody
   , ProtocolParametersUpdate(..)
   , ProtocolParameters(..)
   , ProtocolVersion(..)
@@ -46,7 +49,6 @@ import Cardano.Chain.Update
   , Vote
   , mkProof
   , mkVoteSafe
-  , payload
   , signProposal
   )
 import Cardano.Crypto (ProtocolMagicId(..), hash)
@@ -134,7 +136,7 @@ exampleUpId :: UpId
 exampleUpId = hash exampleProposal
 
 examplePayload :: Payload
-examplePayload = payload up uv
+examplePayload = Payload up uv
  where
   up = Just exampleProposal
   uv = [exampleVote]

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Gen.hs
@@ -1,3 +1,5 @@
+{-# Language PatternSynonyms #-}
+
 module Test.Cardano.Chain.Update.Gen
   ( genCanonicalProtocolParameters
   , genApplicationName
@@ -28,9 +30,12 @@ import qualified Hedgehog.Range as Range
 import Cardano.Chain.Update
   ( ApplicationName(..)
   , Payload
+  , pattern Payload
   , Proof
   , Proposal
+  , pattern UnsafeProposal
   , ProposalBody(..)
+  , pattern ProposalBody
   , ProtocolParametersUpdate(..)
   , ProtocolParameters(..)
   , ProtocolVersion(..)
@@ -41,9 +46,7 @@ import Cardano.Chain.Update
   , InstallerHash(..)
   , Vote
   , applicationNameMaxLength
-  , unsafeProposal
   , mkVote
-  , payload
   , systemTagMaxLength
   )
 import Cardano.Crypto (ProtocolMagicId)
@@ -150,7 +153,7 @@ genInstallerHash :: Gen InstallerHash
 genInstallerHash = InstallerHash <$> genHashRaw
 
 genPayload :: ProtocolMagicId -> Gen Payload
-genPayload pm = payload <$> Gen.maybe (genProposal pm) <*> Gen.list
+genPayload pm = Payload <$> Gen.maybe (genProposal pm) <*> Gen.list
   (Range.linear 0 10)
   (genVote pm)
 
@@ -159,7 +162,7 @@ genProof pm = genAbstractHash (genPayload pm)
 
 genProposal :: ProtocolMagicId -> Gen Proposal
 genProposal pm =
-  unsafeProposal
+  UnsafeProposal
     <$> genProposalBody
     <*> genVerificationKey
     <*> genSignature pm genProposalBody

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ extra-deps:
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 4b0053c528b2c7581053556d7421210a6c75b68f
+    commit: a112c321a161e5daec0a1dfc164bcc4a2ee05af7
     subdirs:
       - binary
       - binary/test

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ extra-deps:
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 1121579803319f01612583fc445c50b0a0ce0424
+    commit: 84d7978baf99443a0d74b6485feda598f9bc98f6
     subdirs:
       - binary
       - binary/test

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ extra-deps:
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 84d7978baf99443a0d74b6485feda598f9bc98f6
+    commit: 4cb99b3ec0aeb8ca76efe48493804b68a97c3ab5
     subdirs:
       - binary
       - binary/test

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ extra-deps:
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 4cb99b3ec0aeb8ca76efe48493804b68a97c3ab5
+    commit: 4b0053c528b2c7581053556d7421210a6c75b68f
     subdirs:
       - binary
       - binary/test

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ extra-deps:
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: a112c321a161e5daec0a1dfc164bcc4a2ee05af7
+    commit: 9d845cbd5005b0683014c134f9c70b9117911379
     subdirs:
       - binary
       - binary/test


### PR DESCRIPTION
(also: https://github.com/input-output-hk/cardano-base/pull/41)

Previously, we used a division of types between `Block` and `ABlock ByteString` to ensure that we don't accidentally re-serialize previously deserialized bytes.

We can accomplish the same goal without this division by putting a lazy reference to a `ByteString` in the constructor for `Block`. For a `Block` constructed locally, this will point to a thunk with serialization logic. For a deserialized `Block`, this will point to the original bytes.

For a type that has gone through this change, we later "serialize" it by extracting the above reference.

This fails the round trip encoding tests because nested annotations aren't being constructed properly during the decoding when interacting with the previous scheme. If this change was propagated to the rest of the types that would be resolved.
