### PR TITLE
Make configGenesisData and configUTxOConfiguration fields strict

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -241,7 +241,10 @@ initialChainValidationState config = do
         $ configGenesisKeyHashes config
       , shSigningQueue = Empty
       }
-    , cvsPreviousHash   = Left $ configGenesisHash config
+      -- Ensure that we don't allow the internal value of this 'Left' to be
+      -- lazy as we want to ensure that the 'ChainValidationState' is always
+      -- in normal form.
+    , cvsPreviousHash   = Left $! configGenesisHash config
     , cvsUtxo           = genesisUtxo config
     , cvsUpdateState    = UPI.initialState config
     , cvsDelegationState = delegationState

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Config.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Config.hs
@@ -55,13 +55,13 @@ import Cardano.Crypto
 --------------------------------------------------------------------------------
 
 data Config = Config
-    { configGenesisData       :: GenesisData
+    { configGenesisData       :: !GenesisData
     -- ^ The data needed at genesis
-    , configGenesisHash       :: GenesisHash
+    , configGenesisHash       :: !GenesisHash
     -- ^ The hash of the canonical JSON representation of the 'GenesisData'
-    , configReqNetMagic       :: RequiresNetworkMagic
+    , configReqNetMagic       :: !RequiresNetworkMagic
     -- ^ Differentiates between Testnet and Mainet/Staging
-    , configUTxOConfiguration :: UTxOConfiguration
+    , configUTxOConfiguration :: !UTxOConfiguration
     -- ^ Extra local data used in UTxO validation rules
     }
 

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Data.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Data.hs
@@ -51,14 +51,14 @@ import Cardano.Crypto
 -- | Genesis data contains all data which determines consensus rules. It must be
 --   same for all nodes. It's used to initialize global state, slotting, etc.
 data GenesisData = GenesisData
-    { gdGenesisKeyHashes :: !GenesisKeyHashes
-    , gdHeavyDelegation  :: !GenesisDelegation
-    , gdStartTime        :: !UTCTime
-    , gdNonAvvmBalances  :: !GenesisNonAvvmBalances
+    { gdGenesisKeyHashes   :: !GenesisKeyHashes
+    , gdHeavyDelegation    :: !GenesisDelegation
+    , gdStartTime          :: !UTCTime
+    , gdNonAvvmBalances    :: !GenesisNonAvvmBalances
     , gdProtocolParameters :: !ProtocolParameters
-    , gdK                :: !BlockCount
-    , gdProtocolMagicId  :: !ProtocolMagicId
-    , gdAvvmDistr        :: !GenesisAvvmBalances
+    , gdK                  :: !BlockCount
+    , gdProtocolMagicId    :: !ProtocolMagicId
+    , gdAvvmDistr          :: !GenesisAvvmBalances
     } deriving (Show, Eq)
 
 instance Monad m => ToJSON m GenesisData where


### PR DESCRIPTION
_Somewhat related to #618_ 

It seems that after a call to `mkConfigFromFile` given the mainnet genesis config, both the `configGenesisData` and `configUTxOConfiguration` fields of the genesis `Config` are thunks. 

Because of this I've made these fields, as well as the others (since we don't require laziness here for any reason that I know of), strict in the `Config` data type.

### Before the Fix

- Notice that the `configGenesisData` field, the first heap object at level 1 of the tree, is a `ThunkClosure`. Also notice how it consists of further `ThunkClosure`s and `IndClosure`s. 

- Notice that the `configUTxOConfiguration` field, the last heap object at level 1 of the tree, is a `ThunkClosure` (I've also seen it allocated as an `IndClosure` before).

```
ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 4, nptrs = 0, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x000000420194fef8,0x000000420194ff38/1,0x000000000468f628/1,0x000000000456e498], dataArgs = [], pkg = "cardano-ledger-0.1.0.0-BZ3sG7KtG0uBft8EdU7TrW", modl = "Cardano.Chain.Genesis.Config", name = "Config"}
|
+- ThunkClosure {info = StgInfoTable {entry = Nothing, ptrs = 4, nptrs = 0, tipe = THUNK, srtlen = 71444960, code = Nothing}, ptrArgs = [0x0000004201951d08/3,0x0000004201951d48/1,0x0000004201951d68,0x0000004201951d90], dataArgs = []}
|  |
|  +- FunClosure {info = StgInfoTable {entry = Nothing, ptrs = 5, nptrs = 0, tipe = FUN, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004201952de8,0x0000004201952e18/1,0x0000004201952e58,0x0000004201952e88,0x0000004201952eb8], dataArgs = []}
|  |  |
|  |  +- ThunkClosure {info = StgInfoTable {entry = Nothing, ptrs = 2, nptrs = 0, tipe = THUNK_2_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000000004c0ae60/1,0x00000042019538f8], dataArgs = []}
|  |  |  |
|  |  |  +- FunClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = FUN_STATIC, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = []}
|  |  |  |
|  |  |  `- ThunkClosure {info = StgInfoTable {entry = Nothing, ptrs = 2, nptrs = 0, tipe = THUNK_2_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004202120230/1,0x0000004202120200], dataArgs = []}
|  |  |     |
|  |  |     +- FunClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = FUN_1_0, srtlen = 57763928, code = Nothing}, ptrArgs = [0x0000000004548ac8], dataArgs = []}
|  |  |     |  |
|  |  |     |  `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 8, nptrs = 0, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x0000000004548a98/1,0x0000000004548a08,0x00000000045489d8,0x00000000045489a8,0x0000000004548978,0x0000000004548948,0x0000000004548918,0x00000000045488e8], dataArgs = [], pkg = "ghc-prim", modl = "GHC.Classes", name = "C:Ord"}
|  |  |     |     |
|  |  |     |     +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 2, nptrs = 0, tipe = CONSTR_2_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000000004548a68,0x0000000004548a38], dataArgs = [], pkg = "ghc-prim", modl = "GHC.Classes", name = "C:Eq"}
|  |  |     |     |  |
|  |  |     |     |  +- IndClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = IND_STATIC, srtlen = 0, code = Nothing}, indirectee = 0x0000004201a49b58}
|  |  |     |     |  |  |
|  |  |     |     |  |  `- PAPClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = PAP, srtlen = 0, code = Nothing}, arity = 2, n_args = 0, fun = 0x0000004201a49e80/2, payload = []}
|  |  |     |     |  |     |
|  |  |     |     |  |     `- FunClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = FUN_0_1, srtlen = 63595544, code = Nothing}, ptrArgs = [], dataArgs = [2]}
|  |  |     |     |  |
|  |  |     |     |  `- ThunkClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = THUNK_STATIC, srtlen = 69374768, code = Nothing}, ptrArgs = [], dataArgs = []}
|  |  |     |     |
|  |  |     |     +- IndClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = IND_STATIC, srtlen = 0, code = Nothing}, indirectee = 0x0000004201a49150}
|  |  |     |     |  |
|  |  |     |     |  `- PAPClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = PAP, srtlen = 0, code = Nothing}, arity = 2, n_args = 0, fun = 0x0000004201a49498/2, payload = []}
|  |  |     |     |     |
|  |  |     |     |     `- FunClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = FUN_0_1, srtlen = 63596576, code = Nothing}, ptrArgs = [], dataArgs = [57]}
|  |  |     |     |
...
|
+- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004202cbc798], dataArgs = [], pkg = "basement-0.0.10-2z2JaOuy7fVLQL3Bi1dEbr", modl = "Basement.Block.Base", name = "Block"}
|  |
|  `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 32, arrWords = [2774925686062653535,6839600870320240897,1390964601859756722,13478873661184007191]}
|
+- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = [9736352], pkg = "cardano-crypto-wrapper-1.3.0-Pny10YO31o7mMW5tXaMkw", modl = "Cardano.Crypto.ProtocolMagic", name = "RequiresNoMagic"}
|
`- ThunkClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = THUNK_STATIC, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = []}
```

### After the Fix
`configGenesisData` is no longer a `ThunkClosure` and in WHNF.
`configUTxOConfiguration` is no longer a `ThunkClosure` and in WHNF. 
```
ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 4, nptrs = 0, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042ec830/1,0x00000042042ec888,0x000000000468dae8/1,0x0000000004c0ac40/2], dataArgs = [], pkg = "cardano-ledger-0.1.0.0-BZ3sG7KtG0uBft8EdU7TrW", modl = "Cardano.Chain.Genesis.Config", name = "Config"}
|
+- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 6, nptrs = 2, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042ec8c8/1,0x00000042042ec900/1,0x00000042042ec940/1,0x0000000004c0a0d0/2,0x00000042042ec968/1,0x00000042042ec9f0/1], dataArgs = [2160,764824073], pkg = "cardano-ledger-0.1.0.0-BZ3sG7KtG0uBft8EdU7TrW", modl = "Cardano.Chain.Genesis.Data", name = "GenesisData"}
|  |
|  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 3, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042eca30/1,0x00000042042eca50/1,0x00000042042eca88/1], dataArgs = [7], pkg = "containers-0.6.0.1", modl = "Data.Set.Internal", name = "Bin"}
|  |  |
|  |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042ed5c0], dataArgs = [], pkg = "basement-0.0.10-2z2JaOuy7fVLQL3Bi1dEbr", modl = "Basement.Block.Base", name = "Block"}
|  |  |  |
|  |  |  `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 28, arrWords = [6940823864025223508,9647857910648353176,11243983844099713174,2562979646]}
|  |  |
|  |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 3, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042ed600/1,0x00000042042ed620/1,0x00000042042ed658/1], dataArgs = [3], pkg = "containers-0.6.0.1", modl = "Data.Set.Internal", name = "Bin"}
|  |  |  |
|  |  |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042ef248], dataArgs = [], pkg = "basement-0.0.10-2z2JaOuy7fVLQL3Bi1dEbr", modl = "Basement.Block.Base", name = "Block"}
|  |  |  |
|  |  |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 3, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042ef288/1,0x0000000004c0ac40/2,0x0000000004c0ac40/2], dataArgs = [1], pkg = "containers-0.6.0.1", modl = "Data.Set.Internal", name = "Bin"}
|  |  |  |
|  |  |  `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 3, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042ef2a8/1,0x0000000004c0ac40/2,0x0000000004c0ac40/2], dataArgs = [1], pkg = "containers-0.6.0.1", modl = "Data.Set.Internal", name = "Bin"}
|  |  |
|  |  `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 3, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042ed690/1,0x00000042042ed6b0/1,0x00000042042ed6e8/1], dataArgs = [3], pkg = "containers-0.6.0.1", modl = "Data.Set.Internal", name = "Bin"}
|  |     |
|  |     +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042ef2c8], dataArgs = [], pkg = "basement-0.0.10-2z2JaOuy7fVLQL3Bi1dEbr", modl = "Basement.Block.Base", name = "Block"}
|  |     |
|  |     +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 3, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042ef308/1,0x0000000004c0ac40/2,0x0000000004c0ac40/2], dataArgs = [1], pkg = "containers-0.6.0.1", modl = "Data.Set.Internal", name = "Bin"}
|  |     |
|  |     `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 3, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042042ef328/1,0x0000000004c0ac40/2,0x0000000004c0ac40/2], dataArgs = [1], pkg = "containers-0.6.0.1", modl = "Data.Set.Internal", name = "Bin"}
|  |
...
|
+- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 32, arrWords = [2774925686062653535,6839600870320240897,1390964601859756722,13478873661184007191]}
|
+- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = [9745328], pkg = "cardano-crypto-wrapper-1.3.0-Pny10YO31o7mMW5tXaMkw", modl = "Cardano.Crypto.ProtocolMagic", name = "RequiresNoMagic"}
|
`- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 1, code = Nothing}, ptrArgs = [], dataArgs = [0], pkg = "containers-0.6.0.1", modl = "Data.Set.Internal", name = "Tip"}
```

Cool thing I just noticed while writing this up:

See how the heap object representation for the field `configGenesisHash` (the second heap object at level 1 of the tree) changed from
```
+- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004202cbc798], dataArgs = [], pkg = "basement-0.0.10-2z2JaOuy7fVLQL3Bi1dEbr", modl = "Basement.Block.Base", name = "Block"}
|  |
|  `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 32, arrWords = [2774925686062653535,6839600870320240897,1390964601859756722,13478873661184007191]}
```

to

```
+- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 32, arrWords = [2774925686062653535,6839600870320240897,1390964601859756722,13478873661184007191]}
```

Looks like GHC decided to unpack it because we specified it strict :smile: 