### PR TITLE
Integrate goblins into the conformance tests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -39,19 +39,19 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 458324852cd1b68bfff35f30ee3a1298b736f106
+  tag: 5fabb962689edd2cc0c6d0a0e382419a496d57fc
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 458324852cd1b68bfff35f30ee3a1298b736f106
+  tag: 5fabb962689edd2cc0c6d0a0e382419a496d57fc
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 458324852cd1b68bfff35f30ee3a1298b736f106
+  tag: 5fabb962689edd2cc0c6d0a0e382419a496d57fc
   subdir: byron/chain/executable-spec
 
 source-repository-package
@@ -63,4 +63,4 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/goblins
-  tag: b5e99cf153a3abb1b764f80095f6a930ba056048
+  tag: 545448938bf620bb2a25212e1686916cfa3acee9

--- a/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
@@ -102,6 +102,9 @@ fromBalances =
     . concat
     . fmap (fromTxOut . uncurry TxOut)
 
+-- | Construct a UTxO from a TxOut. This UTxO is a singleton with a TxIn that
+-- references an address constructed by hashing the TxOut address. This means
+-- it is not guaranteed (or likely) to be a real address.
 fromTxOut :: TxOut -> UTxO
 fromTxOut out = fromList [(TxInUtxo (coerce . hash $ txOutAddress out) 0, out)]
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Model.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Model.hs
@@ -88,6 +88,7 @@ import Ledger.Delegation
   , _dSEnvK
   , _dSEnvSlot
   , randomDCertGen
+  , tamperedDcerts
   )
 import Ledger.Update (tamperWithUpdateProposal, UPIREG, UPIEnv, tamperWithVotes, UPIState)
 import qualified Ledger.Update.Test as Update.Test
@@ -167,7 +168,7 @@ classifyTransactions =
 
 ts_prop_invalidDelegationCertificatesAreRejected :: TSProperty
 ts_prop_invalidDelegationCertificatesAreRejected =
-  invalidChainTracesAreRejected 300 delegationFailureProfile coverDelegationRegistration
+  invalidChainTracesAreRejected 300 delegationFailureProfile coverDcerts
   where
     delegationFailureProfile :: [(Int, SignalGenerator CHAIN)]
     delegationFailureProfile = [(1, invalidDelegationGen)]
@@ -182,8 +183,13 @@ ts_prop_invalidDelegationCertificatesAreRejected =
                 block
                 (\body -> body { Abstract._bDCerts = delegationCerts })
 
-            invalidDelegationCerts = Gen.list (Range.constant 0 10)
-                                              (randomDCertGen delegationEnv)
+            -- This chooses with even probability between manually tweaked
+            -- DCerts and goblin-tweaked ones.
+            invalidDelegationCerts = Gen.choice
+              [ Gen.list (Range.constant 0 10)
+                         (randomDCertGen delegationEnv)
+              , tamperedDcerts delegationEnv delegationSt
+              ]
               where
                 delegationEnv =
                   ( DSEnv
@@ -193,9 +199,16 @@ ts_prop_invalidDelegationCertificatesAreRejected =
                     , _dSEnvK = k
                     }
                   )
+                (_, _, _, _, delegationSt, _) = st
 
 
-    coverDelegationRegistration :: [[PredicateFailure CHAIN]]  -> ChainValidationError -> PropertyT IO ()
+    -- @mhueschen : this is lifted from adjacent coverage checkers and does not (at least intentionally)
+    -- address the TODOs listed below.
+    coverDcerts :: [[PredicateFailure CHAIN]]  -> ChainValidationError -> PropertyT IO ()
+    -- TODO: Establish a mapping between concrete and abstract errors. See 'coverDelegationRegistration'
+    coverDcerts abstractPfs _concretePfs =
+      Update.Test.coverDelegFailures 1 abstractPfs
+
     -- TODO: add coverage testing for delegation.
     --
     -- TODO: we could establish a mapping between concrete and abstract errors.
@@ -208,7 +221,6 @@ ts_prop_invalidDelegationCertificatesAreRejected =
     -- sure that the invalid generators cover a good deal of abstract
     -- errors permutations. So for instance, given abstract errors @X@,
     -- @Y@, and @Z@, we would want to generate all combinations of them.
-    coverDelegationRegistration _abstractPfs _concretePfs = pure ()
 
 
 -- | Test that the invalid chains that are generated according to the given

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
@@ -68,9 +68,9 @@ elaboratePParams pps = Concrete.ProtocolParameters
   , Concrete.ppUnlockStakeEpoch   = Concrete.EpochNumber maxBound
   }
 
-newtype FeeConstant = FeeConstant Int
+newtype FeeConstant = FeeConstant Abstract.FactorA
 
-newtype FeeCoefficient = FeeCoefficient Int
+newtype FeeCoefficient = FeeCoefficient Abstract.FactorB
 
 elaborateFeePolicy
   :: FeeConstant
@@ -78,9 +78,12 @@ elaborateFeePolicy
   -> Concrete.TxFeePolicy
 -- TODO: we should pass the factors wrapped in some type, to avoid errors
 -- resulting from mixing the order of these parameters.
-elaborateFeePolicy (FeeConstant a) (FeeCoefficient b) =
+elaborateFeePolicy feeConst feeCoeff =
   Concrete.TxFeePolicyTxSizeLinear $ Concrete.TxSizeLinear aC bC
   where
+    FeeConstant (Abstract.FactorA a) = feeConst
+    FeeCoefficient (Abstract.FactorB b) = feeCoeff
+
     aC = intToLovelace a
     bC = intToLovelace
        $ floor

--- a/nix/.stack.nix/cs-blockchain.nix
+++ b/nix/.stack.nix/cs-blockchain.nix
@@ -50,8 +50,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "458324852cd1b68bfff35f30ee3a1298b736f106";
-      sha256 = "1if2pjxwzj30cad97i1mmxdi5d6x627dqhvg10m46fz3lsbr3fg6";
+      rev = "5fabb962689edd2cc0c6d0a0e382419a496d57fc";
+      sha256 = "0fzhsfkbqpyvwck6jmzasm5q7x5saxypb9v5gy5rq6f5cd6c6c10";
       });
     postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -21,6 +21,7 @@
           (hsPkgs.bimap)
           (hsPkgs.containers)
           (hsPkgs.filepath)
+          (hsPkgs.file-embed)
           (hsPkgs.goblins)
           (hsPkgs.hashable)
           (hsPkgs.hedgehog)
@@ -67,8 +68,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "458324852cd1b68bfff35f30ee3a1298b736f106";
-      sha256 = "1if2pjxwzj30cad97i1mmxdi5d6x627dqhvg10m46fz3lsbr3fg6";
+      rev = "5fabb962689edd2cc0c6d0a0e382419a496d57fc";
+      sha256 = "0fzhsfkbqpyvwck6jmzasm5q7x5saxypb9v5gy5rq6f5cd6c6c10";
       });
     postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/goblins.nix
+++ b/nix/.stack.nix/goblins.nix
@@ -50,7 +50,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/goblins";
-      rev = "b5e99cf153a3abb1b764f80095f6a930ba056048";
-      sha256 = "14iac7x5d1akd96j2w0m8jg24qhgshyc8m9ljqs8bw73kaiqszzx";
+      rev = "545448938bf620bb2a25212e1686916cfa3acee9";
+      sha256 = "1b9whagxvspzmll7b63ilxvbdq2ha3fkcfmgjnlpn4b939fgpclm";
       });
     }

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -65,8 +65,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "458324852cd1b68bfff35f30ee3a1298b736f106";
-      sha256 = "1if2pjxwzj30cad97i1mmxdi5d6x627dqhvg10m46fz3lsbr3fg6";
+      rev = "5fabb962689edd2cc0c6d0a0e382419a496d57fc";
+      sha256 = "0fzhsfkbqpyvwck6jmzasm5q7x5saxypb9v5gy5rq6f5cd6c6c10";
       });
     postUnpack = "sourceRoot+=/byron/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -27,7 +27,7 @@ extra-deps:
       - binary/test
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 458324852cd1b68bfff35f30ee3a1298b736f106
+    commit: 5fabb962689edd2cc0c6d0a0e382419a496d57fc
     subdirs:
       - byron/semantics/executable-spec
       - byron/ledger/executable-spec
@@ -35,7 +35,7 @@ extra-deps:
 
   # Needed for `cardano-ledger-specs`
   - git: https://github.com/input-output-hk/goblins
-    commit: b5e99cf153a3abb1b764f80095f6a930ba056048
+    commit: 545448938bf620bb2a25212e1686916cfa3acee9
   - moo-1.2
   - gray-code-0.3.1
 


### PR DESCRIPTION
We add a `ts_prop_invalidTxWitsAreRejected` conformance property to `Test.Cardano.Chain.Block.Model`. Adding this property required reworking of a number of types in `cardano-ledger-specs` to capture bounds which were not previously "knowable" from the type of the value.

***

This relates to https://github.com/input-output-hk/cardano-ledger-specs/issues/788 & https://github.com/input-output-hk/cardano-ledger-specs/issues/817.