### PR TITLE
Ensure that GenesisAvvmBalances Map returned by fromJSON is strict

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Genesis/AvvmBalances.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/AvvmBalances.hs
@@ -10,8 +10,10 @@ module Cardano.Chain.Genesis.AvvmBalances
   )
 where
 
-import Cardano.Prelude
+import Cardano.Prelude hiding (toStrict)
+import Prelude (id)
 
+import Data.Map.Strict as Map
 import Text.JSON.Canonical (FromJSON(..), ToJSON(..))
 
 import Cardano.Chain.Common (Lovelace)
@@ -29,5 +31,19 @@ instance Monad m => ToJSON m GenesisAvvmBalances where
     toJSON = toJSON . unGenesisAvvmBalances
 
 instance MonadError SchemaError m => FromJSON m GenesisAvvmBalances where
-    fromJSON = fmap GenesisAvvmBalances . fromJSON
-
+    -- | Unfortunately, because @canonical-json@ doesn't utilize operations from
+    -- "Data.Map.Strict" but only those from "Data.Map.Lazy" (i.e. 'fromJSON'
+    -- will return a 'Map' that is not necessarily strict in its values), we
+    -- need to be careful in order to ensure that we're still dealing with a
+    -- 'Map' that's strict in both its keys and values.
+    --
+    -- To remedy this, we use @Map.map id@ to convert the 'Map'
+    -- to one that is now guaranteed to be strict in both its keys and values.
+    --
+    -- n.b. both the strict and lazy 'Map' modules utilize the same 'Map' data
+    -- type which is what makes something like this possible.
+    fromJSON = fmap (GenesisAvvmBalances . toStrict) . fromJSON
+     where
+      -- | /O(n)/. Ensures that all values in the given 'Map' are in WHNF.
+      toStrict :: Map k a -> Map k a
+      toStrict = Map.map id


### PR DESCRIPTION
_Somewhat related to #618_ 

Unfortunately, because `canonical-json` doesn't utilize operations from `Data.Map.Strict` but only those from `Data.Map.Lazy` (i.e. `fromJSON` will return a `Map` that is not necessarily strict in its values), we need to be careful in order to ensure that we're still dealing with a `Map` that's strict in both its keys and values.

To remedy this, I've used `Map.map (\a -> seq a a)` to convert the `Map` to one that is now guaranteed to be strict in both its keys and values.

### Before the Fix

- Notice that the `gdAvvmDistr` field, the last heap object at level 1 of the tree, is a `ConstrClosure` which represents the `Bin` constructor from `Data.Map`. This would make sense since `GenesisAvvmBalances` is a simple newtype wrapper around a `Map RedeemVerificationKey Lovelace`. Notice how the `Bin` `ConstrClosure`'s second pointer (an actual value of the `Data.Map`) references a `ThunkClosure`.

_n.b. The second pointer of a `Bin` is actually the value field of an entry in the `Map`. So, in this case, it should be a `Lovelace` which, in WHNF, would be represented by a `W64#` `ConstrClosure` since `Lovelace` is a newtype wrapper around a `Word64`._

```
ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 6, nptrs = 2, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004205caa788/1,0x0000004205caa7c0/1,0x0000004205caa800/1,0x0000000004c07e90/2,0x0000004205caa828/1,0x0000004205caa8b0/1], dataArgs = [2160,764824073], pkg = "cardano-ledger-0.1.0.0-BZ3sG7KtG0uBft8EdU7TrW", modl = "Cardano.Chain.Genesis.Data", name = "GenesisData"}
|
+- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 3, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x000000420591be40/1,0x000000420591be60/1,0x000000420591be98/1], dataArgs = [7], pkg = "containers-0.6.0.1", modl = "Data.Set.Internal", name = "Bin"}
|  |
|  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004209ba01d8], dataArgs = [], pkg = "basement-0.0.10-2z2JaOuy7fVLQL3Bi1dEbr", modl = "Basement.Block.Base", name = "Block"}
|  |  |
|  |  `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 28, arrWords = [6940823864025223508,9647857910648353176,11243983844099713174,2562979646]}
|  |
...
|
`- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 4, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x000000420591c0f8/1,0x000000420591c118,0x000000420591c148/1,0x000000420591c188/1], dataArgs = [14505], pkg = "containers-0.6.0.1", modl = "Data.Map.Internal", name = "Bin"}
   |
   +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004202051b60], dataArgs = [], pkg = "memory-0.14.18-9xbpIkcWqsAKLVYhB0lpFa", modl = "Data.ByteArray.Bytes", name = "Bytes"}
   |  |
   |  `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 32, arrWords = [15456467899171930999,9418975410085355951,18121813647148405468,9414897718255952643]}
   |
   +- ThunkClosure {info = StgInfoTable {entry = Nothing, ptrs = 2, nptrs = 0, tipe = THUNK_2_0, srtlen = 0, code = Nothing}, ptrArgs = [0x000000000454ba20/1,0x000000420591cad8], dataArgs = []}
   |  |
   |  +- FunClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = FUN_STATIC, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = []}
   |  |
   |  `- ThunkClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = THUNK_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x000000420591d628], dataArgs = []}
   |     |
   |     `- ThunkClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = THUNK_1_0, srtlen = 15256784, code = Nothing}, ptrArgs = [0x000000420591e000/2], dataArgs = []}
   |        |
   |        `- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 2, nptrs = 0, tipe = CONSTR_2_0, srtlen = 1, code = Nothing}, ptrArgs = [0x0000000004c54f90/1,0x000000420591ecd8/2], dataArgs = [], pkg = "ghc-prim", modl = "GHC.Types", name = ":"}
   |           |
   |           +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = [5], pkg = "ghc-prim", modl = "GHC.Types", name = "I#"}
   |           |
...
```

### After the Fix

- `gdAvvmDistr ` is no longer a `ThunkClosure` and in WHNF.

```
ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 6, nptrs = 2, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042051ca510/1,0x00000042051ca548/1,0x00000042051ca588/1,0x0000000004c0a050/2,0x00000042051ca5b0/1,0x00000042051ca638/1], dataArgs = [2160,764824073], pkg = "cardano-ledger-0.1.0.0-BZ3sG7KtG0uBft8EdU7TrW", modl = "Cardano.Chain.Genesis.Data", name = "GenesisData"}
|
+- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 3, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x000000420512e0e0/1,0x000000420512e100/1,0x000000420512e138/1], dataArgs = [7], pkg = "containers-0.6.0.1", modl = "Data.Set.Internal", name = "Bin"}
|  |
|  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x000000420512f398], dataArgs = [], pkg = "basement-0.0.10-2z2JaOuy7fVLQL3Bi1dEbr", modl = "Basement.Block.Base", name = "Block"}
|  |  |
|  |  `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 28, arrWords = [6940823864025223508,9647857910648353176,11243983844099713174,2562979646]}
|  |
...
|
`- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 4, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x000000420512e398/1,0x000000420512e3b8/1,0x000000420512e3d8/1,0x00000042051cb120/1], dataArgs = [14505], pkg = "containers-0.6.0.1", modl = "Data.Map.Internal", name = "Bin"}
   |
   +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004201765360], dataArgs = [], pkg = "memory-0.14.18-9xbpIkcWqsAKLVYhB0lpFa", modl = "Data.ByteArray.Bytes", name = "Bytes"}
   |  |
   |  `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 32, arrWords = [18389174306018748305,12460601851050031187,1406475198976468069,14715957744570358777]}
   |
   +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = [416666000000], pkg = "base", modl = "GHC.Word", name = "W64#"}
   |
   +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 4, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x000000420512f7e8/1,0x000000420512f808/1,0x000000420512f828/1,0x000000420512f868/1], dataArgs = [8191], pkg = "containers-0.6.0.1", modl = "Data.Map.Internal", name = "Bin"}
   |  |
   |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004200d16590], dataArgs = [], pkg = "memory-0.14.18-9xbpIkcWqsAKLVYhB0lpFa", modl = "Data.ByteArray.Bytes", name = "Bytes"}
   |  |  |
   |  |  `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 32, arrWords = [5434474977359176009,7656875826589110786,9174028477855385939,12552765699850477028]}
   |  |
   |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = [468609000000], pkg = "base", modl = "GHC.Word", name = "W64#"}
   |  |
   |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 4, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004205bdcfb8/1,0x0000004205bdcfd8/1,0x0000004205bdd000/1,0x0000004205bdd040/1], dataArgs = [4095], pkg = "containers-0.6.0.1", modl = "Data.Map.Internal", name = "Bin"}
   |  |  |
   |  |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 1, nptrs = 0, tipe = CONSTR_1_0, srtlen = 0, code = Nothing}, ptrArgs = [0x00000042027134f0], dataArgs = [], pkg = "memory-0.14.18-9xbpIkcWqsAKLVYhB0lpFa", modl = "Data.ByteArray.Bytes", name = "Bytes"}
   |  |  |  |
   |  |  |  `- ArrWordsClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 0, tipe = ARR_WORDS, srtlen = 0, code = Nothing}, bytes = 32, arrWords = [13797890526598118180,6120706604010321561,11027120432462578399,2937647612198474935]}
   |  |  |
   |  |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 0, nptrs = 1, tipe = CONSTR_0_1, srtlen = 0, code = Nothing}, ptrArgs = [], dataArgs = [385509000000], pkg = "base", modl = "GHC.Word", name = "W64#"}
   |  |  |
   |  |  +- ConstrClosure {info = StgInfoTable {entry = Nothing, ptrs = 4, nptrs = 1, tipe = CONSTR, srtlen = 0, code = Nothing}, ptrArgs = [0x0000004205bdd668/1,0x0000004205bdd688/1,0x0000004205bdd6a8/1,0x0000004205bdd6e8/1], dataArgs = [2047], pkg = "containers-0.6.0.1", modl = "Data.Map.Internal", name = "Bin"}
   |  |  |  |
...
```