### PR TITLE
Add CompactRedeemVerificationKey

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Genesis/AvvmBalances.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/AvvmBalances.hs
@@ -15,14 +15,14 @@ import Cardano.Prelude
 import Text.JSON.Canonical (FromJSON(..), ToJSON(..))
 
 import Cardano.Chain.Common (Lovelace)
-import Cardano.Crypto.Signing.Redeem (RedeemVerificationKey)
+import Cardano.Crypto.Signing.Redeem (CompactRedeemVerificationKey)
 
 
 -- | Predefined balances of AVVM (Ada Voucher Vending Machine) entries.
 -- People who purchased Ada at a pre-sale were issued a certificate during
 -- the pre-sale period. These certificates allow customers to redeem ADA.
 newtype GenesisAvvmBalances = GenesisAvvmBalances
-  { unGenesisAvvmBalances :: Map RedeemVerificationKey Lovelace
+  { unGenesisAvvmBalances :: Map CompactRedeemVerificationKey Lovelace
   } deriving (Show, Eq, Semigroup, NoUnexpectedThunks)
 
 instance Monad m => ToJSON m GenesisAvvmBalances where

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
@@ -80,6 +80,7 @@ import Cardano.Crypto
   , noPassSafeSigner
   , redeemDeterministicKeyGen
   , safeKeyGen
+  , toCompactRedeemVerificationKey
   , toVerification
   )
 
@@ -207,7 +208,9 @@ generateGenesisData startTime genesisSpec = do
 
   -- Fake AVVM Balances
   fakeAvvmVerificationKeys <-
-    mapM (maybe (throwError GenesisDataGenerationRedeemKeyGen) (pure . fst))
+    mapM
+      (maybe (throwError GenesisDataGenerationRedeemKeyGen)
+             (pure . toCompactRedeemVerificationKey . fst))
       $ fmap redeemDeterministicKeyGen (gsFakeAvvmSeeds generatedSecrets)
   let
     fakeAvvmDistr = GenesisAvvmBalances . M.fromList $ map

--- a/cardano-ledger/src/Cardano/Chain/UTxO/GenesisUTxO.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/GenesisUTxO.hs
@@ -13,6 +13,7 @@ import Cardano.Chain.Genesis (unGenesisAvvmBalances, unGenesisNonAvvmBalances)
 import qualified Cardano.Chain.Genesis as Genesis
 import Cardano.Chain.UTxO.UTxO (UTxO)
 import qualified Cardano.Chain.UTxO.UTxO as UTxO
+import Cardano.Crypto (fromCompactRedeemVerificationKey)
 
 
 -- | Create initial 'UTxO' from balances defined in the genesis config
@@ -23,7 +24,8 @@ genesisUtxo config = UTxO.fromBalances balances
   balances = avvmBalances <> nonAvvmBalances
 
   avvmBalances :: [(Address, Lovelace)]
-  avvmBalances = first (makeRedeemAddress networkMagic)
+  avvmBalances =
+    first (makeRedeemAddress networkMagic . fromCompactRedeemVerificationKey)
     <$> M.toList (unGenesisAvvmBalances $ Genesis.configAvvmDistr config)
 
   networkMagic :: NetworkMagic

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
@@ -45,10 +45,11 @@ import Cardano.Chain.Slotting (EpochNumber(..))
 import Cardano.Crypto
   ( AProtocolMagic(..)
   , ProtocolMagicId(..)
+  , CompactRedeemVerificationKey
   , RequiresNetworkMagic(..)
-  , RedeemVerificationKey
   , Signature(..)
   , redeemDeterministicKeyGen
+  , toCompactRedeemVerificationKey
   )
 import Cardano.Crypto.Signing (VerificationKey(..))
 import qualified Cardano.Crypto.Wallet as CC
@@ -74,12 +75,12 @@ exampleGenesisSpec = UnsafeGenesisSpec
 
 exampleGenesisAvvmBalances :: GenesisAvvmBalances
 exampleGenesisAvvmBalances = GenesisAvvmBalances $ M.fromList
-  [ (exampleRedeemVerificationKey' (0, 32) , mkKnownLovelace @36524597913081152)
-  , (exampleRedeemVerificationKey' (32, 32), mkKnownLovelace @37343863242999412)
+  [ (exampleCompactRVK' (0, 32) , mkKnownLovelace @36524597913081152)
+  , (exampleCompactRVK' (32, 32), mkKnownLovelace @37343863242999412)
   ]
  where
-  exampleRedeemVerificationKey' :: (Int, Int) -> RedeemVerificationKey
-  exampleRedeemVerificationKey' (m, n) =
+  exampleCompactRVK' :: (Int, Int) -> CompactRedeemVerificationKey
+  exampleCompactRVK' (m, n) = toCompactRedeemVerificationKey $
     fromJust (fst <$> redeemDeterministicKeyGen (getBytes m n))
 
 exampleGenesisData0 :: GenesisData

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Gen.hs
@@ -55,7 +55,7 @@ import Test.Cardano.Chain.Update.Gen
 import Test.Cardano.Crypto.Gen
   ( genProtocolMagic
   , genProtocolMagicId
-  , genRedeemVerificationKey
+  , genCompactRedeemVerificationKey
   , genTextHash
   )
 
@@ -143,7 +143,8 @@ genTestnetBalanceOptions =
 
 genGenesisAvvmBalances :: Gen GenesisAvvmBalances
 genGenesisAvvmBalances =
-  GenesisAvvmBalances <$> customMapGen genRedeemVerificationKey genLovelace
+  GenesisAvvmBalances
+    <$> customMapGen genCompactRedeemVerificationKey genLovelace
 
 genGenesisKeyHashes :: Gen GenesisKeyHashes
 genGenesisKeyHashes =

--- a/crypto/cardano-crypto-wrapper.cabal
+++ b/crypto/cardano-crypto-wrapper.cabal
@@ -101,6 +101,7 @@ test-suite test
                        Test.Cardano.Crypto.Orphans
                        Test.Cardano.Crypto.Random
                        Test.Cardano.Crypto.Signing.Redeem
+                       Test.Cardano.Crypto.Signing.Redeem.Compact
                        Test.Cardano.Crypto.Signing.Safe
                        Test.Cardano.Crypto.Signing.Signing
 

--- a/crypto/cardano-crypto-wrapper.cabal
+++ b/crypto/cardano-crypto-wrapper.cabal
@@ -41,10 +41,11 @@ library
                        Cardano.Crypto.Signing.SigningKey
                        Cardano.Crypto.Signing.Signature
 
+                       Cardano.Crypto.Signing.Redeem.Compact
                        Cardano.Crypto.Signing.Redeem.KeyGen
-                       Cardano.Crypto.Signing.Redeem.VerificationKey
                        Cardano.Crypto.Signing.Redeem.SigningKey
                        Cardano.Crypto.Signing.Redeem.Signature
+                       Cardano.Crypto.Signing.Redeem.VerificationKey
 
                        Cardano.Crypto.Signing.Safe.EncryptedSigningKey
                        Cardano.Crypto.Signing.Safe.KeyGen
@@ -55,6 +56,7 @@ library
                      , aeson
                      , base64-bytestring
                      , base64-bytestring-type
+                     , binary
                      , bytestring
                      , canonical-json
                      , cardano-binary

--- a/crypto/src/Cardano/Crypto/Signing/Redeem.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Redeem.hs
@@ -3,6 +3,7 @@ module Cardano.Crypto.Signing.Redeem
   )
 where
 
+import Cardano.Crypto.Signing.Redeem.Compact as X
 import Cardano.Crypto.Signing.Redeem.KeyGen as X
 import Cardano.Crypto.Signing.Redeem.VerificationKey as X
 import Cardano.Crypto.Signing.Redeem.SigningKey as X

--- a/crypto/src/Cardano/Crypto/Signing/Redeem/Compact.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Redeem/Compact.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -45,6 +46,7 @@ data CompactRedeemVerificationKey =
                                {-# UNPACK #-} !Word64
                                {-# UNPACK #-} !Word64
   deriving (Eq, Generic, Show)
+  deriving NoUnexpectedThunks via UseIsNormalForm CompactRedeemVerificationKey
   deriving anyclass NFData
 
 getCompactRedeemVerificationKey :: Get CompactRedeemVerificationKey

--- a/crypto/src/Cardano/Crypto/Signing/Redeem/VerificationKey.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Redeem/VerificationKey.hs
@@ -16,6 +16,7 @@ module Cardano.Crypto.Signing.Redeem.VerificationKey
   , redeemVKB64UrlF
   , redeemVKB64ShortF
   , fromAvvmVK
+  , fromVerificationKeyToByteString
   , redeemVKBuild
   )
 where

--- a/crypto/test/Test/Cardano/Crypto/Gen.hs
+++ b/crypto/test/Test/Cardano/Crypto/Gen.hs
@@ -17,6 +17,7 @@ module Test.Cardano.Crypto.Gen
   -- * Redeem Key Generators
   , genRedeemKeypair
   , genRedeemVerificationKey
+  , genCompactRedeemVerificationKey
   , genRedeemSigningKey
 
   -- * Signature Generators
@@ -78,11 +79,13 @@ import Cardano.Crypto.Signing
   , signRaw
   )
 import Cardano.Crypto.Signing.Redeem
-  ( RedeemVerificationKey
+  ( CompactRedeemVerificationKey
+  , RedeemVerificationKey
   , RedeemSigningKey
   , RedeemSignature
   , redeemDeterministicKeyGen
   , redeemSign
+  , toCompactRedeemVerificationKey
   )
 import Test.Cardano.Crypto.Orphans ()
 
@@ -152,6 +155,10 @@ genRedeemKeypair = Gen.just $ redeemDeterministicKeyGen <$> gen32Bytes
 
 genRedeemVerificationKey :: Gen RedeemVerificationKey
 genRedeemVerificationKey = fst <$> genRedeemKeypair
+
+genCompactRedeemVerificationKey :: Gen CompactRedeemVerificationKey
+genCompactRedeemVerificationKey =
+  toCompactRedeemVerificationKey <$> genRedeemVerificationKey
 
 genRedeemSigningKey :: Gen RedeemSigningKey
 genRedeemSigningKey = snd <$> genRedeemKeypair

--- a/crypto/test/Test/Cardano/Crypto/Signing/Redeem/Compact.hs
+++ b/crypto/test/Test/Cardano/Crypto/Signing/Redeem/Compact.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cardano.Crypto.Signing.Redeem.Compact
+  ( tests
+  )
+where
+
+import Cardano.Prelude
+import Test.Cardano.Prelude
+
+import Hedgehog (MonadTest, Property, checkParallel, tripping)
+
+import Cardano.Crypto.Signing.Redeem
+  (fromCompactRedeemVerificationKey, toCompactRedeemVerificationKey)
+
+import Test.Cardano.Crypto.Gen (genRedeemVerificationKey)
+
+--------------------------------------------------------------------------------
+-- Compact RedeemVerificationKey
+--------------------------------------------------------------------------------
+
+roundTripCompactRedeemVerificationKey :: Property
+roundTripCompactRedeemVerificationKey =
+  eachOf
+    1000
+    genRedeemVerificationKey
+    (trippingCompact toCompactRedeemVerificationKey fromCompactRedeemVerificationKey)
+
+-------------------------------------------------------------------------------
+-- Tripping util
+-------------------------------------------------------------------------------
+
+trippingCompact
+  :: (HasCallStack, MonadTest m, Show a, Show b, Eq a)
+  => (a -> b) -> (b -> a) -> a -> m ()
+trippingCompact toCompact fromCompact x =
+  tripping x toCompact (Identity . fromCompact)
+
+-------------------------------------------------------------------------------
+-- Main test export
+-------------------------------------------------------------------------------
+
+tests :: IO Bool
+tests = checkParallel $$discoverRoundTrip

--- a/crypto/test/test.hs
+++ b/crypto/test/test.hs
@@ -9,6 +9,7 @@ import qualified Test.Cardano.Crypto.Limits
 import qualified Test.Cardano.Crypto.Keys
 import qualified Test.Cardano.Crypto.Random
 import qualified Test.Cardano.Crypto.Signing.Redeem
+import qualified Test.Cardano.Crypto.Signing.Redeem.Compact
 import qualified Test.Cardano.Crypto.Signing.Safe
 import qualified Test.Cardano.Crypto.Signing.Signing
 
@@ -24,6 +25,7 @@ main = runTests
   , Test.Cardano.Crypto.Limits.tests
   , Test.Cardano.Crypto.Random.tests
   , Test.Cardano.Crypto.Signing.Redeem.tests
+  , Test.Cardano.Crypto.Signing.Redeem.Compact.tests
   , Test.Cardano.Crypto.Signing.Safe.tests
   , Test.Cardano.Crypto.Signing.Signing.tests
   ]

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -21,6 +21,7 @@
           (hsPkgs.aeson)
           (hsPkgs.base64-bytestring)
           (hsPkgs.base64-bytestring-type)
+          (hsPkgs.binary)
           (hsPkgs.bytestring)
           (hsPkgs.canonical-json)
           (hsPkgs.cardano-binary)


### PR DESCRIPTION
Related to #618.

This implementation of `RedeemVerificationKey` reduces the memory usage of loading the mainnet `Genesis.Config` from around ~45MB to ~15MB:

![visualization_compactredeemverificationkey](https://user-images.githubusercontent.com/19835357/65299071-f9158000-db3b-11e9-9312-52f56965c953.png)