### PR TITLE
Update monitoring dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -58,7 +58,7 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   contra-tracer
-  tag: e22be186e0b1018260ed7c5166871f82a869b94d
+  tag: 1ebe57df3a76a8ae4e3b5a31a9b85132f71534fc
 
 source-repository-package
   type: git

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "e22be186e0b1018260ed7c5166871f82a869b94d";
-      sha256 = "1nihpxmkhlhx3sfnwxprhfa0f70rc97zkvhd66hl3wcifgjp40aj";
+      rev = "1ebe57df3a76a8ae4e3b5a31a9b85132f71534fc";
+      sha256 = "0vwl94sda973009746n3l5n8kjlr6fajrazg7sya8plpm4x9v12l";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: e22be186e0b1018260ed7c5166871f82a869b94d
+    commit: 1ebe57df3a76a8ae4e3b5a31a9b85132f71534fc
     subdirs:
       - contra-tracer
 


### PR DESCRIPTION
testing the impact of breaking changes in iohk-monitoring-framework: this repo only references the 'contra-tracer' package, so should be safe.

