### PR TITLE
Add CertificateId and VoteId data types

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
@@ -17,6 +17,7 @@ module Cardano.Chain.Delegation.Certificate
   -- * Certificate
     Certificate
   , ACertificate(..)
+  , CertificateId
 
   -- * Certificate Constructors
   , signCertificate
@@ -24,6 +25,7 @@ module Cardano.Chain.Delegation.Certificate
 
   -- * Certificate Accessor
   , epoch
+  , certificateId
 
   -- * Certificate Predicate
   , isValid
@@ -51,11 +53,13 @@ import Cardano.Binary
   )
 import Cardano.Chain.Slotting (EpochNumber)
 import Cardano.Crypto
-  ( ProtocolMagicId
+  ( Hash
+  , ProtocolMagicId
   , SafeSigner
   , SignTag(SignCertificate)
   , Signature
   , VerificationKey(unVerificationKey)
+  , hash
   , safeSign
   , safeToVerification
   , verifySignatureDecoded
@@ -65,6 +69,9 @@ import Cardano.Crypto
 --------------------------------------------------------------------------------
 -- Certificate
 --------------------------------------------------------------------------------
+
+-- | A delegation certificate identifier (the 'Hash' of a 'Certificate').
+type CertificateId = Hash Certificate
 
 type Certificate = ACertificate ()
 
@@ -129,6 +136,9 @@ unsafeCertificate e = UnsafeACertificate (Annotated e ())
 
 epoch :: ACertificate a -> EpochNumber
 epoch = unAnnotated . aEpoch
+
+certificateId :: ACertificate a -> CertificateId
+certificateId = hash . void
 
 
 --------------------------------------------------------------------------------

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Interface.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Interface.hs
@@ -115,8 +115,9 @@ initialState env genesisDelegation = updateDelegation env' is certificates
   annotateCertificate :: Certificate -> ACertificate ByteString
   annotateCertificate c = c
     { Delegation.aEpoch = Annotated
-      (Delegation.epoch c)
-      (serialize' $ Delegation.epoch c)
+        (Delegation.epoch c)
+        (serialize' $ Delegation.epoch c)
+    , Delegation.annotation = serialize' c
     }
 
 

--- a/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
@@ -14,6 +14,7 @@ module Cardano.Chain.Update.Vote
   -- * Vote
     AVote(..)
   , Vote
+  , VoteId
 
   -- * Vote Constructors
   , mkVote
@@ -23,6 +24,7 @@ module Cardano.Chain.Update.Vote
 
   -- * Vote Accessors
   , proposalId
+  , voteId
 
   -- * Vote Binary Serialization
   , recoverSignedBytes
@@ -51,12 +53,14 @@ import Cardano.Binary
 import Cardano.Chain.Common (addressHash)
 import Cardano.Chain.Update.Proposal (Proposal, UpId)
 import Cardano.Crypto
-  ( ProtocolMagicId
+  ( Hash
+  , ProtocolMagicId
   , VerificationKey
   , SafeSigner
   , SigningKey
   , SignTag(SignUSVote)
   , Signature
+  , hash
   , safeSign
   , safeToVerification
   , shortHashF
@@ -68,6 +72,9 @@ import Cardano.Crypto
 --------------------------------------------------------------------------------
 -- Vote
 --------------------------------------------------------------------------------
+
+-- | An update proposal vote identifier (the 'Hash' of a 'Vote').
+type VoteId = Hash Vote
 
 type Vote = AVote ()
 
@@ -152,6 +159,9 @@ unsafeVote vk upId voteSignature =
 
 proposalId :: AVote a -> UpId
 proposalId = unAnnotated . aProposalId
+
+voteId :: AVote a -> VoteId
+voteId = hash . void
 
 
 --------------------------------------------------------------------------------

--- a/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
@@ -25,6 +25,7 @@ module Cardano.Chain.Update.Vote
   -- * Vote Accessors
   , proposalId
   , voteId
+  , recoverVoteId
 
   -- * Vote Binary Serialization
   , recoverSignedBytes
@@ -42,14 +43,17 @@ import Formatting (Format, bprint, build, later)
 import qualified Formatting.Buildable as B
 
 import Cardano.Binary
-  ( Annotated(..)
+  ( Annotated(Annotated, unAnnotated)
   , ByteSpan
+  , Decoded(..)
   , FromCBOR(..)
   , ToCBOR(..)
+  , annotatedDecoder
   , fromCBORAnnotated
   , encodeListLen
   , enforceSize
   )
+import qualified Cardano.Binary as Binary (annotation)
 import Cardano.Chain.Common (addressHash)
 import Cardano.Chain.Update.Proposal (Proposal, UpId)
 import Cardano.Crypto
@@ -61,6 +65,7 @@ import Cardano.Crypto
   , SignTag(SignUSVote)
   , Signature
   , hash
+  , hashDecoded
   , safeSign
   , safeToVerification
   , shortHashF
@@ -88,6 +93,7 @@ data AVote a = UnsafeVote
   -- ^ Proposal to which this vote applies
   , signature   :: !(Signature (UpId, Bool))
   -- ^ Signature of (Update proposal, Approval/rejection bit)
+  , annotation  :: !a
   } deriving (Eq, Show, Generic, Functor)
     deriving anyclass NFData
 
@@ -110,6 +116,7 @@ mkVote pm sk upId decision = UnsafeVote
   (toVerification sk)
   (Annotated upId ())
   (sign pm SignUSVote sk (upId, decision))
+  ()
 
 
 -- | Create a vote for the given update proposal id, signing it with the
@@ -150,7 +157,7 @@ unsafeVote
   -> Signature (UpId, Bool)
   -> Vote
 unsafeVote vk upId voteSignature =
-  UnsafeVote vk (Annotated upId ()) voteSignature
+  UnsafeVote vk (Annotated upId ()) voteSignature ()
 
 
 --------------------------------------------------------------------------------
@@ -162,6 +169,9 @@ proposalId = unAnnotated . aProposalId
 
 voteId :: AVote a -> VoteId
 voteId = hash . void
+
+recoverVoteId :: AVote ByteString -> VoteId
+recoverVoteId = hashDecoded
 
 
 --------------------------------------------------------------------------------
@@ -185,13 +195,19 @@ instance FromCBOR Vote where
 
 instance FromCBOR (AVote ByteSpan) where
   fromCBOR = do
-    enforceSize "Vote" 4
-    voterVK     <- fromCBOR
-    aProposalId <- fromCBORAnnotated
-    -- Drop the decision bit that previously allowed negative voting
-    void $ fromCBOR @Bool
-    signature <- fromCBOR
-    pure $ UnsafeVote { voterVK, aProposalId, signature }
+    Annotated (voterVK, aProposalId, signature) byteSpan <- annotatedDecoder $ do
+      enforceSize "Vote" 4
+      voterVK     <- fromCBOR
+      aProposalId <- fromCBORAnnotated
+      -- Drop the decision bit that previously allowed negative voting
+      void $ fromCBOR @Bool
+      signature <- fromCBOR
+      pure (voterVK, aProposalId, signature)
+    pure $ UnsafeVote voterVK aProposalId signature byteSpan
+
+instance Decoded (AVote ByteString) where
+  type BaseType (AVote ByteString) = Vote
+  recoverBytes = annotation
 
 recoverSignedBytes :: AVote ByteString -> Annotated (UpId, Bool) ByteString
 recoverSignedBytes v =
@@ -200,7 +216,7 @@ recoverSignedBytes v =
       [ "\130"
       -- The byte above is part of the signed payload, but is not part of the
       -- transmitted payload
-      , annotation $ aProposalId v
+      , Binary.annotation $ aProposalId v
       , "\245"
       -- The byte above is the canonical encoding of @True@, which we hardcode,
       -- because we removed the possibility of negative voting

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Delegation.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Delegation.hs
@@ -107,6 +107,7 @@ elaborateDCertAnnotated pm = annotateDCert . elaborateDCert pm
   annotateDCert :: Concrete.Certificate -> Concrete.ACertificate ByteString
   annotateDCert cert = cert
     { Concrete.Certificate.aEpoch = Annotated omega (serialize' omega)
+    , Concrete.Certificate.annotation = serialize' cert
     }
     where omega = Concrete.Certificate.epoch cert
 


### PR DESCRIPTION
For https://github.com/input-output-hk/ouroboros-network/issues/592 (PR https://github.com/input-output-hk/ouroboros-network/pull/999), each kind of generalized transaction has an identifier (for which we are using a hash of the generalized tx). I think it makes sense that these data types will be maintained by and exposed as part of `cardano-ledger`. Thoughts?

Also, I'm not really sure if I like the suffix, `*Id`, in this case. I was thinking that `CertificateHash` and `VoteHash` were nicer but I don't want to make things inconsistent as we already have `TxId` and `UpId`.