### PR TITLE
Remove signing history from the chain validation state.

### DIFF
--- a/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -251,20 +251,6 @@ ts_roundTripProofCBOR = eachOfTS 20 (feedPM genProof) roundTripsCBORBuildable
 
 
 --------------------------------------------------------------------------------
--- SigningHistory
---------------------------------------------------------------------------------
-
--- TODO:
--- goldenSigningHistory :: Property
--- goldenSigningHistory =
---   goldenTestCBOR exampleSigningHistory "test/golden/cbor/block/SigningHistory"
-
-ts_roundTripSigningHistoryCBOR :: TSProperty
-ts_roundTripSigningHistoryCBOR =
-  eachOfTS 20 genSigningHistory roundTripsCBORShow
-
-
---------------------------------------------------------------------------------
 -- ToSign
 --------------------------------------------------------------------------------
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
@@ -6,7 +6,6 @@ module Test.Cardano.Chain.Block.Gen
   , genHeader
   , genBody
   , genProof
-  , genSigningHistory
   , genToSign
   , genBlock
   , genBlockWithEpochSlots
@@ -35,13 +34,11 @@ import Cardano.Chain.Block
   , Header
   , HeaderHash
   , Proof(..)
-  , SigningHistory(..)
   , ToSign(..)
   , hashHeader
   , mkBlockExplicit
   , mkHeaderExplicit
   )
-import Cardano.Chain.Common (KeyHash, BlockCount)
 import Cardano.Chain.Delegation (signCertificate)
 import Cardano.Chain.Genesis (GenesisHash(..))
 import Cardano.Chain.Slotting
@@ -57,7 +54,7 @@ import Cardano.Crypto
   )
 
 import Test.Cardano.Chain.Common.Gen
-  (genBlockCount, genChainDifficulty, genKeyHash)
+  (genChainDifficulty)
 import qualified Test.Cardano.Chain.Delegation.Gen as Delegation
 import Test.Cardano.Chain.Slotting.Gen
   (genEpochNumber, genEpochSlots, genSlotNumber, genEpochAndSlotCount)
@@ -141,16 +138,6 @@ genProof pm =
     <*> pure SscProof
     <*> genAbstractHash (Delegation.genPayload pm)
     <*> Update.genProof pm
-
-genSigningHistory :: Gen SigningHistory
-genSigningHistory =
-  SigningHistory
-    <$> genBlockCount
-    <*> Gen.seq (Range.constant 10 25) genKeyHash
-    <*> Gen.map (Range.constant 10 25) genKeyHashBlockCount
- where
-  genKeyHashBlockCount :: Gen (KeyHash, BlockCount)
-  genKeyHashBlockCount = (,) <$> genKeyHash <*> genBlockCount
 
 genToSign :: ProtocolMagicId -> EpochSlots -> Gen ToSign
 genToSign pm epochSlots =

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Validation.hs
@@ -12,27 +12,19 @@ where
 import Cardano.Prelude
 
 import Control.Monad.Trans.Resource (ResIO, runResourceT)
-import qualified Data.Map.Strict as M
 import Data.Maybe (isJust)
-import qualified Data.Sequence as Seq
 import Streaming (Of(..), Stream, hoist)
 import qualified Streaming.Prelude as S
 
 import Hedgehog
   ( Group(..)
-  , Property
-  , PropertyT
   , annotate
   , assert
   , discover
   , evalEither
-  , forAll
   , property
   , withTests
-  , (===)
   )
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
 import System.Environment (lookupEnv)
 
 import Cardano.Chain.Block
@@ -40,22 +32,17 @@ import Cardano.Chain.Block
   , BlockValidationMode (BlockValidation)
   , ChainValidationError
   , ChainValidationState(..)
-  , SigningHistory(..)
   , blockSlot
   , initialChainValidationState
   , updateBlock
   , updateChainBoundary
-  , updateSigningHistory
   )
-import Cardano.Chain.Common (BlockCount(..), hashKey)
 import Cardano.Chain.Epoch.File (ParseError, parseEpochFilesWithBoundary)
 import Cardano.Chain.Genesis as Genesis (Config(..), configEpochSlots)
 import Cardano.Chain.Slotting (SlotNumber)
 import Cardano.Chain.ValidationMode (fromBlockValidationMode)
-import Cardano.Crypto (VerificationKey)
 
 import Test.Cardano.Chain.Config (readMainetCfg)
-import Test.Cardano.Crypto.Gen (genVerificationKey)
 import Test.Cardano.Mirror (mainnetEpochFiles)
 import Test.Options
   (ShouldAssertNF(..), TestScenario(..), TSGroup, TSProperty, concatTSGroups)
@@ -152,67 +139,3 @@ foldChainValidationState shouldAssertNF config cvs blocks =
   blockOrBoundarySlot = \case
     ABOBBoundary _     -> Nothing
     ABOBBlock    block -> Just $ blockSlot block
-
-
---------------------------------------------------------------------------------
--- SigningHistory
---------------------------------------------------------------------------------
-
--- | Check that updating a 'SigningHistory' maintains the invariants that:
---
---   - The map and sequence agree on the number of blocks signed by each
---     keyHash
---   - The sequence never exceeds @k@ values
-prop_signingHistoryUpdatesPreserveInvariants :: Property
-prop_signingHistoryUpdatesPreserveInvariants =
-  withTests 100
-    . property
-    $ do
-
-        -- Generate a list of fake genesis keyHashes
-        verificationKeys <- forAll $ replicateM 7 genVerificationKey
-        let keyHashes = fmap hashKey verificationKeys
-
-        -- Generate a length for the 'SigningHistory'
-        -- We don't use 'genBlockCount' as that would produce too large values
-        k <- forAll $ BlockCount <$> Gen.word64 (Range.constant 1 100)
-
-        let
-          initialSigningHistory = SigningHistory
-            { shK = k
-            , shSigningQueue = Seq.Empty
-            , shKeyHashCounts = M.fromList $ fmap (, BlockCount 0) keyHashes
-            }
-
-        -- Generate a list of signers with which to update the 'SigningHistory'
-        signers <- forAll $ Gen.list
-          (Range.constant 0 (fromIntegral $ 2 * unBlockCount k))
-          (Gen.element verificationKeys)
-
-        let
-          updateAndCheckSigningHistory
-            :: SigningHistory -> VerificationKey -> PropertyT IO SigningHistory
-          updateAndCheckSigningHistory sh s = do
-            -- Update the  'SigningHistory'
-            let sh' = updateSigningHistory s sh
-
-            -- For each keyHash the value in the map is the same as that in
-            -- the sequence
-            keyHashes `forM_` \s' -> do
-              let
-                keyHashCount :: Int
-                keyHashCount = maybe 0 (fromIntegral . unBlockCount) $ M.lookup
-                  s'
-                  (shKeyHashCounts sh')
-                keyHashCount' =
-                  length $ Seq.filter (== s') (shSigningQueue sh')
-              keyHashCount === keyHashCount'
-
-            -- The length of the overall sequence is less than or equal to 'k'
-            assert $ length (shSigningQueue sh') <= fromIntegral (unBlockCount $ shK sh')
-
-            pure sh'
-
-        -- Check that at each stage the 'Map' and 'Seq' are in agreement and the
-        -- sequence never exceeds 'k'
-        foldM_ updateAndCheckSigningHistory initialSigningHistory signers


### PR DESCRIPTION
Consensus layer takes care of maintaining the history of signers. This was a
vestigial field from when we did these checks in the ledger layer.