### PR TITLE
Bump CLS version, which fixes low coverage of `AlreadyProposedSv`.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -45,19 +45,19 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e52fea6ecd6ccb227de8333b0cb7482e81879691
+  tag: 749b71269d8599a39817234b6a51788dd9fb57f4
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e52fea6ecd6ccb227de8333b0cb7482e81879691
+  tag: 749b71269d8599a39817234b6a51788dd9fb57f4
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e52fea6ecd6ccb227de8333b0cb7482e81879691
+  tag: 749b71269d8599a39817234b6a51788dd9fb57f4
   subdir: byron/chain/executable-spec
 
 source-repository-package

--- a/nix/.stack.nix/cs-blockchain.nix
+++ b/nix/.stack.nix/cs-blockchain.nix
@@ -50,8 +50,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "e52fea6ecd6ccb227de8333b0cb7482e81879691";
-      sha256 = "0y2j85dqijafz6rfkfa53yfndf3hazs3cjahrqkv5jqvrpj8gsak";
+      rev = "749b71269d8599a39817234b6a51788dd9fb57f4";
+      sha256 = "118l9sffr72nm2f01sxb0c76mlpdpxmnwg816s34akbsigbky0li";
       });
     postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -69,8 +69,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "e52fea6ecd6ccb227de8333b0cb7482e81879691";
-      sha256 = "0y2j85dqijafz6rfkfa53yfndf3hazs3cjahrqkv5jqvrpj8gsak";
+      rev = "749b71269d8599a39817234b6a51788dd9fb57f4";
+      sha256 = "118l9sffr72nm2f01sxb0c76mlpdpxmnwg816s34akbsigbky0li";
       });
     postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -66,8 +66,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "e52fea6ecd6ccb227de8333b0cb7482e81879691";
-      sha256 = "0y2j85dqijafz6rfkfa53yfndf3hazs3cjahrqkv5jqvrpj8gsak";
+      rev = "749b71269d8599a39817234b6a51788dd9fb57f4";
+      sha256 = "118l9sffr72nm2f01sxb0c76mlpdpxmnwg816s34akbsigbky0li";
       });
     postUnpack = "sourceRoot+=/byron/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,7 +28,7 @@ extra-deps:
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: e52fea6ecd6ccb227de8333b0cb7482e81879691
+    commit: 749b71269d8599a39817234b6a51788dd9fb57f4
     subdirs:
       - byron/semantics/executable-spec
       - byron/ledger/executable-spec


### PR DESCRIPTION
Closes #657 