### PR TITLE
Revert annotation changes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,30 +11,30 @@ constraints:
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 3c40edcf5bdba8721d3430d0aaaeea8770ce9bec
+  tag: 7a8755b6988a9dd137f3f61a77c6d51e4eafa781
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 3c40edcf5bdba8721d3430d0aaaeea8770ce9bec
+  tag: 7a8755b6988a9dd137f3f61a77c6d51e4eafa781
   subdir: test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 057d8a9a3e751f88fc7677df5713c5ecc47a37c4
+  tag: d733bbc887d800c387b7ef4ed0a23225fca28d02
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 057d8a9a3e751f88fc7677df5713c5ecc47a37c4
+  tag: d733bbc887d800c387b7ef4ed0a23225fca28d02
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 057d8a9a3e751f88fc7677df5713c5ecc47a37c4
+  tag: d733bbc887d800c387b7ef4ed0a23225fca28d02
   subdir: binary/test
 
 source-repository-package
@@ -45,26 +45,26 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c1f9d85f50a6e71b2376618cb57656a1b7192ef1
+  tag: 203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c1f9d85f50a6e71b2376618cb57656a1b7192ef1
+  tag: 203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c1f9d85f50a6e71b2376618cb57656a1b7192ef1
+  tag: 203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   contra-tracer
-  tag: 4956b32f039579a0e7e4fd10793f65b4c77d9044
+  tag: a71addb2c45a8e116c2a57385b67812d51352a7a
 
 source-repository-package
   type: git

--- a/cardano-ledger/src/Cardano/Chain/Block/Block.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Block.hs
@@ -13,14 +13,16 @@
 module Cardano.Chain.Block.Block
   (
   -- * Block
-    Block (Block, blockHeader, blockBody, blockSerialized)
+    Block (blockHeader, blockBody, blockSerialized)
 
   -- * Block Constructors
+  , pattern Block
   , mkBlockExplicit
 
   -- * Block Accessors
   , blockHash
   , blockHashAnnotated
+  , blockAProtocolMagicId
   , blockProtocolMagicId
   , blockPrevHash
   , blockProof
@@ -52,11 +54,13 @@ module Cardano.Chain.Block.Block
   , toCBORBlockOrBoundary
 
   -- * BoundaryBlock
-  , BoundaryBlock(BoundaryBlock, boundaryBlockLength, boundaryHeader, boundaryBody)
+  , BoundaryBlock(boundaryBlockLength, boundaryHeader, boundaryBody)
+  , pattern BoundaryBlock
   , boundaryHashAnnotated
   , toCBORBOBBoundary
 
-  , BoundaryBody(BoundaryBody)
+  , BoundaryBody
+  , pattern BoundaryBody
   )
 where
 
@@ -68,7 +72,8 @@ import Formatting (bprint, build, int, later, shown)
 import qualified Formatting.Buildable as B
 
 import Cardano.Binary
-  ( AnnotatedDecoder
+  ( Annotated(..)
+  , AnnotatedDecoder
   , DecoderError(..)
   , Encoding
   , FromCBOR(..)
@@ -99,6 +104,7 @@ import Cardano.Chain.Block.Header
   , Header
   , HeaderHash
   , ToSign
+  , aHeaderProtocolMagicId
   , boundaryHeaderHashAnnotated
   , fromCBORHeader
   , hashHeader
@@ -202,6 +208,9 @@ blockHashAnnotated = hashHeader . blockHeader
 
 blockProtocolMagicId :: Block -> ProtocolMagicId
 blockProtocolMagicId = headerProtocolMagicId . blockHeader
+
+blockAProtocolMagicId :: Block -> Annotated ProtocolMagicId ByteString
+blockAProtocolMagicId = aHeaderProtocolMagicId . blockHeader
 
 blockPrevHash :: Block -> HeaderHash
 blockPrevHash = headerPrevHash . blockHeader

--- a/cardano-ledger/src/Cardano/Chain/Block/Block.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Block.hs
@@ -8,15 +8,15 @@
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE PatternSynonyms      #-}
 
 module Cardano.Chain.Block.Block
   (
   -- * Block
-    Block (blockHeader, blockBody, blockSerialized)
+    Block
+  , ABlock(..)
 
   -- * Block Constructors
-  , pattern Block
+  , mkBlock
   , mkBlockExplicit
 
   -- * Block Accessors
@@ -41,26 +41,27 @@ module Cardano.Chain.Block.Block
   , blockLength
 
   -- * Block Binary Serialization
-  , fromCBORBlock
+  , toCBORBlock
+  , fromCBORABlock
 
   -- * Block Formatting
   , renderBlock
 
-  -- * BlockOrBoundary
-  , BlockOrBoundary(..)
-  , toCBORBOBBlock
-  , fromCBORBOBBlock
-  , fromCBORBlockOrBoundary
-  , toCBORBlockOrBoundary
+  -- * ABlockOrBoundary
+  , ABlockOrBoundary(..)
+  , toCBORABOBBlock
+  , fromCBORABOBBlock
+  , fromCBORABlockOrBoundary
+  , toCBORABlockOrBoundary
 
-  -- * BoundaryBlock
-  , BoundaryBlock(boundaryBlockLength, boundaryHeader, boundaryBody)
-  , pattern BoundaryBlock
+  -- * ABoundaryBlock
+  , ABoundaryBlock(..)
   , boundaryHashAnnotated
-  , toCBORBOBBoundary
+  , fromCBORABoundaryBlock
+  , toCBORABoundaryBlock
+  , toCBORABOBBoundary
 
-  , BoundaryBody
-  , pattern BoundaryBody
+  , ABoundaryBody(..)
   )
 where
 
@@ -73,22 +74,22 @@ import qualified Formatting.Buildable as B
 
 import Cardano.Binary
   ( Annotated(..)
-  , AnnotatedDecoder
+  , ByteSpan(..)
+  , Decoded(..)
+  , Decoder
   , DecoderError(..)
   , Encoding
   , FromCBOR(..)
-  , FromCBORAnnotated (..)
   , ToCBOR(..)
+  , annotatedDecoder
   , encodeBreak
   , encodeListLen
   , encodeListLenIndef
-  , encodePreEncoded
   , enforceSize
-  , withSlice'
-  , serializeEncoding'
   )
 import Cardano.Chain.Block.Body
-  ( Body
+  ( ABody
+  , Body
   , bodyDlgPayload
   , bodySscPayload
   , bodyTxPayload
@@ -98,17 +99,19 @@ import Cardano.Chain.Block.Body
 import Cardano.Chain.Block.Boundary
   (dropBoundaryBody, dropBoundaryExtraBodyData)
 import Cardano.Chain.Block.Header
-  ( BlockSignature
-  , Header(..)
-  , BoundaryHeader(..)
+  ( ABlockSignature
+  , AHeader(..)
+  , ABoundaryHeader(..)
   , Header
   , HeaderHash
   , ToSign
-  , aHeaderProtocolMagicId
   , boundaryHeaderHashAnnotated
-  , fromCBORHeader
+  , fromCBORABoundaryHeader
+  , fromCBORAHeader
+  , genesisHeaderHash
   , hashHeader
   , headerDifficulty
+  , headerHashAnnotated
   , headerGenesisKey
   , headerIssuer
   , headerPrevHash
@@ -120,6 +123,8 @@ import Cardano.Chain.Block.Header
   , headerSoftwareVersion
   , headerToSign
   , mkHeaderExplicit
+  , toCBORHeader
+  , toCBORABoundaryHeader
   )
 import Cardano.Chain.Block.Proof (Proof(..))
 import Cardano.Chain.Common (ChainDifficulty(..), dropEmptyAttributes)
@@ -131,7 +136,7 @@ import Cardano.Chain.Slotting
   , WithEpochSlots(WithEpochSlots)
   )
 import Cardano.Chain.Ssc (SscPayload)
-import Cardano.Chain.UTxO.TxPayload (TxPayload)
+import Cardano.Chain.UTxO.TxPayload (ATxPayload)
 import Cardano.Chain.Update.ProtocolVersion (ProtocolVersion)
 import qualified Cardano.Chain.Update.Payload as Update
 import Cardano.Chain.Update.SoftwareVersion (SoftwareVersion)
@@ -142,11 +147,13 @@ import Cardano.Crypto (ProtocolMagicId, SigningKey, VerificationKey)
 -- Block
 --------------------------------------------------------------------------------
 
-data Block = Block'
-  { blockHeader'    :: !Header
-  , blockBody'      :: !Body
-  , blockSerialized :: ByteString
-  } deriving (Eq, Show, Generic, NFData)
+type Block = ABlock ()
+
+data ABlock a = ABlock
+  { blockHeader     :: AHeader a
+  , blockBody       :: ABody a
+  , blockAnnotation :: a
+  } deriving (Eq, Show, Generic, NFData, Functor)
 
 
 --------------------------------------------------------------------------------
@@ -154,19 +161,35 @@ data Block = Block'
 --------------------------------------------------------------------------------
 
 -- | Smart constructor for 'Block'
-{-# COMPLETE Block #-}
-pattern Block :: Header -> Body -> Block
-pattern Block { blockHeader, blockBody } <- Block' blockHeader blockBody _
-  where
-  Block header body =
-    let bytes = serializeEncoding' $ encodeListLen 3
-                <> toCBOR header
-                <> toCBOR body
-                <> (encodeListLen 1 <> toCBOR (mempty :: Map Word8 LByteString))
-    in Block' header body bytes
+mkBlock
+  :: ProtocolMagicId
+  -> ProtocolVersion
+  -> SoftwareVersion
+  -> Either GenesisHash Header
+  -> EpochSlots
+  -> SlotNumber
+  -> SigningKey
+  -- ^ The 'SigningKey' used for signing the block
+  -> Delegation.Certificate
+  -- ^ A certificate of delegation from a genesis key to the 'SigningKey'
+  -> Body
+  -> Block
+mkBlock pm bv sv prevHeader epochSlots = mkBlockExplicit
+  pm
+  bv
+  sv
+  prevHash
+  difficulty
+  epochSlots
+ where
+  prevHash = either genesisHeaderHash (hashHeader epochSlots) prevHeader
+  difficulty =
+    either (const $ ChainDifficulty 0) (succ . headerDifficulty) prevHeader
 
 -- | Smart constructor for 'Block', without requiring the entire previous
 --   'Header'. Instead, you give its hash and the difficulty of this block.
+--   These are derived from the previous header in 'mkBlock' so if you have
+--   the previous header, consider using that one.
 mkBlockExplicit
   :: ProtocolMagicId
   -> ProtocolVersion
@@ -182,96 +205,112 @@ mkBlockExplicit
   -> Body
   -> Block
 mkBlockExplicit pm pv sv prevHash difficulty epochSlots slotNumber sk dlgCert body
-  = let header = mkHeaderExplicit
-          pm
-          prevHash
-          difficulty
-          epochSlots
-          slotNumber
-          sk
-          dlgCert
-          body
-          pv
-          sv
-    in Block header body
+  = ABlock
+    (mkHeaderExplicit
+      pm
+      prevHash
+      difficulty
+      epochSlots
+      slotNumber
+      sk
+      dlgCert
+      body
+      pv
+      sv
+    )
+    body
+    ()
 
 
 --------------------------------------------------------------------------------
 -- Block Accessors
 --------------------------------------------------------------------------------
 
-blockHash :: Block -> HeaderHash
-blockHash = hashHeader . blockHeader
+blockHash :: EpochSlots -> Block -> HeaderHash
+blockHash epochSlots = hashHeader epochSlots . blockHeader
 
-blockHashAnnotated :: Block -> HeaderHash
-blockHashAnnotated = hashHeader . blockHeader
+blockHashAnnotated :: ABlock ByteString -> HeaderHash
+blockHashAnnotated = headerHashAnnotated . blockHeader
 
-blockProtocolMagicId :: Block -> ProtocolMagicId
+blockProtocolMagicId :: ABlock a -> ProtocolMagicId
 blockProtocolMagicId = headerProtocolMagicId . blockHeader
 
-blockAProtocolMagicId :: Block -> Annotated ProtocolMagicId ByteString
+blockAProtocolMagicId :: ABlock a -> Annotated ProtocolMagicId a
 blockAProtocolMagicId = aHeaderProtocolMagicId . blockHeader
 
-blockPrevHash :: Block -> HeaderHash
+blockPrevHash :: ABlock a -> HeaderHash
 blockPrevHash = headerPrevHash . blockHeader
 
-blockProof :: Block -> Proof
+blockProof :: ABlock a -> Proof
 blockProof = headerProof . blockHeader
 
-blockSlot :: Block -> SlotNumber
+blockSlot :: ABlock a -> SlotNumber
 blockSlot = headerSlot . blockHeader
 
-blockGenesisKey :: Block -> VerificationKey
+blockGenesisKey :: ABlock a -> VerificationKey
 blockGenesisKey = headerGenesisKey . blockHeader
 
-blockIssuer :: Block -> VerificationKey
+blockIssuer :: ABlock a -> VerificationKey
 blockIssuer = headerIssuer . blockHeader
 
-blockDifficulty :: Block -> ChainDifficulty
+blockDifficulty :: ABlock a -> ChainDifficulty
 blockDifficulty = headerDifficulty . blockHeader
 
-blockToSign :: EpochSlots -> Block -> ToSign
+blockToSign :: EpochSlots -> ABlock a -> ToSign
 blockToSign epochSlots = headerToSign epochSlots . blockHeader
 
-blockSignature :: Block -> BlockSignature
+blockSignature :: ABlock a -> ABlockSignature a
 blockSignature = headerSignature . blockHeader
 
-blockProtocolVersion :: Block -> ProtocolVersion
+blockProtocolVersion :: ABlock a -> ProtocolVersion
 blockProtocolVersion = headerProtocolVersion . blockHeader
 
-blockSoftwareVersion :: Block -> SoftwareVersion
+blockSoftwareVersion :: ABlock a -> SoftwareVersion
 blockSoftwareVersion = headerSoftwareVersion . blockHeader
 
-blockTxPayload :: Block -> TxPayload
+blockTxPayload :: ABlock a -> ATxPayload a
 blockTxPayload = bodyTxPayload . blockBody
 
-blockSscPayload :: Block -> SscPayload
+blockSscPayload :: ABlock a -> SscPayload
 blockSscPayload = bodySscPayload . blockBody
 
-blockUpdatePayload :: Block -> Update.Payload
+blockUpdatePayload :: ABlock a -> Update.APayload a
 blockUpdatePayload = bodyUpdatePayload . blockBody
 
-blockDlgPayload :: Block -> Delegation.Payload
+blockDlgPayload :: ABlock a -> Delegation.APayload a
 blockDlgPayload = bodyDlgPayload . blockBody
 
-blockLength :: Block -> Natural
-blockLength = fromIntegral . BS.length . blockSerialized
+blockLength :: ABlock ByteString -> Natural
+blockLength = fromIntegral . BS.length . blockAnnotation
 
 
 --------------------------------------------------------------------------------
 -- Block Binary Serialization
 --------------------------------------------------------------------------------
 
-instance ToCBOR Block where
-  toCBOR = encodePreEncoded . blockSerialized
+-- | Encode a block, given a number of slots-per-epoch.
+--
+--   Unlike 'toCBORABOBBlock', this function does not take the deprecated epoch
+--   boundary blocks into account.
+--
+toCBORBlock :: EpochSlots -> Block -> Encoding
+toCBORBlock epochSlots block
+  =  encodeListLen 3
+  <> toCBORHeader epochSlots (blockHeader block)
+  <> toCBOR (blockBody block)
+  <> (encodeListLen 1 <> toCBOR (mempty :: Map Word8 LByteString))
 
-fromCBORBlock :: EpochSlots -> AnnotatedDecoder s Block
-fromCBORBlock epochSlots = withSlice' $
-  Block' <$ lift (enforceSize "Block" 3)
-    <*> fromCBORHeader epochSlots
-    <*> fromCBORAnnotated'
-    -- Drop the deprecated ExtraBodyData
-    <* (lift $ enforceSize "ExtraBodyData" 1 >> dropEmptyAttributes)
+fromCBORABlock :: EpochSlots -> Decoder s (ABlock ByteSpan)
+fromCBORABlock epochSlots = do
+  Annotated (header, body) byteSpan <- annotatedDecoder $ do
+    enforceSize "Block" 3
+    (,)
+      <$> fromCBORAHeader epochSlots
+      <*> fromCBOR
+      -- Drop the deprecated ExtraBodyData
+      <*  (enforceSize "ExtraBodyData" 1 >> dropEmptyAttributes)
+  pure $ ABlock header body byteSpan
+
 
 --------------------------------------------------------------------------------
 -- Block Formatting
@@ -299,34 +338,34 @@ renderBlock es block =
 
 
 --------------------------------------------------------------------------------
--- BlockOrBoundary
+-- ABlockOrBoundary
 --------------------------------------------------------------------------------
 
-data BlockOrBoundary
-  = BOBBlock Block
-  | BOBBoundary BoundaryBlock
-  deriving (Eq, Show)
+data ABlockOrBoundary a
+  = ABOBBlock (ABlock a)
+  | ABOBBoundary (ABoundaryBlock a)
+  deriving (Eq, Show, Functor)
 
 -- | Encode a 'Block' accounting for deprecated epoch boundary blocks
-toCBORBOBBlock :: Block -> Encoding
-toCBORBOBBlock block =
+toCBORABOBBlock :: EpochSlots -> ABlock a -> Encoding
+toCBORABOBBlock epochSlots block =
   encodeListLen 2
     <> toCBOR (1 :: Word)
-    <> toCBOR block
+    <> toCBORBlock epochSlots (fmap (const ()) block)
 
 -- | toCBORABoundaryBlock but with the list length and tag discriminator bytes.
-toCBORBOBBoundary :: BoundaryBlock -> Encoding
-toCBORBOBBoundary bvd =
+toCBORABOBBoundary :: ProtocolMagicId -> ABoundaryBlock a -> Encoding
+toCBORABOBBoundary pm bvd =
   encodeListLen 2
     <> toCBOR (0 :: Word)
-    <> toCBOR bvd
+    <> toCBORABoundaryBlock pm bvd
 
 -- | Decode a 'Block' accounting for deprecated epoch boundary blocks
-fromCBORBOBBlock :: EpochSlots -> AnnotatedDecoder s (Maybe Block)
-fromCBORBOBBlock epochSlots =
-  fromCBORBlockOrBoundary epochSlots >>= \case
-    BOBBoundary _ -> pure Nothing
-    BOBBlock    b -> pure . Just $ b
+fromCBORABOBBlock :: EpochSlots -> Decoder s (Maybe Block)
+fromCBORABOBBlock epochSlots =
+  fromCBORABlockOrBoundary epochSlots >>= \case
+    ABOBBoundary _ -> pure Nothing
+    ABOBBlock    b -> pure . Just $ void b
 
 -- | Decode a 'Block' accounting for deprecated epoch boundary blocks
 --
@@ -335,87 +374,95 @@ fromCBORBOBBlock epochSlots =
 --   now deprecated these explicit boundary blocks, but we still need to decode
 --   blocks in the old format. In the case that we find a boundary block, we
 --   drop it using 'dropBoundaryBlock' and return a 'Nothing'.
-fromCBORBlockOrBoundary
-  :: EpochSlots -> AnnotatedDecoder s BlockOrBoundary
-fromCBORBlockOrBoundary epochSlots = do
-  lift $ enforceSize "Block" 2
-  (lift $ fromCBOR @Word) >>= \case
-    0 -> BOBBoundary <$> fromCBORAnnotated'
-    1 -> BOBBlock <$> fromCBORBlock epochSlots
-    t -> lift $ cborError $ DecoderErrorUnknownTag "Block" (fromIntegral t)
+fromCBORABlockOrBoundary
+  :: EpochSlots -> Decoder s (ABlockOrBoundary ByteSpan)
+fromCBORABlockOrBoundary epochSlots = do
+  enforceSize "Block" 2
+  fromCBOR @Word >>= \case
+    0 -> ABOBBoundary <$> fromCBORABoundaryBlock
+    1 -> ABOBBlock <$> fromCBORABlock epochSlots
+    t -> cborError $ DecoderErrorUnknownTag "Block" (fromIntegral t)
 
-toCBORBlockOrBoundary :: BlockOrBoundary -> Encoding
-toCBORBlockOrBoundary abob = case abob of
-  BOBBlock    blk -> toCBORBOBBlock blk
-  BOBBoundary ebb -> toCBORBOBBoundary ebb
+toCBORABlockOrBoundary
+  :: ProtocolMagicId -> EpochSlots -> ABlockOrBoundary a -> Encoding
+toCBORABlockOrBoundary pm epochSlots abob = case abob of
+  ABOBBlock    blk -> toCBORABOBBlock epochSlots blk
+  ABOBBoundary ebb -> toCBORABOBBoundary pm ebb
 
 --------------------------------------------------------------------------------
--- BoundaryBlock
+-- ABoundaryBlock
 --------------------------------------------------------------------------------
 
 -- | For boundary body data, we only keep an annotation. It's the body and
 -- extra body data.
-data BoundaryBody = BoundaryBody'
-  { boundaryBodySerialized :: ByteString
-  } deriving (Eq, Show)
+data ABoundaryBody a = ABoundaryBody
+  { boundaryBodyAnnotation :: !a
+  } deriving (Eq, Show, Functor)
 
-pattern BoundaryBody :: BoundaryBody
-pattern BoundaryBody <- BoundaryBody' _
-  where
-  BoundaryBody = BoundaryBody' $ serializeEncoding' $
-    (encodeListLenIndef <> encodeBreak)
-      <> ( encodeListLen 1 <> toCBOR (mempty :: Map Word8 LByteString))
+instance Decoded (ABoundaryBody ByteString) where
+  type BaseType (ABoundaryBody ByteString) = ABoundaryBody ()
+  recoverBytes = boundaryBodyAnnotation
 
-instance FromCBORAnnotated BoundaryBody where
-  fromCBORAnnotated' = withSlice' $
-    BoundaryBody'
-      <$ lift dropBoundaryBody
-      <* lift dropBoundaryExtraBodyData
+fromCBORABoundaryBody :: Decoder s (ABoundaryBody ByteSpan)
+fromCBORABoundaryBody = do
+  Annotated _ bs <- annotatedDecoder $ do
+    dropBoundaryBody
+    dropBoundaryExtraBodyData
+  pure $ ABoundaryBody bs
 
-instance ToCBOR BoundaryBody where
-  toCBOR = encodePreEncoded . boundaryBodySerialized
+-- | Every boundary body has the same encoding: empty.
+toCBORABoundaryBody :: ABoundaryBody a -> Encoding
+toCBORABoundaryBody _ =
+  (encodeListLenIndef <> encodeBreak)
+    <> ( encodeListLen 1
+        <> toCBOR (mempty :: Map Word8 LByteString)
+       )
 
 -- | For a boundary block, we keep the header, body, and an annotation for
 -- the whole thing (commonly the bytes from which it was decoded).
-data BoundaryBlock = BoundaryBlock'
-  { boundaryBlockLength     :: Int64
+data ABoundaryBlock a = ABoundaryBlock
+  { boundaryBlockLength     :: !Int64
   -- ^ Needed for validation.
-  , boundaryHeader'         :: !BoundaryHeader
-  , boundaryBody'           :: !BoundaryBody
-  , boundarySerialized      :: ByteString
-  } deriving (Eq, Show)
+  , boundaryHeader          :: !(ABoundaryHeader a)
+  , boundaryBody            :: !(ABoundaryBody a)
+  , boundaryAnnotation      :: !a
+  } deriving (Eq, Show, Functor)
+
+instance Decoded (ABoundaryBlock ByteString) where
+  type BaseType (ABoundaryBlock ByteString) = ABoundaryBlock ()
+  recoverBytes = boundaryAnnotation
 
 -- | Extract the hash of a boundary block from its annotation.
-boundaryHashAnnotated :: BoundaryBlock -> HeaderHash
+boundaryHashAnnotated :: ABoundaryBlock ByteString -> HeaderHash
 boundaryHashAnnotated = boundaryHeaderHashAnnotated . boundaryHeader
 
-instance FromCBORAnnotated BoundaryBlock where
-  fromCBORAnnotated' = withSlice' $ do
-    lift $ enforceSize "BoundaryBlock" 3
+fromCBORABoundaryBlock :: Decoder s (ABoundaryBlock ByteSpan)
+fromCBORABoundaryBlock = do
+  Annotated (hdr, bod) bytespan@(ByteSpan start end) <- annotatedDecoder $ do
+    enforceSize "BoundaryBlock" 3
     -- 1 item (list of 5)
-    hdr <- fromCBORAnnotated'
+    hdr <- fromCBORABoundaryHeader
     -- 2 items (body and extra body data)
-    bod <- fromCBORAnnotated'
-    pure $
-      \bytes -> BoundaryBlock' (fromIntegral $ BS.length bytes) hdr bod bytes
+    bod <- fromCBORABoundaryBody
+    pure (hdr, bod)
+  pure $ ABoundaryBlock
+    { boundaryBlockLength = end - start
+    , boundaryHeader      = hdr
+    , boundaryBody        = bod
+    , boundaryAnnotation  = bytespan
+    }
 
-pattern BoundaryBlock :: BoundaryHeader -> BoundaryBody -> BoundaryBlock
-pattern BoundaryBlock{ boundaryHeader, boundaryBody } <-
-  BoundaryBlock' _ boundaryHeader boundaryBody _
-  where
-    BoundaryBlock hdr bod =
-      let bytes = serializeEncoding' $ 
-            encodeListLen 3
-              -- 1 item (list of 5)
-              <> toCBOR hdr
-              -- 2 items (body and extra body data)
-              <> toCBOR bod
-      in BoundaryBlock' (fromIntegral $ BS.length bytes) hdr bod bytes
+-- | See note on `toCBORABoundaryHeader`. This as well does not necessarily
+-- invert the decoder `fromCBORABoundaryBlock`.
+toCBORABoundaryBlock :: ProtocolMagicId -> ABoundaryBlock a -> Encoding
+toCBORABoundaryBlock pm ebb =
+    encodeListLen 3
+      -- 1 item (list of 5)
+      <> toCBORABoundaryHeader pm (boundaryHeader ebb)
+      -- 2 items (body and extra body data)
+      <> toCBORABoundaryBody (boundaryBody ebb)
 
-instance ToCBOR BoundaryBlock where
-  toCBOR = encodePreEncoded . boundarySerialized
-
-instance B.Buildable BoundaryBlock where
+instance B.Buildable (ABoundaryBlock a) where
   build bvd = bprint
     ( "Boundary:\n"
     . "  Starting epoch: " . int . "\n"

--- a/cardano-ledger/src/Cardano/Chain/Block/Body.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Body.hs
@@ -1,21 +1,16 @@
 {-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Cardano.Chain.Block.Body
   ( Body
-    ( bodyTxPayload
-    , bodySscPayload
-    , bodyDlgPayload
-    , bodyUpdatePayload
-    , bodySerialized
-    )
   , pattern Body
+  , ABody(..)
   , bodyTxs
   , bodyWitnesses
   )
@@ -24,65 +19,52 @@ where
 import Cardano.Prelude
 
 import Cardano.Binary
-  (FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize,
-  FromCBORAnnotated(..), serializeEncoding', encodePreEncoded, serialize',
-  withSlice')
+  (ByteSpan, FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize)
 import qualified Cardano.Chain.Delegation.Payload as Delegation
 import Cardano.Chain.Ssc (SscPayload(..))
 import Cardano.Chain.UTxO.Tx (Tx)
-import Cardano.Chain.UTxO.TxPayload (TxPayload, txpTxs, txpWitnesses)
+import Cardano.Chain.UTxO.TxPayload (ATxPayload, TxPayload, txpTxs, txpWitnesses)
 import Cardano.Chain.UTxO.TxWitness (TxWitness)
 import qualified Cardano.Chain.Update.Payload as Update
 
+-- | 'Body' consists of payloads of all block components
+type Body = ABody ()
+
 -- | Constructor for 'Body'
-{-# COMPLETE Body #-}
 pattern Body :: TxPayload -> SscPayload -> Delegation.Payload -> Update.Payload -> Body
-pattern Body
-  { bodyTxPayload
-  , bodySscPayload
-  , bodyDlgPayload
-  , bodyUpdatePayload
-  } <- Body'
-    bodyTxPayload
-    bodySscPayload
-    bodyDlgPayload
-    bodyUpdatePayload
-    _
-  where
-  Body tx ssc dlg upd =
-    let bytes = serializeEncoding' $ encodeListLen 4
-          <> toCBOR tx
-          <> encodePreEncoded sscBytes
-          <> encodePreEncoded dlgBytes
-          <> encodePreEncoded updBytes
-        sscBytes = serialize' ssc
-        dlgBytes = serialize' dlg
-        updBytes = serialize' upd
-    in Body' tx ssc dlg upd bytes
+pattern Body tx ssc dlg upd = ABody tx ssc dlg upd
 
 -- | 'Body' consists of payloads of all block components
-data Body = Body'
-  { bodyTxPayload'    :: !TxPayload
+data ABody a = ABody
+  { bodyTxPayload     :: !(ATxPayload a)
   -- ^ UTxO payload
-  , bodySscPayload'   :: !SscPayload
+  , bodySscPayload    :: !SscPayload
   -- ^ Ssc payload
-  , bodyDlgPayload'   :: !Delegation.Payload
+  , bodyDlgPayload    :: !(Delegation.APayload a)
   -- ^ Heavyweight delegation payload (no-ttl certificates)
-  , bodyUpdatePayload':: !Update.Payload
+  , bodyUpdatePayload :: !(Update.APayload a)
   -- ^ Additional update information for the update system
-  , bodySerialized    :: ByteString
-  } deriving (Eq, Show, Generic, NFData)
+  } deriving (Eq, Show, Generic, Functor, NFData)
 
 instance ToCBOR Body where
-  toCBOR = encodePreEncoded . bodySerialized
+  toCBOR bc =
+    encodeListLen 4
+      <> toCBOR (bodyTxPayload bc)
+      <> toCBOR (bodySscPayload bc)
+      <> toCBOR (bodyDlgPayload bc)
+      <> toCBOR (bodyUpdatePayload bc)
 
-instance FromCBORAnnotated Body where
-  fromCBORAnnotated' = withSlice' $
-    Body' <$ lift (enforceSize "Body" 4)
-      <*> fromCBORAnnotated'
-      <*> lift fromCBOR
-      <*> fromCBORAnnotated'
-      <*> fromCBORAnnotated'
+instance FromCBOR Body where
+  fromCBOR = void <$> fromCBOR @(ABody ByteSpan)
+
+instance FromCBOR (ABody ByteSpan) where
+  fromCBOR = do
+    enforceSize "Body" 4
+    ABody
+      <$> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
 
 bodyTxs :: Body -> [Tx]
 bodyTxs = txpTxs . bodyTxPayload

--- a/cardano-ledger/src/Cardano/Chain/Block/Body.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Body.hs
@@ -9,13 +9,13 @@
 
 module Cardano.Chain.Block.Body
   ( Body
-    ( Body
-    , bodyTxPayload
+    ( bodyTxPayload
     , bodySscPayload
     , bodyDlgPayload
     , bodyUpdatePayload
     , bodySerialized
     )
+  , pattern Body
   , bodyTxs
   , bodyWitnesses
   )

--- a/cardano-ledger/src/Cardano/Chain/Block/Header.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Header.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE BangPatterns         #-}
-{-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE DeriveFunctor        #-}
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE DerivingVia          #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE LambdaCase           #-}
@@ -13,38 +11,31 @@
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE PatternSynonyms      #-}
-{-# LANGUAGE ViewPatterns         #-}
 
 module Cardano.Chain.Block.Header
   (
   -- * Header
-  Header
-    ( headerProtocolMagicId
-    , headerPrevHash
-    , headerSlot
-    , headerDifficulty
-    , headerProtocolVersion
-    , headerSoftwareVersion
-    , headerProof
-    , headerGenesisKey
-    , headerSignature
-    , headerEpochSlots
-    )
-  , pattern UnsafeHeader
+    Header
+  , AHeader(..)
 
   -- * Header Constructors
   , mkHeader
   , mkHeaderExplicit
 
   -- * Header Accessors
+  , headerProtocolMagicId
+  , headerPrevHash
+  , headerProof
+  , headerSlot
   , headerIssuer
   , headerLength
+  , headerDifficulty
   , headerToSign
-  , aHeaderProtocolMagicId
 
   -- * Header Binary Serialization
+  , toCBORHeader
   , toCBORHeaderToHash
+  , fromCBORAHeader
   , fromCBORHeader
   , fromCBORHeaderToHash
   , wrapHeaderBytes
@@ -53,13 +44,10 @@ module Cardano.Chain.Block.Header
   , renderHeader
 
   -- * Boundary Header
-  , BoundaryHeader
-    ( boundaryPrevHash
-    , boundaryEpoch
-    , boundaryDifficulty
-    )
-  , pattern BoundaryHeader
-  , mkBoundaryHeader
+  , ABoundaryHeader(..)
+  , mkABoundaryHeader
+  , toCBORABoundaryHeader
+  , fromCBORABoundaryHeader
   , boundaryHeaderHashAnnotated
   , wrapBoundaryBytes
 
@@ -67,10 +55,12 @@ module Cardano.Chain.Block.Header
   , HeaderHash
   , headerHashF
   , hashHeader
+  , headerHashAnnotated
   , genesisHeaderHash
 
   -- * BlockSignature
-  , BlockSignature(..)
+  , BlockSignature
+  , ABlockSignature(..)
 
   -- * ToSign
   , ToSign(..)
@@ -89,23 +79,20 @@ import qualified Formatting.Buildable as B
 
 import Cardano.Binary
   ( Annotated(..)
-  , AnnotatedDecoder
+  , ByteSpan
   , Decoded(..)
   , Decoder
   , DecoderError(..)
   , Encoding
   , FromCBOR(..)
-  , FromCBORAnnotated(..)
   , ToCBOR(..)
+  , annotatedDecoder
+  , fromCBORAnnotated
   , dropBytes
   , dropInt32
   , encodeListLen
   , enforceSize
   , serializeEncoding
-  , withSlice'
-  , serialize'
-  , encodePreEncoded
-  , serializeEncoding'
   )
 import Cardano.Chain.Block.Body (Body)
 import Cardano.Chain.Block.Boundary
@@ -132,6 +119,7 @@ import Cardano.Crypto
   , SigningKey
   , VerificationKey
   , hash
+  , hashDecoded
   , hashHexF
   , hashRaw
   , sign
@@ -143,103 +131,31 @@ import Cardano.Crypto
 -- Header
 --------------------------------------------------------------------------------
 
-data Header = Header'
-  { aHeaderProtocolMagicId' :: !(Annotated ProtocolMagicId ByteString)
-  , aHeaderPrevHash         :: !(Annotated HeaderHash ByteString)
+type Header = AHeader ()
+
+data AHeader a = AHeader
+  { aHeaderProtocolMagicId :: !(Annotated ProtocolMagicId a)
+  , aHeaderPrevHash        :: !(Annotated HeaderHash a)
   -- ^ Pointer to the header of the previous block
-  , aHeaderSlot             :: !(Annotated SlotNumber ByteString)
+  , aHeaderSlot            :: !(Annotated SlotNumber a)
   -- ^ The slot number this block was published for
-  , aHeaderDifficulty       :: !(Annotated ChainDifficulty ByteString)
+  , aHeaderDifficulty      :: !(Annotated ChainDifficulty a)
   -- ^ The chain difficulty up to this block
-  , headerProtocolVersion'  :: !ProtocolVersion
+  , headerProtocolVersion  :: !ProtocolVersion
   -- ^ The version of the protocol parameters this block is using
-  , headerSoftwareVersion'  :: !SoftwareVersion
+  , headerSoftwareVersion  :: !SoftwareVersion
   -- ^ The software version this block was published from
-  , headerProof'            :: !Proof
+  , aHeaderProof           :: !(Annotated Proof a)
   -- ^ Proof of body
-  , headerGenesisKey'       :: !VerificationKey
+  , headerGenesisKey       :: !VerificationKey
   -- ^ The genesis key that is delegating to publish this block
-  , headerSignature'        :: !BlockSignature
+  , headerSignature        :: !(ABlockSignature a)
   -- ^ The signature of the block, which contains the delegation certificate
-  , headerEpochSlots'       :: !EpochSlots
-  -- ^ Number of slots per epoch. This is needed to serialize the header.
-  , headerExtraAnnotation   :: ByteString
-  -- ^ An annotation that captures the bytes from the deprecated ExtraHeaderData
-  , headerAnnotation        :: ByteString
+  , headerAnnotation       :: !a
   -- ^ An annotation that captures the full header bytes
-  } deriving (Eq, Show, Generic, NFData)
-    deriving NoUnexpectedThunks via AllowThunksIn '["headerExtraAnnotation","headerAnnotation"] Header
-
-
-{-# COMPLETE UnsafeHeader #-}
-pattern UnsafeHeader
- :: ProtocolMagicId
- -> HeaderHash
- -> SlotNumber
- -> ChainDifficulty
- -> ProtocolVersion
- -> SoftwareVersion
- -> Proof
- -> VerificationKey
- -> BlockSignature
- -> EpochSlots
- -> Header
-pattern UnsafeHeader
-  { headerProtocolMagicId
-  , headerPrevHash
-  , headerSlot
-  , headerDifficulty
-  , headerProtocolVersion
-  , headerSoftwareVersion
-  , headerProof
-  , headerGenesisKey
-  , headerSignature
-  , headerEpochSlots
-  } <- Header'
-    (unAnnotated -> headerProtocolMagicId)
-    (unAnnotated -> headerPrevHash)
-    (unAnnotated -> headerSlot)
-    (unAnnotated -> headerDifficulty)
-    headerProtocolVersion
-    headerSoftwareVersion
-    headerProof
-    headerGenesisKey
-    headerSignature
-    headerEpochSlots
-    _ _
-  where
-  UnsafeHeader pm prevHash slotNumber difficulty pv sv proof genesisVK sig
-    epochSlots =
-    let pmBytes = serialize' pm
-        prevHashBytes = serialize' prevHash
-        slotNumberBytes = serialize' (fromSlotNumber epochSlots $ slotNumber)
-        difficultyBytes = serialize' difficulty
-        headerExtraBytes = serializeEncoding' $ toCBORBlockVersions pv sv
-        headerBytes = serializeEncoding' $
-          encodeListLen 5
-            <> encodePreEncoded pmBytes
-            <> encodePreEncoded prevHashBytes
-            <> encodePreEncoded (serialize' proof)
-            <> (  encodeListLen 4
-               <> encodePreEncoded slotNumberBytes
-               <> toCBOR genesisVK
-               <> encodePreEncoded difficultyBytes
-               <> toCBOR sig
-               )
-            <> encodePreEncoded headerExtraBytes
-    in Header'
-          (Annotated pm pmBytes)
-          (Annotated prevHash prevHashBytes)
-          (Annotated slotNumber slotNumberBytes)
-          (Annotated difficulty difficultyBytes)
-          pv
-          sv
-          proof
-          genesisVK
-          sig
-          epochSlots
-          headerExtraBytes
-          headerBytes
+  , headerExtraAnnotation  :: !a
+  -- ^ An annotation that captures the bytes from the deprecated ExtraHeaderData
+  } deriving (Eq, Show, Generic, NFData, Functor, NoUnexpectedThunks)
 
 
 --------------------------------------------------------------------------------
@@ -270,7 +186,7 @@ mkHeader pm prevHeader epochSlots = mkHeaderExplicit
   difficulty
   epochSlots
  where
-  prevHash   = either genesisHeaderHash hashHeader prevHeader
+  prevHash   = either genesisHeaderHash (hashHeader epochSlots) prevHeader
   difficulty = either
     (const $ ChainDifficulty 0)
     (succ . headerDifficulty)
@@ -295,32 +211,54 @@ mkHeaderExplicit
   -> SoftwareVersion
   -> Header
 mkHeaderExplicit pm prevHash difficulty epochSlots slotNumber sk dlgCert body pv sv
-  = UnsafeHeader pm prevHash slotNumber difficulty pv sv
-    proof genesisVK sig epochSlots
+  = AHeader
+    (Annotated pm ())
+    (Annotated prevHash ())
+    (Annotated slotNumber ())
+    (Annotated difficulty ())
+    pv
+    sv
+    (Annotated proof ())
+    genesisVK
+    sig
+    ()
+    ()
  where
   proof     = mkProof body
+
   genesisVK = Delegation.issuerVK dlgCert
-  sig       = BlockSignature dlgCert $ sign pm (SignBlock genesisVK) sk toSign
+
+  sig       = ABlockSignature dlgCert $ sign pm (SignBlock genesisVK) sk toSign
+
   toSign    = ToSign prevHash proof epochAndSlotCount difficulty pv sv
+
   epochAndSlotCount = fromSlotNumber epochSlots slotNumber
-
-
-
-
-
-
-
 
 
 --------------------------------------------------------------------------------
 -- Header Accessors
 --------------------------------------------------------------------------------
 
-headerIssuer :: Header -> VerificationKey
-headerIssuer h = case headerSignature h of
-  BlockSignature cert _ -> Delegation.delegateVK cert
+headerProtocolMagicId :: AHeader a -> ProtocolMagicId
+headerProtocolMagicId = unAnnotated . aHeaderProtocolMagicId
 
-headerToSign :: EpochSlots -> Header -> ToSign
+headerPrevHash :: AHeader a -> HeaderHash
+headerPrevHash = unAnnotated . aHeaderPrevHash
+
+headerSlot :: AHeader a -> SlotNumber
+headerSlot = unAnnotated . aHeaderSlot
+
+headerDifficulty :: AHeader a -> ChainDifficulty
+headerDifficulty = unAnnotated . aHeaderDifficulty
+
+headerProof :: AHeader a -> Proof
+headerProof = unAnnotated . aHeaderProof
+
+headerIssuer :: AHeader a -> VerificationKey
+headerIssuer h = case headerSignature h of
+  ABlockSignature cert _ -> Delegation.delegateVK cert
+
+headerToSign :: EpochSlots -> AHeader a -> ToSign
 headerToSign epochSlots h = ToSign
   (headerPrevHash h)
   (headerProof h)
@@ -329,18 +267,29 @@ headerToSign epochSlots h = ToSign
   (headerProtocolVersion h)
   (headerSoftwareVersion h)
 
-headerLength :: Header -> Natural
+headerLength :: AHeader ByteString -> Natural
 headerLength = fromIntegral . BS.length . headerAnnotation
 
-aHeaderProtocolMagicId :: Header -> Annotated ProtocolMagicId ByteString
-aHeaderProtocolMagicId = aHeaderProtocolMagicId'
 
 --------------------------------------------------------------------------------
 -- Header Binary Serialization
 --------------------------------------------------------------------------------
 
-instance ToCBOR Header where
-  toCBOR = encodePreEncoded . headerAnnotation
+-- | Encode a header, without taking in to account deprecated epoch boundary
+-- blocks.
+toCBORHeader :: EpochSlots -> Header -> Encoding
+toCBORHeader es h =
+  encodeListLen 5
+    <> toCBOR (headerProtocolMagicId h)
+    <> toCBOR (headerPrevHash h)
+    <> toCBOR (headerProof h)
+    <> (  encodeListLen 4
+       <> toCBOR (fromSlotNumber es $ headerSlot h)
+       <> toCBOR (headerGenesisKey h)
+       <> toCBOR (headerDifficulty h)
+       <> toCBOR (headerSignature h)
+       )
+    <> toCBORBlockVersions (headerProtocolVersion h) (headerSoftwareVersion h)
 
 toCBORBlockVersions :: ProtocolVersion -> SoftwareVersion -> Encoding
 toCBORBlockVersions pv sv =
@@ -352,20 +301,37 @@ toCBORBlockVersions pv sv =
     -- Hash of the encoding of empty ExtraBodyData
     <> toCBOR (hashRaw "\129\160")
 
-fromCBORHeader :: EpochSlots -> AnnotatedDecoder s Header
-fromCBORHeader epochSlots = withSlice' $ do
-  lift $ enforceSize "Header" 5
-  pm <- fromCBORAnnotated'
-  prevHash <- fromCBORAnnotated'
-  proof <- fromCBORAnnotated'
-  lift $ enforceSize "ConsensusData" 4
-  slot <- fmap (first (toSlotNumber epochSlots)) fromCBORAnnotated'
-  genesisKey <- lift fromCBOR
-  difficulty <- fromCBORAnnotated'
-  sig <- fromCBORAnnotated'
-  ((protocolVersion, softwareVersion), extraBytes) <- withSlice' $
-    (,) <$> lift fromCBORBlockVersions
-  pure $ Header'
+fromCBORHeader :: EpochSlots -> Decoder s Header
+fromCBORHeader epochSlots = void <$> fromCBORAHeader epochSlots
+
+fromCBORAHeader :: EpochSlots -> Decoder s (AHeader ByteSpan)
+fromCBORAHeader epochSlots = do
+  Annotated
+    ( pm
+    , prevHash
+    , proof
+    , (slot, genesisKey, difficulty, sig)
+    , Annotated (protocolVersion, softwareVersion) extraByteSpan
+    )
+    byteSpan <-
+    annotatedDecoder $ do
+      enforceSize "Header" 5
+      (,,,,)
+        <$> fromCBORAnnotated
+        <*> fromCBORAnnotated
+        <*> fromCBORAnnotated
+        <*> do
+              enforceSize "ConsensusData" 4
+              (,,,)
+                -- Next, we decode a 'EpochAndSlotCount' into a 'SlotNumber': the `EpochAndSlotCount`
+                -- used in 'AConsensusData' is encoded as a epoch and slot-count
+                -- pair.
+                <$> fmap (first (toSlotNumber epochSlots)) fromCBORAnnotated
+                <*> fromCBOR
+                <*> fromCBORAnnotated
+                <*> fromCBOR
+        <*> annotatedDecoder fromCBORBlockVersions
+  pure $ AHeader
     pm
     prevHash
     slot
@@ -375,16 +341,16 @@ fromCBORHeader epochSlots = withSlice' $ do
     proof
     genesisKey
     sig
-    epochSlots
-    extraBytes
+    byteSpan
+    extraByteSpan
 
 fromCBORBlockVersions :: Decoder s (ProtocolVersion, SoftwareVersion)
 fromCBORBlockVersions = do
   enforceSize "BlockVersions" 4
   (,) <$> fromCBOR <*> fromCBOR <* dropEmptyAttributes <* dropBytes
 
-instance Decoded Header where
-  type BaseType Header = Header
+instance Decoded (AHeader ByteString) where
+  type BaseType (AHeader ByteString) = Header
   recoverBytes = headerAnnotation
 
 -- | Encode a 'Header' accounting for deprecated epoch boundary blocks
@@ -392,19 +358,19 @@ instance Decoded Header where
 --   This encoding is only used when hashing the header for backwards
 --   compatibility, but should not be used when serializing a header within a
 --   block
-toCBORHeaderToHash :: Header -> Encoding
-toCBORHeaderToHash h =
-  encodeListLen 2 <> toCBOR (1 :: Word) <> toCBOR h
+toCBORHeaderToHash :: EpochSlots -> Header -> Encoding
+toCBORHeaderToHash epochSlots h =
+  encodeListLen 2 <> toCBOR (1 :: Word) <> toCBORHeader epochSlots h
 
-fromCBORHeaderToHash :: EpochSlots -> AnnotatedDecoder s (Maybe Header)
+fromCBORHeaderToHash :: EpochSlots -> Decoder s (Maybe Header)
 fromCBORHeaderToHash epochSlots = do
-  lift $ enforceSize "Header" 2
-  lift (fromCBOR @Word) >>= \case
+  enforceSize "Header" 2
+  fromCBOR @Word >>= \case
     0 -> do
-      void $ (fromCBORAnnotated' :: AnnotatedDecoder s BoundaryHeader)
+      void fromCBORABoundaryHeader
       pure Nothing
     1 -> Just <$!> fromCBORHeader epochSlots
-    t -> lift $ cborError $ DecoderErrorUnknownTag "Header" (fromIntegral t)
+    t -> cborError $ DecoderErrorUnknownTag "Header" (fromIntegral t)
 
 
 --------------------------------------------------------------------------------
@@ -412,10 +378,10 @@ fromCBORHeaderToHash epochSlots = do
 --------------------------------------------------------------------------------
 
 instance B.Buildable (WithEpochSlots Header) where
-  build (WithEpochSlots _ header) = renderHeader header
+  build (WithEpochSlots es header) = renderHeader es header
 
-renderHeader :: Header -> Builder
-renderHeader header = bprint
+renderHeader :: EpochSlots -> Header -> Builder
+renderHeader es header = bprint
   ( "Header:\n"
   . "    hash: " . hashHexF . "\n"
   . "    previous block: " . hashHexF . "\n"
@@ -436,7 +402,7 @@ renderHeader header = bprint
   (headerSignature header)
  where
   headerHash :: HeaderHash
-  headerHash = hashHeader header
+  headerHash = hashHeader es header
 
 
 --------------------------------------------------------------------------------
@@ -468,88 +434,95 @@ wrapHeaderBytes = mappend "\130\SOH"
 --
 --   For backwards compatibility we have to take the hash of the header
 --   serialised with 'toCBORHeaderToHash'
-hashHeader :: Header -> HeaderHash
-hashHeader = unsafeAbstractHash . serializeEncoding . toCBORHeaderToHash
+hashHeader :: EpochSlots -> Header -> HeaderHash
+hashHeader es = unsafeAbstractHash . serializeEncoding . toCBORHeaderToHash es
+
+headerHashAnnotated :: AHeader ByteString -> HeaderHash
+headerHashAnnotated = hashDecoded . fmap wrapHeaderBytes
 
 
 --------------------------------------------------------------------------------
 -- BoundaryHeader
 --------------------------------------------------------------------------------
 
-data BoundaryHeader = BoundaryHeader'
+data ABoundaryHeader a = UnsafeABoundaryHeader
   { boundaryPrevHash         :: !(Either GenesisHash HeaderHash)
   , boundaryEpoch            :: !Word64
   , boundaryDifficulty       :: !ChainDifficulty
-  , boundaryHeaderSerialized :: ByteString
-  } deriving (Eq, Show, Generic)
-    deriving NoUnexpectedThunks via AllowThunksIn '["boundaryHeaderSerialized"] BoundaryHeader
+  , boundaryHeaderAnnotation :: !a
+  } deriving (Eq, Show, Functor, Generic, NoUnexpectedThunks)
 
-pattern BoundaryHeader
-  :: (Either GenesisHash HeaderHash)
-  -> Word64
-  -> ChainDifficulty
-  -> BoundaryHeader
-pattern BoundaryHeader prevHash epoch difficulty <- BoundaryHeader' prevHash epoch difficulty _
+-- | Smart constructor for 'ABoundaryHeader'
+--
+-- Makes sure that the hash is forced.
+mkABoundaryHeader :: Either GenesisHash HeaderHash
+                  -> Word64
+                  -> ChainDifficulty
+                  -> a
+                  -> ABoundaryHeader a
+mkABoundaryHeader prevHash epoch dty ann =
+    case prevHash of
+      Left  !genHash -> UnsafeABoundaryHeader (Left  genHash) epoch dty ann
+      Right !hdrHash -> UnsafeABoundaryHeader (Right hdrHash) epoch dty ann
 
-mkBoundaryHeader
-  :: ProtocolMagicId
-  -> (Either GenesisHash HeaderHash)
-  -> Word64
-  -> ChainDifficulty
-  -> BoundaryHeader
-mkBoundaryHeader pm prevHash epoch difficulty =
-    let bytes = serializeEncoding' $ encodeListLen 5
-          <> toCBOR pm
-          <> ( case prevHash of
-                 Left  gh -> toCBOR (genesisHeaderHash gh)
-                 Right hh -> toCBOR hh
-             )
-          -- Body proof
-          <> toCBOR (hash (mempty :: LByteString))
-          -- Consensus data
-          <> ( encodeListLen 2
-              -- Epoch
-              <> toCBOR epoch
-              -- Chain difficulty
-              <> toCBOR difficulty
-             )
-          -- Extra data
-          <> ( encodeListLen 1
-              <> toCBOR genesisTag
-             )
-       -- Genesis tag to indicate the presence of a genesis hash in a non-zero
-       -- epoch. See 'dropBoundaryExtraHeaderDataRetainGenesisTag' for more
-       -- details on this.
-        genesisTag = case (prevHash, epoch) of
-          (Left _, n) | n > 0 -> Map.singleton 255 "Genesis"
-          _ -> mempty :: Map Word8 LByteString
-        hashData = case prevHash of
-          Left  !genHash -> Left  genHash
-          Right !hdrHash -> Right hdrHash
-    in BoundaryHeader' hashData epoch difficulty bytes
-
+instance Decoded (ABoundaryHeader ByteString) where
+  type BaseType (ABoundaryHeader ByteString) = ABoundaryHeader ()
+  recoverBytes = boundaryHeaderAnnotation
 
 -- | Compute the hash of a boundary block header from its annotation.
 -- It uses `wrapBoundaryBytes`, for the hash must be computed on the header
 -- bytes tagged with the CBOR list length and tag discriminator, which is
 -- the encoding chosen by cardano-sl.
-boundaryHeaderHashAnnotated :: BoundaryHeader -> HeaderHash
-boundaryHeaderHashAnnotated = coerce . hash . wrapBoundaryBytes . boundaryHeaderSerialized
+boundaryHeaderHashAnnotated :: ABoundaryHeader ByteString -> HeaderHash
+boundaryHeaderHashAnnotated = coerce . hashDecoded . fmap wrapBoundaryBytes
 
-instance FromCBORAnnotated BoundaryHeader where
-  fromCBORAnnotated' = withSlice' $ do
-    lift $ enforceSize "BoundaryHeader" 5
-    lift dropInt32
-    hh <- lift fromCBOR
+-- | Encode from a boundary header with any annotation. This does not
+-- necessarily invert `fromCBORBoundaryHeader`, because that decoder drops
+-- information that this encoder replaces, such as the body proof (assumes
+-- the body is empty) and the extra header data (sets it to empty map).
+toCBORABoundaryHeader :: ProtocolMagicId -> ABoundaryHeader a -> Encoding
+toCBORABoundaryHeader pm hdr =
+    encodeListLen 5
+      <> toCBOR pm
+      <> ( case boundaryPrevHash hdr of
+             Left  gh -> toCBOR (genesisHeaderHash gh)
+             Right hh -> toCBOR hh
+         )
+      -- Body proof
+      <> toCBOR (hash (mempty :: LByteString))
+      -- Consensus data
+      <> ( encodeListLen 2
+          -- Epoch
+          <> toCBOR (boundaryEpoch hdr)
+          -- Chain difficulty
+          <> toCBOR (boundaryDifficulty hdr)
+         )
+      -- Extra data
+      <> ( encodeListLen 1
+          <> toCBOR genesisTag
+         )
+  where
+    -- Genesis tag to indicate the presence of a genesis hash in a non-zero
+    -- epoch. See 'dropBoundaryExtraHeaderDataRetainGenesisTag' for more
+    -- details on this.
+    genesisTag = case (boundaryPrevHash hdr, boundaryEpoch hdr) of
+      (Left _, n) | n > 0 -> Map.singleton 255 "Genesis"
+      _ -> mempty :: Map Word8 LByteString
+
+fromCBORABoundaryHeader :: Decoder s (ABoundaryHeader ByteSpan)
+fromCBORABoundaryHeader = do
+  Annotated header bytespan <- annotatedDecoder $ do
+    enforceSize "BoundaryHeader" 5
+    dropInt32
+    -- HeaderHash
+    hh <- fromCBOR
     -- BoundaryBodyProof
-    lift dropBytes
-    (epoch, difficulty) <- lift fromCBORBoundaryConsensusData
-    isGen <- lift dropBoundaryExtraHeaderDataRetainGenesisTag
+    dropBytes
+    (epoch, difficulty) <- fromCBORBoundaryConsensusData
+    isGen <- dropBoundaryExtraHeaderDataRetainGenesisTag
     let hh' = if epoch == 0 || isGen then Left (coerce hh) else Right hh
-    pure $ BoundaryHeader' hh' epoch difficulty
-
-instance ToCBOR BoundaryHeader where
-  toCBOR = encodePreEncoded . boundaryHeaderSerialized
+    pure $ mkABoundaryHeader hh' epoch difficulty ()
+  pure (header { boundaryHeaderAnnotation = bytespan })
 
 -- | These bytes must be prepended when hashing raw boundary header data
 --
@@ -559,9 +532,12 @@ instance ToCBOR BoundaryHeader where
 wrapBoundaryBytes :: ByteString -> ByteString
 wrapBoundaryBytes = mappend "\130\NUL"
 
+
 --------------------------------------------------------------------------------
 -- BlockSignature
 --------------------------------------------------------------------------------
+
+type BlockSignature = ABlockSignature ()
 
 -- | Signature of the 'Block'
 --
@@ -569,38 +545,40 @@ wrapBoundaryBytes = mappend "\130\NUL"
 --
 --   1. A delegation certificate from a genesis key to the block signer
 --   2. The actual signature over `ToSign`
-data BlockSignature = BlockSignature
-  { delegationCertificate :: !Delegation.Certificate
+data ABlockSignature a = ABlockSignature
+  { delegationCertificate :: !(Delegation.ACertificate a)
   , signature             :: !(Signature ToSign)
-  } deriving (Show, Eq, Generic)
+  } deriving (Show, Eq, Generic, Functor)
     deriving anyclass (NFData, NoUnexpectedThunks)
 
 instance B.Buildable BlockSignature where
-  build (BlockSignature cert _) = bprint
+  build (ABlockSignature cert _) = bprint
     ( "BlockSignature:\n"
     . "  Delegation certificate: " . build
     )
     cert
 
 instance ToCBOR BlockSignature where
-  toCBOR (BlockSignature cert sig) =
+  toCBOR (ABlockSignature cert sig) =
     -- Tag 0 was previously used for BlockSignature (no delegation)
     -- Tag 1 was previously used for BlockPSignatureLight
     encodeListLen 2
       <> toCBOR (2 :: Word8)
       <> (encodeListLen 2 <> toCBOR cert <> toCBOR sig)
 
-instance FromCBORAnnotated BlockSignature where
-  fromCBORAnnotated' = do
-    lift $ enforceSize "BlockSignature" 2
-    lift fromCBOR >>= \case
-      2 ->
-        BlockSignature
-          <$  lift (enforceSize "BlockSignature" 2)
-          <*> fromCBORAnnotated'
-          <*> lift fromCBOR
-      t -> lift $ cborError $ DecoderErrorUnknownTag "BlockSignature" t
+instance FromCBOR BlockSignature where
+  fromCBOR = void <$> fromCBOR @(ABlockSignature ByteSpan)
 
+instance FromCBOR (ABlockSignature ByteSpan) where
+  fromCBOR = do
+    enforceSize "BlockSignature" 2
+    fromCBOR >>= \case
+      2 ->
+        ABlockSignature
+          <$  enforceSize "BlockSignature" 2
+          <*> fromCBOR
+          <*> fromCBOR
+      t -> cborError $ DecoderErrorUnknownTag "BlockSignature" t
 
 
 --------------------------------------------------------------------------------
@@ -609,7 +587,7 @@ instance FromCBORAnnotated BlockSignature where
 
 -- | Produces the ByteString that was signed in the block
 recoverSignedBytes
-  :: EpochSlots -> Header -> Annotated ToSign ByteString
+  :: EpochSlots -> AHeader ByteString -> Annotated ToSign ByteString
 recoverSignedBytes es h = Annotated (headerToSign es h) bytes
  where
   bytes = BS.concat
@@ -618,7 +596,7 @@ recoverSignedBytes es h = Annotated (headerToSign es h) bytes
     -- It is hard coded here because the signed bytes included it as an
     -- implementation artifact
     , (annotation . aHeaderPrevHash) h
-    , (proofSerialized . headerProof) h
+    , (annotation . aHeaderProof) h
     , (annotation . aHeaderSlot) h
     , (annotation . aHeaderDifficulty) h
     , headerExtraAnnotation h
@@ -644,12 +622,8 @@ instance ToCBOR ToSign where
       <> toCBOR (tsDifficulty ts)
       <> toCBORBlockVersions (tsProtocolVersion ts) (tsSoftwareVersion ts)
 
-instance FromCBORAnnotated ToSign where
-  fromCBORAnnotated' = do
-    lift $ enforceSize "ToSign" 5
-    headerHash <- lift fromCBOR
-    bodyProof <- fromCBORAnnotated'
-    slotCount' <- lift fromCBOR
-    difficulty <- lift fromCBOR
-    (protocolVersion, softwareVersion) <- lift fromCBORBlockVersions
-    pure $ ToSign headerHash bodyProof slotCount' difficulty protocolVersion softwareVersion
+instance FromCBOR ToSign where
+  fromCBOR = do
+    enforceSize "ToSign" 5
+    fmap uncurry (ToSign <$> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR)
+      <*> fromCBORBlockVersions

--- a/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
@@ -1,21 +1,10 @@
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms   #-}
 
 module Cardano.Chain.Block.Proof
-  ( Proof
-    ( proofUTxO
-    , proofSsc
-    , proofDelegation
-    , proofUpdate
-    , proofSerialized
-    )
-  , pattern Proof
+  ( Proof(..)
   , ProofValidationError (..)
   , mkProof
   , recoverProof
@@ -27,47 +16,23 @@ import Cardano.Prelude
 import Formatting (bprint, build, shown)
 import qualified Formatting.Buildable as B
 
-import Cardano.Binary
-  ( FromCBOR(..)
-  , FromCBORAnnotated(..)
-  , ToCBOR(..)
-  , encodeListLen
-  , enforceSize
-  , serializeEncoding'
-  , encodePreEncoded
-  , withSlice'
-  )
+import Cardano.Binary (FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize)
 import Cardano.Chain.Block.Body
-  (Body(..), bodyDlgPayload, bodyTxPayload, bodyUpdatePayload)
+  (ABody(..), Body, bodyDlgPayload, bodyTxPayload, bodyUpdatePayload)
 import qualified Cardano.Chain.Delegation.Payload as Delegation
 import Cardano.Chain.Ssc (SscProof(..))
 import Cardano.Chain.UTxO.TxProof (TxProof, mkTxProof, recoverTxProof)
 import qualified Cardano.Chain.Update.Proof as Update
-import Cardano.Crypto (Hash, hash)
+import Cardano.Crypto (Hash, hash, hashDecoded)
 
 
 -- | Proof of everything contained in the payload
-data Proof = Proof'
-  { proofUTxO'      :: !TxProof
-  , proofSsc'       :: !SscProof
-  , proofDelegation':: !(Hash Delegation.Payload)
-  , proofUpdate'    :: !Update.Proof
-  , proofSerialized :: ByteString
-  } deriving (Eq, Show, Generic, NFData)
-    deriving NoUnexpectedThunks via AllowThunksIn '["proofSerialized"] Proof
-
-{-# COMPLETE Proof #-}
-pattern Proof :: TxProof -> SscProof -> (Hash Delegation.Payload) -> Update.Proof -> Proof
-pattern Proof{ proofUTxO, proofSsc, proofDelegation, proofUpdate } <-
-  Proof' proofUTxO proofSsc proofDelegation proofUpdate _
-  where
-  Proof utxo ssc delegation update =
-    let bytes = serializeEncoding' $ encodeListLen 4
-          <> toCBOR utxo
-          <> toCBOR ssc
-          <> toCBOR delegation
-          <> toCBOR update
-    in Proof' utxo ssc delegation update bytes
+data Proof = Proof
+  { proofUTxO       :: !TxProof
+  , proofSsc        :: !SscProof
+  , proofDelegation :: !(Hash Delegation.Payload)
+  , proofUpdate     :: !Update.Proof
+  } deriving (Eq, Show, Generic, NFData, NoUnexpectedThunks)
 
 instance B.Buildable Proof where
   build proof = bprint
@@ -78,30 +43,34 @@ instance B.Buildable Proof where
     (proofUpdate proof)
 
 instance ToCBOR Proof where
-  toCBOR = encodePreEncoded . proofSerialized
+  toCBOR bc =
+    encodeListLen 4
+      <> toCBOR (proofUTxO bc)
+      <> toCBOR (proofSsc bc)
+      <> toCBOR (proofDelegation bc)
+      <> toCBOR (proofUpdate bc)
 
-instance FromCBORAnnotated Proof where
-  fromCBORAnnotated' = withSlice' $
-     Proof' <$ lift (enforceSize "Proof" 4)
-     <*> fromCBORAnnotated'
-     <*> lift fromCBOR
-     <*> lift fromCBOR
-     <*> lift fromCBOR
+instance FromCBOR Proof where
+  fromCBOR = do
+    enforceSize "Proof" 4
+    Proof <$> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR
 
 mkProof :: Body -> Proof
 mkProof body = Proof
-   (mkTxProof $ bodyTxPayload body)
-   SscProof
-   (hash $ bodyDlgPayload body)
-   (Update.mkProof $ bodyUpdatePayload body)
+  { proofUTxO        = mkTxProof $ bodyTxPayload body
+  , proofSsc        = SscProof
+  , proofDelegation = hash $ bodyDlgPayload body
+  , proofUpdate     = Update.mkProof $ bodyUpdatePayload body
+  }
 
 -- TODO: Should we be using this somewhere?
-recoverProof :: Body -> Proof
+recoverProof :: ABody ByteString -> Proof
 recoverProof body = Proof
-   (recoverTxProof $ bodyTxPayload body)
-   SscProof
-   (hash $ bodyDlgPayload body)
-   (Update.recoverProof $ bodyUpdatePayload body)
+  { proofUTxO        = recoverTxProof $ bodyTxPayload body
+  , proofSsc        = SscProof
+  , proofDelegation = hashDecoded $ bodyDlgPayload body
+  , proofUpdate     = Update.recoverProof $ bodyUpdatePayload body
+  }
 
 -- | Error which can result from attempting to validate an invalid payload
 -- proof.

--- a/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
@@ -9,13 +9,13 @@
 
 module Cardano.Chain.Block.Proof
   ( Proof
-    ( Proof
-    , proofUTxO
+    ( proofUTxO
     , proofSsc
     , proofDelegation
     , proofUpdate
     , proofSerialized
     )
+  , pattern Proof
   , ProofValidationError (..)
   , mkProof
   , recoverProof

--- a/cardano-ledger/src/Cardano/Chain/Common/Merkle.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Merkle.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE UndecidableInstances       #-}
@@ -47,7 +48,8 @@ import qualified Data.Foldable as Foldable
 import Formatting.Buildable (Buildable(..))
 import qualified Prelude
 
-import Cardano.Binary (Annotated(..), FromCBOR(..), Raw, ToCBOR(..), serializeBuilder)
+import Cardano.Binary
+  (Annotated(..), FromCBOR(..), Raw, ToCBOR(..), serializeBuilder)
 import Cardano.Crypto (AbstractHash(..), Hash, hashDecoded, hashRaw)
 
 
@@ -68,7 +70,7 @@ instance Buildable (MerkleRoot a) where
 instance ToCBOR a => ToCBOR (MerkleRoot a) where
   toCBOR = toCBOR . getMerkleRoot
 
-instance Typeable a => FromCBOR (MerkleRoot a) where
+instance FromCBOR a => FromCBOR (MerkleRoot a) where
   fromCBOR = MerkleRoot <$> fromCBOR
 
 merkleRootToBuilder :: MerkleRoot a -> Builder

--- a/cardano-ledger/src/Cardano/Chain/Common/NetworkMagic.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/NetworkMagic.hs
@@ -16,7 +16,7 @@ import qualified Formatting.Buildable as B
 
 import           Cardano.Binary (DecoderError(..), FromCBOR(..), ToCBOR(..),
                      decodeListLen, decodeWord8, encodeListLen , matchSize)
-import           Cardano.Crypto.ProtocolMagic (ProtocolMagic (..),
+import           Cardano.Crypto.ProtocolMagic (AProtocolMagic (..),
                      RequiresNetworkMagic (..), getProtocolMagic)
 
 
@@ -53,7 +53,7 @@ instance FromCBOR NetworkMagic where
       1 -> matchSize "NetworkMagic" 2 len >> NetworkTestnet <$> fromCBOR
       _ -> cborError $ DecoderErrorUnknownTag "NetworkMagic" tag
 
-makeNetworkMagic :: ProtocolMagic -> NetworkMagic
+makeNetworkMagic :: AProtocolMagic a -> NetworkMagic
 makeNetworkMagic pm = case getRequiresNetworkMagic pm of
     RequiresNoMagic -> NetworkMainOrStage
     RequiresMagic   -> NetworkTestnet (getProtocolMagic pm)

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
@@ -21,11 +21,12 @@
 module Cardano.Chain.Delegation.Certificate
   (
   -- * Certificate
-    Certificate(UnsafeCertificate, epoch, issuerVK, delegateVK, signature, serialize)
+    Certificate(epoch, issuerVK, delegateVK, signature, serialize)
   , CertificateId
 
   -- * Certificate Constructors
   , signCertificate
+  , pattern UnsafeCertificate
 
   -- * Certificate Accessor
   , certificateId
@@ -155,7 +156,7 @@ certificateId = hash
 
 -- | A 'Certificate' is valid if the 'Signature' is valid
 isValid
-  :: ProtocolMagicId
+  :: Annotated ProtocolMagicId ByteString
   -> Certificate
   -> Bool
 isValid pm cert =

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
@@ -1,9 +1,7 @@
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveFunctor         #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -12,24 +10,24 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
-{-# LANGUAGE UndecidableInstances  #-}
-{-# LANGUAGE PatternSynonyms       #-}
-{-# LANGUAGE ViewPatterns          #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Chain.Delegation.Certificate
   (
   -- * Certificate
-    Certificate(epoch, issuerVK, delegateVK, signature, serialize)
+    Certificate
+  , ACertificate(..)
   , CertificateId
 
   -- * Certificate Constructors
   , signCertificate
-  , pattern UnsafeCertificate
+  , unsafeCertificate
 
   -- * Certificate Accessor
+  , epoch
   , certificateId
+  , recoverCertificateId
 
   -- * Certificate Predicate
   , isValid
@@ -47,15 +45,15 @@ import Text.JSON.Canonical
 
 import Cardano.Binary
   ( Annotated(Annotated, unAnnotated)
+  , ByteSpan
+  , Decoded(..)
   , FromCBOR(..)
   , ToCBOR(..)
-  , FromCBORAnnotated (..)
+  , annotatedDecoder
+  , fromCBORAnnotated
   , encodeListLen
   , enforceSize
   , serialize'
-  , encodePreEncoded
-  , serializeEncoding'
-  , withSlice'
   )
 import Cardano.Chain.Slotting (EpochNumber)
 import Cardano.Crypto
@@ -66,6 +64,7 @@ import Cardano.Crypto
   , Signature
   , VerificationKey(unVerificationKey)
   , hash
+  , hashDecoded
   , safeSign
   , safeToVerification
   , verifySignatureDecoded
@@ -79,52 +78,31 @@ import Cardano.Crypto
 -- | A delegation certificate identifier (the 'Hash' of a 'Certificate').
 type CertificateId = Hash Certificate
 
+type Certificate = ACertificate ()
+
 -- | Delegation certificate allowing the @delegateVK@ to sign blocks on behalf
 --   of @issuerVK@
 --
 --   Each delegator can publish at most one 'Certificate' per 'EpochNumber', and
 --   that 'EpochNumber' must correspond to the current or next 'EpochNumber' at
 --   the time of publishing
-data Certificate = UnsafeCertificate'
-  { aEpoch     :: !(Annotated EpochNumber ByteString)
+data ACertificate a = UnsafeACertificate
+  { aEpoch     :: !(Annotated EpochNumber a)
   -- ^ The epoch from which the delegation is valid
-  , issuerVK'  :: !VerificationKey
+  , issuerVK   :: !VerificationKey
   -- ^ The issuer of the certificate, who delegates their right to sign blocks
-  , delegateVK':: !VerificationKey
+  , delegateVK :: !VerificationKey
   -- ^ The delegate, who gains the right to sign blocks
-  , signature' :: !(Signature EpochNumber)
+  , signature  :: !(Signature EpochNumber)
   -- ^ The signature that proves the certificate was issued by @issuerVK@
-  , serialize  :: ByteString
-  } deriving (Eq, Ord, Show, Generic)
-    deriving anyclass (NFData)
-    deriving NoUnexpectedThunks via AllowThunksIn '["serialize"] Certificate
+  , annotation :: !a
+  } deriving (Eq, Ord, Show, Generic, Functor)
+    deriving anyclass (NFData, NoUnexpectedThunks)
+
 
 --------------------------------------------------------------------------------
 -- Certificate Constructors
 --------------------------------------------------------------------------------
-
--- | Create a certificate using the provided signature.
-{-# COMPLETE UnsafeCertificate #-}
-pattern UnsafeCertificate
-  :: EpochNumber
-  -> VerificationKey
-  -- ^ The issuer of the certificate.
-  -> VerificationKey
-  -- ^ The delegate of the certificate.
-  -> Signature EpochNumber
-  -> Certificate
-pattern UnsafeCertificate { epoch, issuerVK, delegateVK, signature } <-
-    UnsafeCertificate' (unAnnotated -> epoch) issuerVK delegateVK signature _
-  where
-  UnsafeCertificate epochNumber ivk dvk sig =
-    let serialize =  serializeEncoding' $ encodeListLen 4
-          <> encodePreEncoded epochNumberBytes
-          <> toCBOR ivk
-          <> toCBOR dvk
-          <> toCBOR sig
-        epochNumberBytes = serialize' epochNumber
-        aEpoch = Annotated epochNumber epochNumberBytes
-    in UnsafeCertificate' aEpoch ivk dvk sig serialize
 
 -- | Create a 'Certificate', signing it with the provided safe signer.
 signCertificate
@@ -133,22 +111,45 @@ signCertificate
   -> EpochNumber
   -> SafeSigner
   -> Certificate
-signCertificate protocolMagicId dvk epochNumber safeSigner =
-  UnsafeCertificate epochNumber ivk dvk (coerce sig)
-  where
-  ivk   = safeToVerification safeSigner
+signCertificate protocolMagicId delegateVK epochNumber safeSigner =
+  UnsafeACertificate
+  { aEpoch     = Annotated epochNumber ()
+  , issuerVK   = safeToVerification safeSigner
+  , delegateVK = delegateVK
+  , signature  = coerce sig
+  , annotation = ()
+  }
+ where
   sig = safeSign protocolMagicId SignCertificate safeSigner
     $ mconcat [ "00"
-              , CC.unXPub (unVerificationKey dvk)
+              , CC.unXPub (unVerificationKey delegateVK)
               , serialize' epochNumber]
+
+-- | Create a certificate using the provided signature.
+unsafeCertificate
+  :: EpochNumber
+  -> VerificationKey
+  -- ^ The issuer of the certificate. See 'UnsafeACertificate'.
+  -> VerificationKey
+  -- ^ The delegate of the certificate. See 'UnsafeACertificate'.
+  -> Signature EpochNumber
+  -> Certificate
+unsafeCertificate e ivk dvk sig = UnsafeACertificate (Annotated e ()) ivk dvk sig ()
 
 
 --------------------------------------------------------------------------------
 -- Certificate Accessor
 --------------------------------------------------------------------------------
 
-certificateId :: Certificate -> CertificateId
-certificateId = hash
+epoch :: ACertificate a -> EpochNumber
+epoch = unAnnotated . aEpoch
+
+certificateId :: ACertificate a -> CertificateId
+certificateId = hash . void
+
+recoverCertificateId :: ACertificate ByteString -> CertificateId
+recoverCertificateId = hashDecoded
+
 
 --------------------------------------------------------------------------------
 -- Certificate Predicate
@@ -157,18 +158,18 @@ certificateId = hash
 -- | A 'Certificate' is valid if the 'Signature' is valid
 isValid
   :: Annotated ProtocolMagicId ByteString
-  -> Certificate
+  -> ACertificate ByteString
   -> Bool
-isValid pm cert =
+isValid pm UnsafeACertificate { aEpoch, issuerVK, delegateVK, signature } =
   verifySignatureDecoded
     pm
     SignCertificate
-    (issuerVK cert)
+    issuerVK
     (   serialize'
-    .   mappend ("00" <> CC.unXPub (unVerificationKey $ delegateVK cert))
-    <$> (aEpoch cert)
+    .   mappend ("00" <> CC.unXPub (unVerificationKey delegateVK))
+    <$> aEpoch
     )
-    (signature cert)
+    signature
 
 
 --------------------------------------------------------------------------------
@@ -176,29 +177,44 @@ isValid pm cert =
 --------------------------------------------------------------------------------
 
 instance ToCBOR Certificate where
-  toCBOR = encodePreEncoded . serialize
+  toCBOR cert =
+    encodeListLen 4
+      <> toCBOR (epoch cert)
+      <> toCBOR (issuerVK cert)
+      <> toCBOR (delegateVK cert)
+      <> toCBOR (signature cert)
 
-instance FromCBORAnnotated Certificate where
-  fromCBORAnnotated' = withSlice' $
-    UnsafeCertificate' <$ lift (enforceSize "Delegation.Certificate" 4)
-      <*> fromCBORAnnotated'
-      <*> lift fromCBOR
-      <*> lift fromCBOR
-      <*> lift fromCBOR
+instance FromCBOR Certificate where
+  fromCBOR = void <$> fromCBOR @(ACertificate ByteSpan)
+
+instance FromCBOR (ACertificate ByteSpan) where
+  fromCBOR = do
+    Annotated (e, ivk, dvk, sig) byteSpan <- annotatedDecoder $ do
+      enforceSize "Delegation.Certificate" 4
+      (,,,)
+        <$> fromCBORAnnotated
+        <*> fromCBOR
+        <*> fromCBOR
+        <*> fromCBOR
+    pure $ UnsafeACertificate e ivk dvk sig byteSpan
+
+instance Decoded (ACertificate ByteString) where
+  type BaseType (ACertificate ByteString) = Certificate
+  recoverBytes = annotation
 
 
 --------------------------------------------------------------------------------
 -- Certificate Formatting
 --------------------------------------------------------------------------------
 
-instance B.Buildable Certificate where
-  build (UnsafeCertificate e iVK dVK _) = bprint
+instance B.Buildable (ACertificate a) where
+  build (UnsafeACertificate e iVK dVK _ _) = bprint
     ( "Delegation.Certificate { w = " . build
     . ", iVK = " . build
     . ", dVK = " . build
     . " }"
     )
-    e
+    (unAnnotated e)
     iVK
     dVK
 
@@ -218,7 +234,7 @@ instance Monad m => ToJSON m Certificate where
 
 instance MonadError SchemaError m => FromJSON m Certificate where
   fromJSON obj =
-    UnsafeCertificate
+    unsafeCertificate
       <$> (fromIntegral @Int54 <$> fromJSField obj "omega")
       <*> fromJSField obj "issuerPk"
       <*> fromJSField obj "delegatePk"

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Payload.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Payload.hs
@@ -10,7 +10,8 @@
 {-# LANGUAGE PatternSynonyms            #-}
 
 module Cardano.Chain.Delegation.Payload
-  ( Payload( UnsafePayload, getPayload, serializePayload )
+  ( Payload( getPayload, serializePayload )
+  , pattern UnsafePayload
   )
 where
 

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Interface.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Interface.hs
@@ -24,7 +24,8 @@ import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 
 import Cardano.Binary
-  ( FromCBOR(..)
+  ( Annotated(..)
+  , FromCBOR(..)
   , ToCBOR(..)
   , encodeListLen
   , enforceSize
@@ -47,7 +48,7 @@ import Cardano.Crypto (ProtocolMagicId, VerificationKey)
 --------------------------------------------------------------------------------
 
 data Environment = Environment
-  { protocolMagic      :: !ProtocolMagicId
+  { protocolMagic      :: !(Annotated ProtocolMagicId ByteString)
   , allowedDelegators  :: !(Set KeyHash)
   , k                  :: !BlockCount
   , currentEpoch       :: !EpochNumber

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Scheduling.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Scheduling.hs
@@ -34,7 +34,7 @@ import Cardano.Binary
   , matchSize
   )
 import Cardano.Chain.Common (BlockCount, KeyHash, hashKey)
-import Cardano.Chain.Delegation.Certificate (Certificate)
+import Cardano.Chain.Delegation.Certificate (ACertificate)
 import qualified Cardano.Chain.Delegation.Certificate as Certificate
 import Cardano.Chain.ProtocolConstants (kSlotSecurityParam)
 import Cardano.Chain.Slotting
@@ -161,7 +161,7 @@ scheduleCertificate
   :: MonadError Error m
   => Environment
   -> State
-  -> Certificate
+  -> ACertificate ByteString
   -> m State
 scheduleCertificate env st cert = do
   -- Check that the delegator is a genesis key

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Scheduling.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Validation/Scheduling.hs
@@ -22,7 +22,8 @@ import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 
 import Cardano.Binary
-  ( Decoder
+  ( Annotated(..)
+  , Decoder
   , DecoderError(..)
   , FromCBOR(..)
   , ToCBOR(..)
@@ -49,7 +50,7 @@ import Cardano.Crypto (ProtocolMagicId)
 --------------------------------------------------------------------------------
 
 data Environment = Environment
-  { protocolMagic     :: !ProtocolMagicId
+  { protocolMagic     :: !(Annotated ProtocolMagicId ByteString)
   , allowedDelegators :: !(Set KeyHash)
   , currentEpoch      :: !EpochNumber
   , currentSlot       :: !SlotNumber

--- a/cardano-ledger/src/Cardano/Chain/Epoch/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Epoch/Validation.hs
@@ -18,7 +18,7 @@ import Streaming (Of(..), Stream, hoist)
 import qualified Streaming.Prelude as S
 
 import Cardano.Chain.Block
-  ( BlockOrBoundary(..)
+  ( ABlockOrBoundary(..)
   , ChainValidationError
   , ChainValidationState(..)
   , blockSlot
@@ -84,7 +84,7 @@ validateEpochFiles vMode config cvs fps =
 foldChainValidationState
   :: Genesis.Config
   -> ChainValidationState
-  -> Stream (Of BlockOrBoundary) (ExceptT ParseError ResIO) ()
+  -> Stream (Of (ABlockOrBoundary ByteString)) (ExceptT ParseError ResIO) ()
   -> ExceptT EpochError (ReaderT ValidationMode ResIO) ChainValidationState
 foldChainValidationState config chainValState blocks = S.foldM_
   (\cvs block ->
@@ -94,7 +94,7 @@ foldChainValidationState config chainValState blocks = S.foldM_
   (pure chainValState)
   pure (pure (hoist (withExceptT EpochParseError) blocks))
  where
-  blockOrBoundarySlot :: BlockOrBoundary -> Maybe EpochAndSlotCount
+  blockOrBoundarySlot :: ABlockOrBoundary a -> Maybe EpochAndSlotCount
   blockOrBoundarySlot = \case
-    BOBBoundary _     -> Nothing
-    BOBBlock    block -> Just . fromSlotNumber mainnetEpochSlots $ blockSlot block
+    ABOBBoundary _     -> Nothing
+    ABOBBlock    block -> Just . fromSlotNumber mainnetEpochSlots $ blockSlot block

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Config.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Config.hs
@@ -27,7 +27,7 @@ import Cardano.Prelude
 import Control.Monad.Except (MonadError(..))
 import Data.Time (UTCTime)
 
-import Cardano.Binary (Raw)
+import Cardano.Binary (Annotated(..), Raw)
 import Cardano.Chain.Block.Header (HeaderHash, genesisHeaderHash)
 import Cardano.Chain.Common (BlockCount)
 import Cardano.Chain.Genesis.Data
@@ -44,7 +44,7 @@ import Cardano.Chain.Update (ProtocolParameters)
 import Cardano.Chain.UTxO.UTxOConfiguration
   (UTxOConfiguration, defaultUTxOConfiguration)
 import Cardano.Crypto
-  ( ProtocolMagic(..)
+  ( AProtocolMagic(..)
   , Hash
   , ProtocolMagic
   , ProtocolMagicId(..)
@@ -87,7 +87,7 @@ configEpochSlots = kEpochSlots . configK
 -- @ProtocolMagicId@ and @RequiresNetworkMagic@ are stored separately.
 -- We use them to construct and return a @ProtocolMagic@.
 configProtocolMagic :: Config -> ProtocolMagic
-configProtocolMagic config = ProtocolMagic pmi rnm
+configProtocolMagic config = AProtocolMagic (Annotated pmi ()) rnm
  where
   pmi = configProtocolMagicId config
   rnm = configReqNetMagic config

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Data.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Data.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE PatternSynonyms  #-}
 
 module Cardano.Chain.Genesis.Data
   ( GenesisData(..)
@@ -44,7 +45,11 @@ import Cardano.Chain.Genesis.Hash (GenesisHash(..))
 import Cardano.Chain.Genesis.NonAvvmBalances (GenesisNonAvvmBalances)
 import Cardano.Chain.Genesis.KeyHashes (GenesisKeyHashes)
 import Cardano.Chain.Update.ProtocolParameters (ProtocolParameters)
-import Cardano.Crypto (ProtocolMagicId (..), hashRaw)
+import Cardano.Crypto
+  ( ProtocolMagicId (..)
+  , pattern ProtocolMagicId
+  , hashRaw
+  )
 
 
 -- | Genesis data contains all data which determines consensus rules. It must be

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Data.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Data.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE UndecidableInstances  #-}
-{-# LANGUAGE PatternSynonyms  #-}
 
 module Cardano.Chain.Genesis.Data
   ( GenesisData(..)
@@ -46,8 +45,7 @@ import Cardano.Chain.Genesis.NonAvvmBalances (GenesisNonAvvmBalances)
 import Cardano.Chain.Genesis.KeyHashes (GenesisKeyHashes)
 import Cardano.Chain.Update.ProtocolParameters (ProtocolParameters)
 import Cardano.Crypto
-  ( ProtocolMagicId (..)
-  , pattern ProtocolMagicId
+  ( ProtocolMagicId(..)
   , hashRaw
   )
 

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Delegation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Delegation.hs
@@ -26,7 +26,8 @@ import Text.JSON.Canonical (FromJSON(..), ReportSchemaErrors(..), ToJSON(..))
 
 import Cardano.Chain.Common (KeyHash, hashKey)
 import Cardano.Chain.Delegation.Certificate
-  ( Certificate(delegateVK, issuerVK)
+  ( ACertificate(delegateVK, issuerVK)
+  , Certificate
   )
 
 

--- a/cardano-ledger/src/Cardano/Chain/MempoolPayload.hs
+++ b/cardano-ledger/src/Cardano/Chain/MempoolPayload.hs
@@ -5,36 +5,44 @@
 {-# LANGUAGE TypeApplications  #-}
 
 module Cardano.Chain.MempoolPayload
-  ( MempoolPayload (..)
+  ( MempoolPayload
+  , AMempoolPayload (..)
   )
 where
 
 import Cardano.Prelude
 
 import Cardano.Binary
-  ( DecoderError(..)
-  , FromCBORAnnotated(..)
+  ( ByteSpan
+  , DecoderError(..)
+  , FromCBOR(..)
   , ToCBOR(..)
   , decodeWord8
   , encodeListLen
+  , encodePreEncoded
   , enforceSize
+  , recoverBytes
   )
 import qualified Cardano.Chain.Delegation as Delegation
-import Cardano.Chain.UTxO (TxAux)
+import Cardano.Chain.UTxO (ATxAux)
 import qualified Cardano.Chain.Update as Update
 
 -- | A payload which can be submitted into or between mempools via the
 -- transaction submission protocol.
-data MempoolPayload
-  = MempoolTx !(TxAux)
+type MempoolPayload = AMempoolPayload ()
+
+-- | A payload which can be submitted into or between mempools via the
+-- transaction submission protocol.
+data AMempoolPayload a
+  = MempoolTx !(ATxAux a)
   -- ^ A transaction payload (transaction and witness).
-  | MempoolDlg !(Delegation.Certificate)
+  | MempoolDlg !(Delegation.ACertificate a)
   -- ^ A delegation certificate payload.
-  | MempoolUpdateProposal !(Update.Proposal)
+  | MempoolUpdateProposal !(Update.AProposal a)
   -- ^ An update proposal payload.
-  | MempoolUpdateVote !(Update.Vote)
+  | MempoolUpdateVote !(Update.AVote a)
   -- ^ An update vote payload.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Functor)
 
 instance ToCBOR MempoolPayload where
   toCBOR (MempoolTx tp) =
@@ -46,12 +54,25 @@ instance ToCBOR MempoolPayload where
   toCBOR (MempoolUpdateVote upv) =
     encodeListLen 2 <> toCBOR (3 :: Word8) <> toCBOR upv
 
-instance FromCBORAnnotated MempoolPayload where
-  fromCBORAnnotated' = do
-    lift $ enforceSize "MempoolPayload" 2
-    (lift decodeWord8) >>= \case
-      0   -> MempoolTx             <$> fromCBORAnnotated'
-      1   -> MempoolDlg            <$> fromCBORAnnotated'
-      2   -> MempoolUpdateProposal <$> fromCBORAnnotated'
-      3   -> MempoolUpdateVote     <$> fromCBORAnnotated'
-      tag -> lift $ cborError $ DecoderErrorUnknownTag "MempoolPayload" tag
+instance ToCBOR (AMempoolPayload ByteString) where
+  toCBOR (MempoolTx tp) =
+    encodeListLen 2 <> toCBOR (0 :: Word8) <> encodePreEncoded (recoverBytes tp)
+  toCBOR (MempoolDlg dp) =
+    encodeListLen 2 <> toCBOR (1 :: Word8) <> encodePreEncoded (recoverBytes dp)
+  toCBOR (MempoolUpdateProposal upp) =
+    encodeListLen 2 <> toCBOR (2 :: Word8) <> encodePreEncoded (recoverBytes upp)
+  toCBOR (MempoolUpdateVote upv) =
+    encodeListLen 2 <> toCBOR (3 :: Word8) <> encodePreEncoded (recoverBytes upv)
+
+instance FromCBOR MempoolPayload where
+  fromCBOR = void <$> fromCBOR @(AMempoolPayload ByteSpan)
+
+instance FromCBOR (AMempoolPayload ByteSpan) where
+  fromCBOR = do
+    enforceSize "MempoolPayload" 2
+    decodeWord8 >>= \case
+      0   -> MempoolTx             <$> fromCBOR
+      1   -> MempoolDlg            <$> fromCBOR
+      2   -> MempoolUpdateProposal <$> fromCBOR
+      3   -> MempoolUpdateVote     <$> fromCBOR
+      tag -> cborError $ DecoderErrorUnknownTag "MempoolPayload" tag

--- a/cardano-ledger/src/Cardano/Chain/Slotting/EpochSlots.hs
+++ b/cardano-ledger/src/Cardano/Chain/Slotting/EpochSlots.hs
@@ -19,8 +19,7 @@ import Cardano.Binary (FromCBOR(..), ToCBOR(..))
 -- | The number of slots per epoch.
 newtype EpochSlots = EpochSlots
   { unEpochSlots :: Word64
-  } deriving (Data, Eq, Ord, Read, Show, Buildable, Generic, NoUnexpectedThunks
-             , NFData)
+  } deriving (Data, Eq, Ord, Read, Show, Buildable, Generic, NoUnexpectedThunks)
 
 instance ToCBOR EpochSlots where
   toCBOR = toCBOR . unEpochSlots

--- a/cardano-ledger/src/Cardano/Chain/UTxO/Tx.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/Tx.hs
@@ -7,7 +7,8 @@
 {-# LANGUAGE TypeApplications   #-}
 
 module Cardano.Chain.UTxO.Tx
-  ( Tx(Tx, txInputs, txOutputs, txAttributes, txSerialized)
+  ( Tx(txInputs, txOutputs, txAttributes, txSerialized)
+  , pattern Tx
   , txF
   , TxId
   , TxAttributes

--- a/cardano-ledger/src/Cardano/Chain/UTxO/Tx.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/Tx.hs
@@ -1,14 +1,13 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE PatternSynonyms    #-}
+{-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeApplications   #-}
 
 module Cardano.Chain.UTxO.Tx
-  ( Tx(txInputs, txOutputs, txAttributes, txSerialized)
-  , pattern Tx
+  ( Tx(..)
   , txF
   , TxId
   , TxAttributes
@@ -26,14 +25,10 @@ import Cardano.Binary
   ( Case(..)
   , DecoderError(DecoderErrorUnknownTag)
   , FromCBOR(..)
-  , FromCBORAnnotated(..)
   , ToCBOR(..)
   , encodeListLen
-  , encodePreEncoded
   , enforceSize
-  , serializeEncoding'
   , szCases
-  , withSlice'
   )
 import Cardano.Chain.Common.CBOR
   (encodeKnownCborDataItem, knownCborDataItemSizeExpr, decodeKnownCborDataItem)
@@ -50,29 +45,16 @@ import Cardano.Crypto (Hash, hash, shortHashF)
 -- Tx
 --------------------------------------------------------------------------------
 
-pattern Tx :: NonEmpty TxIn -> NonEmpty TxOut -> TxAttributes -> Tx
-pattern Tx{txInputs, txOutputs, txAttributes} <-
-   Tx' txInputs txOutputs txAttributes _
-  where
-    Tx txin txout txattr =
-      let bytes = serializeEncoding' $
-            encodeListLen 3
-              <> toCBOR txin
-              <> toCBOR txout
-              <> toCBOR txattr
-      in Tx' txin txout txattr bytes
-
 -- | Transaction
 --
 --   NB: transaction witnesses are stored separately
-data Tx = Tx'
-  { txInputs'    :: !(NonEmpty TxIn)
+data Tx = UnsafeTx
+  { txInputs     :: !(NonEmpty TxIn)
   -- ^ Inputs of transaction.
-  , txOutputs'   :: !(NonEmpty TxOut)
+  , txOutputs    :: !(NonEmpty TxOut)
   -- ^ Outputs of transaction.
-  , txAttributes':: !TxAttributes
+  , txAttributes :: !TxAttributes
   -- ^ Attributes of transaction
-  , txSerialized :: ByteString
   } deriving (Eq, Ord, Generic, Show)
     deriving anyclass NFData
 
@@ -97,18 +79,18 @@ instance B.Buildable Tx where
       | otherwise                = bprint (", attributes: " . build) attrs
 
 instance ToCBOR Tx where
-  toCBOR = encodePreEncoded . txSerialized
+  toCBOR tx =
+    encodeListLen 3 <> toCBOR (txInputs tx) <> toCBOR (txOutputs tx) <> toCBOR
+      (txAttributes tx)
 
   encodedSizeExpr size pxy =
     1 + size (txInputs <$> pxy) + size (txOutputs <$> pxy) + size
       (txAttributes <$> pxy)
 
-instance FromCBORAnnotated Tx where
-  fromCBORAnnotated' = withSlice' . lift $
-    Tx' <$ enforceSize "Tx" 3
-      <*> fromCBOR
-      <*> fromCBOR
-      <*> fromCBOR
+instance FromCBOR Tx where
+  fromCBOR = do
+    enforceSize "Tx" 3
+    UnsafeTx <$> fromCBOR <*> fromCBOR <*> fromCBOR
 
 -- | Specialized formatter for 'Tx'
 txF :: Format r (Tx -> r)
@@ -200,3 +182,4 @@ instance FromCBOR TxOut where
 
 instance HeapWords TxOut where
   heapWords (TxOut address _) = 3 + heapWords address
+

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxAux.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxAux.hs
@@ -1,44 +1,84 @@
 {-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveFunctor      #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE TypeFamilies       #-}
 
 module Cardano.Chain.UTxO.TxAux
-  ( TxAux(..)
+  ( TxAux
+  , ATxAux(..)
+  , mkTxAux
+  , annotateTxAux
+  , taTx
+  , taWitness
   , txaF
   )
 where
 
 import Cardano.Prelude
 
+import qualified Data.ByteString.Lazy as Lazy
 import Formatting (Format, bprint, build, later)
 import qualified Formatting.Buildable as B
 
 import Cardano.Binary
-  ( FromCBORAnnotated(..)
+  ( Annotated(..)
+  , ByteSpan
+  , Decoded(..)
+  , FromCBOR(..)
   , ToCBOR(..)
+  , annotatedDecoder
+  , fromCBORAnnotated
   , encodeListLen
   , enforceSize
+  , serialize
+  , slice
+  , unsafeDeserialize
   )
 import Cardano.Chain.UTxO.Tx (Tx)
-import Cardano.Chain.UTxO.TxWitness (TxWitness(..))
+import Cardano.Chain.UTxO.TxWitness (TxWitness)
 
 
 -- | Transaction + auxiliary data
-data TxAux = TxAux
-  { taTx      :: !Tx
-  , taWitness :: !TxWitness
-  } deriving (Generic, Show, Eq)
+type TxAux = ATxAux ()
+
+mkTxAux :: Tx -> TxWitness -> TxAux
+mkTxAux tx tw = ATxAux (Annotated tx ()) (Annotated tw ()) ()
+
+annotateTxAux :: TxAux -> ATxAux ByteString
+annotateTxAux ta = Lazy.toStrict . slice bs <$> ta'
+  where
+    bs  = serialize ta
+    ta' = unsafeDeserialize bs
+
+data ATxAux a = ATxAux
+  { aTaTx         :: !(Annotated Tx a)
+  , aTaWitness    :: !(Annotated TxWitness a)
+  , aTaAnnotation :: !a
+  } deriving (Generic, Show, Eq, Functor)
     deriving anyclass NFData
+
+instance Decoded (ATxAux ByteString) where
+  type BaseType (ATxAux ByteString) = ATxAux ()
+  recoverBytes = aTaAnnotation
+
+taTx :: ATxAux a -> Tx
+taTx = unAnnotated . aTaTx
+
+taWitness :: ATxAux a -> TxWitness
+taWitness = unAnnotated . aTaWitness
 
 -- | Specialized formatter for 'TxAux'
 txaF :: Format r (TxAux -> r)
 txaF = later $ \ta -> bprint
   (build . "\n" . "witnesses: " . listJsonIndent 4)
   (taTx ta)
-  (txInWitnesses $ taWitness ta)
+  (taWitness ta)
 
 instance B.Buildable TxAux where
   build = bprint txaF
@@ -48,8 +88,14 @@ instance ToCBOR TxAux where
 
   encodedSizeExpr size pxy = 1 + size (taTx <$> pxy) + size (taWitness <$> pxy)
 
-instance FromCBORAnnotated TxAux where
-  fromCBORAnnotated' =
-    TxAux <$ lift (enforceSize "TxAux" 2)
-      <*> fromCBORAnnotated'
-      <*> fromCBORAnnotated'
+instance FromCBOR TxAux where
+  fromCBOR = void <$> fromCBOR @(ATxAux ByteSpan)
+
+instance FromCBOR (ATxAux ByteSpan) where
+  fromCBOR = do
+    Annotated (tx, witness) byteSpan <- annotatedDecoder $ do
+      enforceSize "TxAux" 2
+      tx      <- fromCBORAnnotated
+      witness <- fromCBORAnnotated
+      pure (tx, witness)
+    pure $ ATxAux tx witness byteSpan

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxPayload.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxPayload.hs
@@ -1,53 +1,73 @@
 {-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveFunctor      #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TypeApplications   #-}
 
 module Cardano.Chain.UTxO.TxPayload
-  ( TxPayload(..)
+  ( TxPayload
+  , ATxPayload(..)
+  , mkTxPayload
   , recoverHashedBytes
+  , txpAnnotatedTxs
   , txpTxs
   , txpWitnesses
+  , unTxPayload
   )
 where
 
 import Cardano.Prelude
 
-import Cardano.Binary (Annotated(..), FromCBORAnnotated(..), ToCBOR(..))
+import Cardano.Binary (Annotated(..), ByteSpan, FromCBOR(..), ToCBOR(..))
 import Cardano.Chain.UTxO.Tx (Tx)
-import Cardano.Chain.UTxO.TxAux (TxAux(..))
-import Cardano.Chain.UTxO.TxWitness (TxWitness(..))
+import Cardano.Chain.UTxO.TxAux (ATxAux(..), TxAux, taTx, taWitness)
+import Cardano.Chain.UTxO.TxWitness (TxWitness)
 
 
 -- | Payload of UTxO component which is part of the block body
-newtype TxPayload = TxPayload
-  { unTxPayload :: [TxAux]
-  } deriving (Show, Eq, Generic)
+type TxPayload = ATxPayload ()
+
+mkTxPayload :: [TxAux] -> TxPayload
+mkTxPayload = ATxPayload
+
+newtype ATxPayload a = ATxPayload
+  { aUnTxPayload :: [ATxAux a]
+  } deriving (Show, Eq, Generic, Functor)
     deriving anyclass NFData
+
+unTxPayload :: ATxPayload a -> [TxAux]
+unTxPayload = fmap void . aUnTxPayload
 
 instance ToCBOR TxPayload where
   toCBOR = toCBOR . unTxPayload
 
-instance FromCBORAnnotated TxPayload where
-  fromCBORAnnotated' = TxPayload <$> fromCBORAnnotated'
+instance FromCBOR TxPayload where
+  fromCBOR = void <$> fromCBOR @(ATxPayload ByteSpan)
 
-txpTxs :: TxPayload -> [Tx]
+instance FromCBOR (ATxPayload ByteSpan) where
+  fromCBOR = ATxPayload <$> fromCBOR
+
+txpAnnotatedTxs :: ATxPayload a -> [Annotated Tx a]
+txpAnnotatedTxs = fmap aTaTx . aUnTxPayload
+
+txpTxs :: ATxPayload a -> [Tx]
 txpTxs = fmap taTx . unTxPayload
 
 txpWitnesses :: TxPayload -> [TxWitness]
 txpWitnesses = fmap taWitness . unTxPayload
 
-recoverHashedBytes :: TxPayload -> Annotated [TxWitness] ByteString
-recoverHashedBytes (TxPayload auxs) =
+recoverHashedBytes :: ATxPayload ByteString -> Annotated [TxWitness] ByteString
+recoverHashedBytes (ATxPayload auxs) =
   let
-    witnesses  = taWitness <$> auxs
+    aWitnesses  = aTaWitness <$> auxs
     prefix      = "\159" :: ByteString
     -- This is the value of Codec.CBOR.Write.toLazyByteString encodeListLenIndef
     suffix      = "\255" :: ByteString
     -- This is the value of Codec.CBOR.Write.toLazyByteString encodeBreak
     -- They are hard coded here because the hashed bytes included them as an
     -- implementation artifact
-    hashedByted = prefix <> mconcat (txWitnessSerialized <$> witnesses) <> suffix
-  in Annotated witnesses hashedByted
+    hashedByted = prefix <> mconcat (annotation <$> aWitnesses) <> suffix
+  in Annotated (unAnnotated <$> aWitnesses) hashedByted

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
@@ -8,7 +8,8 @@
 {-# LANGUAGE PatternSynonyms     #-}
 
 module Cardano.Chain.UTxO.TxWitness
-  ( TxWitness(TxWitness, txInWitnesses, txWitnessSerialized)
+  ( TxWitness(txInWitnesses, txWitnessSerialized)
+  , pattern TxWitness
   , TxInWitness(..)
   , TxSigData(..)
   , TxSig

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
@@ -4,12 +4,11 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE PatternSynonyms     #-}
 
 module Cardano.Chain.UTxO.TxWitness
-  ( TxWitness(txInWitnesses, txWitnessSerialized)
-  , pattern TxWitness
+  ( TxWitness
   , TxInWitness(..)
   , TxSigData(..)
   , TxSig
@@ -17,7 +16,7 @@ module Cardano.Chain.UTxO.TxWitness
   )
 where
 
-import Cardano.Prelude as P
+import Cardano.Prelude
 
 import Data.Vector (Vector)
 import Formatting (bprint, build)
@@ -28,16 +27,12 @@ import Cardano.Binary
   , Case(..)
   , DecoderError(DecoderErrorUnknownTag)
   , FromCBOR(..)
-  , FromCBORAnnotated(..)
   , ToCBOR(..)
   , decodeListLen
   , encodeListLen
-  , encodePreEncoded
   , matchSize
   , serialize'
   , szCases
-  , withSlice'
-  , serializeEncoding'
   )
 import Cardano.Chain.Common.CBOR
   (encodeKnownCborDataItem, knownCborDataItemSizeExpr, decodeKnownCborDataItem)
@@ -49,7 +44,7 @@ import Cardano.Crypto
   , RedeemVerificationKey
   , RedeemSignature
   , Signature
-  , hash
+  , hashDecoded
   , shortHashF
   )
 
@@ -57,25 +52,7 @@ import Cardano.Crypto
 -- | A witness is a proof that a transaction is allowed to spend the funds it
 --   spends (by providing signatures, redeeming scripts, etc). A separate proof
 --   is provided for each input.
-data TxWitness = TxWitness'
-  { txInWitnesses' :: !(Vector TxInWitness)
-  , txWitnessSerialized :: ByteString
-  } deriving (Eq, Show, Generic)
-    deriving anyclass NFData
-
-instance ToCBOR TxWitness where
-  toCBOR = encodePreEncoded . txWitnessSerialized
-
-  encodedSizeExpr size _ = encodedSizeExpr size (Proxy :: Proxy (Vector TxInWitness))
-
-pattern TxWitness :: Vector TxInWitness -> TxWitness
-pattern TxWitness{ txInWitnesses } <- TxWitness' txInWitnesses _
-  where
-  TxWitness wits = TxWitness' wits (serializeEncoding' $ toCBOR wits)
-
-instance FromCBORAnnotated TxWitness where
-  fromCBORAnnotated' = withSlice' . lift $
-    TxWitness' <$> fromCBOR
+type TxWitness = Vector TxInWitness
 
 -- | A witness for a single input
 data TxInWitness
@@ -139,10 +116,10 @@ newtype TxSigData = TxSigData
   { txSigTxHash :: Hash Tx
   } deriving (Eq, Show, Generic)
 
-recoverSigData :: Tx -> Annotated TxSigData ByteString
-recoverSigData tx =
+recoverSigData :: Annotated Tx ByteString -> Annotated TxSigData ByteString
+recoverSigData atx =
   let
-    txHash      = hash tx
+    txHash      = hashDecoded atx
     signedBytes = serialize' txHash --TODO: make the prefix bytes explicit
   in Annotated (TxSigData txHash) signedBytes
 
@@ -155,3 +132,4 @@ instance FromCBOR TxSigData where
 
 -- | 'Signature' of addrId
 type TxSig = Signature TxSigData
+

--- a/cardano-ledger/src/Cardano/Chain/UTxO/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/Validation.hs
@@ -30,7 +30,6 @@ import Cardano.Binary
   , Decoder
   , DecoderError(DecoderErrorUnknownTag)
   , FromCBOR(..)
-  , FromCBORAnnotated(..)
   , ToCBOR(..)
   , decodeListLen
   , decodeWord8
@@ -55,9 +54,9 @@ import Cardano.Chain.Common
   )
 import Cardano.Chain.UTxO.Tx (Tx(..), TxIn, TxOut(..))
 import Cardano.Chain.UTxO.Compact (CompactTxOut(..), toCompactTxIn)
-import Cardano.Chain.UTxO.TxAux (TxAux(..))
+import Cardano.Chain.UTxO.TxAux (ATxAux, aTaTx, taWitness)
 import Cardano.Chain.UTxO.TxWitness
-  (TxInWitness(..), TxSigData(..), TxWitness(..), recoverSigData)
+  (TxInWitness(..), TxSigData(..), recoverSigData)
 import Cardano.Chain.UTxO.UTxO
   (UTxO, UTxOError, balance, isRedeemUTxO, txOutputUTxO, (</|), (<|))
 import qualified Cardano.Chain.UTxO.UTxO as UTxO
@@ -136,25 +135,23 @@ instance ToCBOR TxValidationError where
       encodeListLen 1
         <> toCBOR @Word8 8
 
-instance FromCBORAnnotated TxValidationError where
-  fromCBORAnnotated' = do
-    len <- lift $ decodeListLen
+instance FromCBOR TxValidationError where
+  fromCBOR = do
+    len <- decodeListLen
     let checkSize :: forall s. Int -> Decoder s ()
         checkSize size = matchSize "TxValidationError" size len
-    tag <- lift $ decodeWord8
+    tag <- decodeWord8
     case tag of
-      0 -> lift $ checkSize 3 >> TxValidationLovelaceError <$> fromCBOR <*> fromCBOR
-      1 -> lift (checkSize 4) >>
-             TxValidationFeeTooSmall <$> fromCBORAnnotated' <*> lift fromCBOR <*> lift fromCBOR
-      2 -> lift $ checkSize 4 >> 
-             TxValidationWitnessWrongSignature <$> fromCBOR <*> fromCBOR <*> fromCBOR
-      3 -> lift $ checkSize 3 >> TxValidationWitnessWrongKey <$> fromCBOR <*> fromCBOR
-      4 -> lift $ checkSize 2 >> TxValidationMissingInput <$> fromCBOR
-      5 -> lift $ checkSize 3 >> TxValidationNetworkMagicMismatch <$> fromCBOR <*> fromCBOR
-      6 -> lift $ checkSize 3 >> TxValidationTxTooLarge <$> fromCBOR <*> fromCBOR
-      7 -> lift $ checkSize 1 $> TxValidationUnknownAddressAttributes
-      8 -> lift $ checkSize 1 $> TxValidationUnknownAttributes
-      _ -> lift $ cborError   $  DecoderErrorUnknownTag "TxValidationError" tag
+      0 -> checkSize 3 >> TxValidationLovelaceError <$> fromCBOR <*> fromCBOR
+      1 -> checkSize 4 >> TxValidationFeeTooSmall   <$> fromCBOR <*> fromCBOR <*> fromCBOR
+      2 -> checkSize 4 >> TxValidationWitnessWrongSignature <$> fromCBOR <*> fromCBOR <*> fromCBOR
+      3 -> checkSize 3 >> TxValidationWitnessWrongKey <$> fromCBOR <*> fromCBOR
+      4 -> checkSize 2 >> TxValidationMissingInput <$> fromCBOR
+      5 -> checkSize 3 >> TxValidationNetworkMagicMismatch <$> fromCBOR <*> fromCBOR
+      6 -> checkSize 3 >> TxValidationTxTooLarge <$> fromCBOR <*> fromCBOR
+      7 -> checkSize 1 $> TxValidationUnknownAddressAttributes
+      8 -> checkSize 1 $> TxValidationUnknownAttributes
+      _ -> cborError   $  DecoderErrorUnknownTag "TxValidationError" tag
 
 -- | Validate that:
 --
@@ -168,9 +165,9 @@ validateTx
   :: MonadError TxValidationError m
   => Environment
   -> UTxO
-  -> Tx
+  -> Annotated Tx ByteString
   -> m ()
-validateTx env utxo tx = do
+validateTx env utxo (Annotated tx txBytes) = do
 
   -- Check that the size of the transaction is less than the maximum
   txSize <= maxTxSize
@@ -213,7 +210,7 @@ validateTx env utxo tx = do
   feePolicy = ppTxFeePolicy protocolParameters
 
   txSize :: Natural
-  txSize = fromIntegral $ BS.length (txSerialized tx)
+  txSize = fromIntegral $ BS.length txBytes
 
   inputUTxO = S.fromList (NE.toList (txInputs tx)) <| utxo
 
@@ -305,23 +302,23 @@ instance ToCBOR UTxOValidationError where
     UTxOValidationUTxOError uTxOError ->
       encodeListLen 2 <> toCBOR @Word8 1 <> toCBOR uTxOError
 
-instance FromCBORAnnotated UTxOValidationError where
-  fromCBORAnnotated' = do
-    lift $ enforceSize "UTxOValidationError" 2
-    lift decodeWord8 >>= \case
-      0   -> UTxOValidationTxValidationError <$> fromCBORAnnotated'
-      1   -> UTxOValidationUTxOError <$> lift fromCBOR
-      tag -> lift $ cborError $ DecoderErrorUnknownTag "UTxOValidationError" tag
+instance FromCBOR UTxOValidationError where
+  fromCBOR = do
+    enforceSize "UTxOValidationError" 2
+    decodeWord8 >>= \case
+      0   -> UTxOValidationTxValidationError <$> fromCBOR
+      1   -> UTxOValidationUTxOError <$> fromCBOR
+      tag -> cborError $ DecoderErrorUnknownTag "UTxOValidationError" tag
 
 -- | Validate a transaction and use it to update the 'UTxO'
 updateUTxOTx
   :: (MonadError UTxOValidationError m, MonadReader ValidationMode m)
   => Environment
   -> UTxO
-  -> Tx
+  -> Annotated Tx ByteString
   -> m UTxO
-updateUTxOTx env utxo tx = do
-  unlessNoTxValidation (validateTx env utxo tx)
+updateUTxOTx env utxo aTx@(Annotated tx _) = do
+  unlessNoTxValidation (validateTx env utxo aTx)
     `wrapErrorWithValidationMode` UTxOValidationTxValidationError
 
   UTxO.union (S.fromList (NE.toList (txInputs tx)) </| utxo) (txOutputUTxO tx)
@@ -333,7 +330,7 @@ updateUTxOTxWitness
   :: (MonadError UTxOValidationError m, MonadReader ValidationMode m)
   => Environment
   -> UTxO
-  -> TxAux
+  -> ATxAux ByteString
   -> m UTxO
 updateUTxOTxWitness env utxo ta = do
   whenTxValidation $ do
@@ -345,17 +342,18 @@ updateUTxOTxWitness env utxo ta = do
     -- Validate witnesses and their signing addresses
     mapM_
         (uncurry $ validateWitness pmi sigData)
-        (zip addresses (V.toList $ txInWitnesses witness))
+        (zip addresses (V.toList witness))
       `wrapError` UTxOValidationTxValidationError
 
   -- Update 'UTxO' ignoring witnesses
-  updateUTxOTx env utxo tx
+  updateUTxOTx env utxo aTx
  where
   Environment { protocolMagic } = env
   pmi = getAProtocolMagicId protocolMagic
 
-  TxAux { taTx = tx, taWitness = witness} = ta
-  sigData = recoverSigData tx
+  aTx@(Annotated tx _) = aTaTx ta
+  witness = taWitness ta
+  sigData = recoverSigData aTx
 
 
 -- | Update UTxO with a list of transactions
@@ -363,6 +361,6 @@ updateUTxO
   :: (MonadError UTxOValidationError m, MonadReader ValidationMode m)
   => Environment
   -> UTxO
-  -> [TxAux]
+  -> [ATxAux ByteString]
   -> m UTxO
 updateUTxO env as = foldM (updateUTxOTxWitness env) as

--- a/cardano-ledger/src/Cardano/Chain/Update/Payload.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Payload.hs
@@ -9,7 +9,8 @@
 {-# LANGUAGE TypeFamilies       #-}
 
 module Cardano.Chain.Update.Payload
-  ( Payload(Payload, payloadProposal, payloadVotes, payloadSerialized)
+  ( Payload(payloadProposal, payloadVotes, payloadSerialized)
+  , pattern Payload
   )
 where
 

--- a/cardano-ledger/src/Cardano/Chain/Update/Payload.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Payload.hs
@@ -1,16 +1,17 @@
 {-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveFunctor      #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE PatternSynonyms    #-}
+{-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE TypeFamilies       #-}
 
 module Cardano.Chain.Update.Payload
-  ( Payload(payloadProposal, payloadVotes, payloadSerialized)
-  , pattern Payload
+  ( APayload(..)
+  , Payload
+  , payload
   )
 where
 
@@ -20,46 +21,43 @@ import Formatting (bprint)
 import qualified Formatting.Buildable as B
 
 import Cardano.Binary
-  ( Decoded(..)
-  , FromCBORAnnotated(..)
+  ( Annotated(..)
+  , ByteSpan
+  , Decoded(..)
+  , FromCBOR(..)
   , ToCBOR(..)
+  , annotatedDecoder
   , encodeListLen
-  , encodePreEncoded
   , enforceSize
-  , serializeEncoding'
-  , withSlice'
   )
 import Cardano.Chain.Update.Proposal
-  ( Proposal
+  ( AProposal
+  , Proposal
   , formatMaybeProposal
   )
 import Cardano.Chain.Update.Vote
-  ( Vote
+  ( AVote
+  , Vote
   , formatVoteShort
   )
 
 
-{-# COMPLETE Payload #-}
-pattern Payload :: Maybe Proposal -> [Vote] -> Payload
-pattern Payload{payloadProposal, payloadVotes} <- 
-  Payload' payloadProposal payloadVotes _
-  where
-    Payload pp pv =
-      let bytes = serializeEncoding' $
-            encodeListLen 2 <> toCBOR pp <> toCBOR pv
-      in Payload' pp pv bytes
-
 -- | Update System payload
-data Payload = Payload'
-  { payloadProposal'  :: !(Maybe Proposal)
-  , payloadVotes'     :: ![Vote]
-  , payloadSerialized :: ByteString
-  } deriving (Eq, Show, Generic)
+data APayload a = APayload
+  { payloadProposal   :: !(Maybe (AProposal a))
+  , payloadVotes      :: ![AVote a]
+  , payloadAnnotation :: a
+  } deriving (Eq, Show, Generic, Functor)
     deriving anyclass NFData
 
-instance Decoded Payload where
-  type BaseType Payload = Payload
-  recoverBytes = payloadSerialized
+type Payload = APayload ()
+
+payload :: Maybe Proposal -> [Vote] -> Payload
+payload p v = APayload p v ()
+
+instance Decoded (APayload ByteString) where
+  type BaseType (APayload ByteString) = Payload
+  recoverBytes = payloadAnnotation
 
 instance B.Buildable Payload where
   build p
@@ -71,10 +69,15 @@ instance B.Buildable Payload where
       (map formatVoteShort (payloadVotes p))
 
 instance ToCBOR Payload where
-  toCBOR = encodePreEncoded . payloadSerialized
+  toCBOR p =
+    encodeListLen 2 <> toCBOR (payloadProposal p) <> toCBOR (payloadVotes p)
 
-instance FromCBORAnnotated Payload where
-  fromCBORAnnotated' = withSlice' $
-    Payload' <$ lift (enforceSize "Update.Payload" 2)
-      <*> fromCBORAnnotated'
-      <*> fromCBORAnnotated'
+instance FromCBOR Payload where
+  fromCBOR = void <$> fromCBOR @(APayload ByteSpan)
+
+instance FromCBOR (APayload ByteSpan) where
+  fromCBOR = do
+    Annotated (proposal, votes) byteSpan <- annotatedDecoder $ do
+      enforceSize "Update.Payload" 2
+      (,) <$> fromCBOR <*> fromCBOR
+    pure $ APayload proposal votes byteSpan

--- a/cardano-ledger/src/Cardano/Chain/Update/Proof.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Proof.hs
@@ -5,8 +5,9 @@ module Cardano.Chain.Update.Proof
   )
 where
 
-import Cardano.Chain.Update.Payload (Payload(..))
-import Cardano.Crypto (Hash, hash)
+import Cardano.Chain.Update.Payload (APayload(..), Payload)
+import Cardano.Crypto (Hash, hash, hashDecoded)
+import Cardano.Prelude
 
 
 -- | Proof that body of update message contains 'Update.Payload'
@@ -15,5 +16,5 @@ type Proof = Hash Payload
 mkProof :: Payload -> Proof
 mkProof = hash
 
-recoverProof :: Payload -> Proof
-recoverProof = hash
+recoverProof :: APayload ByteString -> Proof
+recoverProof = hashDecoded

--- a/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
@@ -1,36 +1,37 @@
 {-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveFunctor         #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 
 module Cardano.Chain.Update.Proposal
   (
   -- * Proposal
-    Proposal(proposalBody, proposalIssuer, proposalSignature, proposalSerialized)
-  , pattern UnsafeProposal
+    AProposal(..)
+  , Proposal
   , UpId
 
   -- * Proposal Constructors
+  , unsafeProposal
   , signProposal
   , signatureForProposal
+
+  -- * Proposal Accessors
+  , body
+  , recoverUpId
 
   -- * Proposal Formatting
   , formatMaybeProposal
 
   -- * ProposalBody
-  , ProposalBody
-    ( proposalBodyProtocolVersion
-    , proposalBodyProtocolParametersUpdate
-    , proposalBodySoftwareVersion
-    , proposalBodyMetadata
-    , proposalBodySerialized
-    )
-  , pattern ProposalBody
+  , ProposalBody(..)
+
+  -- * ProposalBody Binary Serialization
+  , recoverProposalSignedBytes
   )
 where
 
@@ -42,16 +43,14 @@ import Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
 import Cardano.Binary
-  ( Decoded(..)
-  , Decoder
+  ( Annotated(..)
+  , ByteSpan
+  , Decoded(..)
   , FromCBOR(..)
-  , FromCBORAnnotated(..)
   , ToCBOR(..)
+  , annotatedDecoder
   , encodeListLen
-  , encodePreEncoded
   , enforceSize
-  , serializeEncoding'
-  , withSlice'
   )
 import Cardano.Chain.Common.Attributes (dropEmptyAttributes)
 import Cardano.Chain.Update.InstallerHash (InstallerHash)
@@ -67,6 +66,7 @@ import Cardano.Crypto
   , SignTag(SignUSProposal)
   , Signature
   , hash
+  , hashDecoded
   , safeSign
   , safeToVerification
   )
@@ -79,97 +79,106 @@ import Cardano.Crypto
 -- | ID of software update proposal
 type UpId = Hash Proposal
 
--- | Create an update 'Proposal' using the provided signature.
-{-# COMPLETE UnsafeProposal #-}
-pattern UnsafeProposal
-  :: ProposalBody
-  -> VerificationKey
-  -> Signature ProposalBody
-  -> Proposal
-pattern UnsafeProposal{proposalBody, proposalIssuer, proposalSignature} <-
-  Proposal' proposalBody proposalIssuer proposalSignature _
-  where
-    UnsafeProposal b iss s =
-      let bytes = serializeEncoding' $
-            encodeListLen 7
-              <> toCBOR (proposalBodyProtocolVersion b)
-              <> toCBOR (proposalBodyProtocolParametersUpdate b)
-              <> toCBOR (proposalBodySoftwareVersion b)
-              <> toCBOR (proposalBodyMetadata b)
-              <> toCBOR (mempty :: Map Word8 LByteString)
-              <> toCBOR iss
-              <> toCBOR s
-      in Proposal' b iss s bytes
-
 -- | Proposal for software update
-data Proposal = Proposal'
-  { body'              :: !ProposalBody
-  , issuer'            :: !VerificationKey
+data AProposal a = AProposal
+  { aBody      :: !(Annotated ProposalBody a)
+  , issuer     :: !VerificationKey
   -- ^ Who proposed this UP.
-  , signature'         :: !(Signature ProposalBody)
-  , proposalSerialized :: ByteString
-  } deriving (Eq, Show, Generic)
+  , signature  :: !(Signature ProposalBody)
+  , annotation :: !a
+  } deriving (Eq, Show, Generic, Functor)
     deriving anyclass NFData
+
+type Proposal = AProposal ()
 
 
 --------------------------------------------------------------------------------
 -- Proposal Constructors
 --------------------------------------------------------------------------------
 
+
 -- | Create an update 'Proposal', signing it with the provided safe signer.
 --
 signProposal :: ProtocolMagicId -> ProposalBody -> SafeSigner -> Proposal
-signProposal protocolMagicId body safeSigner =
-  UnsafeProposal
-    body
+signProposal protocolMagicId proposalBody safeSigner =
+  unsafeProposal
+    proposalBody
     (safeToVerification safeSigner)
-    (signatureForProposal protocolMagicId body safeSigner)
+    (signatureForProposal protocolMagicId proposalBody safeSigner)
+
 
 signatureForProposal
   :: ProtocolMagicId
   -> ProposalBody
   -> SafeSigner
   -> Signature ProposalBody
-signatureForProposal protocolMagicId body safeSigner =
-  safeSign protocolMagicId SignUSProposal safeSigner body
+signatureForProposal protocolMagicId proposalBody safeSigner =
+  safeSign protocolMagicId SignUSProposal safeSigner proposalBody
 
 
+-- | Create an update 'Proposal' using the provided signature.
 --
+unsafeProposal :: ProposalBody -> VerificationKey -> Signature ProposalBody -> Proposal
+unsafeProposal b k s = AProposal (Annotated b ()) k s ()
+
+
+--------------------------------------------------------------------------------
+-- Proposal Accessors
+--------------------------------------------------------------------------------
+
+body :: AProposal a -> ProposalBody
+body = unAnnotated . aBody
+
+recoverUpId :: AProposal ByteString -> UpId
+recoverUpId = hashDecoded
+
+
 --------------------------------------------------------------------------------
 -- Proposal Binary Serialization
 --------------------------------------------------------------------------------
 
 instance ToCBOR Proposal where
-  toCBOR = encodePreEncoded . proposalSerialized
+  toCBOR proposal =
+    encodeListLen 7
+      <> toCBOR (protocolVersion body')
+      <> toCBOR (protocolParametersUpdate body')
+      <> toCBOR (softwareVersion body')
+      <> toCBOR (metadata body')
+      <> toCBOR (mempty :: Map Word8 LByteString)
+      <> toCBOR (issuer proposal)
+      <> toCBOR (signature proposal)
+    where body' = body proposal
 
-instance FromCBORAnnotated Proposal where
-  fromCBORAnnotated' = withSlice' $
-    Proposal' <$ lift (enforceSize "Proposal" 7)
-      <*> withSlice' (lift fromCBORProposalBody)
-      <*> lift fromCBOR
-      <*> lift fromCBOR
-   where
-    -- Prepend byte corresponding to `encodeListLen 5`, which was used during
-    -- signing
-    fromCBORProposalBody :: Decoder s (ByteString -> ProposalBody)
-    fromCBORProposalBody = fmap (. ("\133" <>)) $
-      ProposalBody'
+instance FromCBOR Proposal where
+  fromCBOR = void <$> fromCBOR @(AProposal ByteSpan)
+
+instance FromCBOR (AProposal ByteSpan) where
+  fromCBOR = do
+    Annotated (pb, vk, sig) byteSpan <- annotatedDecoder $ do
+      enforceSize "Proposal" 7
+      pb <- annotatedDecoder
+        (   ProposalBody
         <$> fromCBOR
         <*> fromCBOR
         <*> fromCBOR
         <*> fromCBOR
         <*  dropEmptyAttributes
+        )
+      vk  <- fromCBOR
+      sig <- fromCBOR
+      pure (pb, vk, sig)
+    pure $ AProposal pb vk sig byteSpan
 
-instance Decoded Proposal where
-  type BaseType Proposal = Proposal
-  recoverBytes = proposalSerialized
+instance Decoded (AProposal ByteString) where
+  type BaseType (AProposal ByteString) = Proposal
+  recoverBytes = annotation
 
 
 --------------------------------------------------------------------------------
 -- Proposal Formatting
 --------------------------------------------------------------------------------
 
-instance B.Buildable Proposal where
+instance B.Buildable (AProposal ()) where
   build proposal = bprint
     ( build
     . " { block v"
@@ -182,13 +191,13 @@ instance B.Buildable Proposal where
     . listJson
     . " }"
     )
-    (proposalBodySoftwareVersion body')
-    (proposalBodyProtocolVersion body')
+    (softwareVersion body')
+    (protocolVersion body')
     (hash proposal)
-    (proposalBodyProtocolParametersUpdate body')
-    (M.keys $ proposalBodyMetadata body')
+    (protocolParametersUpdate body')
+    (M.keys $ metadata body')
    where
-    body' = proposalBody proposal
+    body' = body proposal
 
 formatMaybeProposal :: Maybe Proposal -> Builder
 formatMaybeProposal = maybe "no proposal" B.build
@@ -198,43 +207,12 @@ formatMaybeProposal = maybe "no proposal" B.build
 -- ProposalBody
 --------------------------------------------------------------------------------
 
-{-# COMPLETE ProposalBody #-}
-pattern ProposalBody
-  :: ProtocolVersion
-  -> ProtocolParametersUpdate
-  -> SoftwareVersion
-  -> Map SystemTag InstallerHash
-  -> ProposalBody
-pattern ProposalBody
-  { proposalBodyProtocolVersion
-  , proposalBodyProtocolParametersUpdate
-  , proposalBodySoftwareVersion
-  , proposalBodyMetadata
-  } <- ProposalBody'
-       proposalBodyProtocolVersion
-       proposalBodyProtocolParametersUpdate
-       proposalBodySoftwareVersion
-       proposalBodyMetadata
-       _
-  where
-    ProposalBody protocolVersion protocolParametersUpdate softwareVersion metadata =
-      let bytes = serializeEncoding' $
-            encodeListLen 5
-              <> toCBOR protocolVersion
-              <> toCBOR protocolParametersUpdate
-              <> toCBOR softwareVersion
-              <> toCBOR metadata
-              -- Encode empty Attributes
-              <> toCBOR (mempty :: Map Word8 LByteString)
-      in ProposalBody' protocolVersion protocolParametersUpdate softwareVersion metadata bytes
-
-data ProposalBody = ProposalBody'
-  { protocolVersion'         :: !ProtocolVersion
-  , protocolParametersUpdate':: !ProtocolParametersUpdate
-  , softwareVersion'         :: !SoftwareVersion
-  , metadata'                :: !(Map SystemTag InstallerHash)
+data ProposalBody = ProposalBody
+  { protocolVersion          :: !ProtocolVersion
+  , protocolParametersUpdate :: !ProtocolParametersUpdate
+  , softwareVersion          :: !SoftwareVersion
+  , metadata                 :: !(Map SystemTag InstallerHash)
   -- ^ InstallerHash for each system which this update affects
-  , proposalBodySerialized   :: ByteString
   } deriving (Eq, Show, Generic)
     deriving anyclass NFData
 
@@ -244,18 +222,27 @@ data ProposalBody = ProposalBody'
 --------------------------------------------------------------------------------
 
 instance ToCBOR ProposalBody where
-  toCBOR = encodePreEncoded . proposalBodySerialized
+  toCBOR pb =
+    encodeListLen 5
+      <> toCBOR (protocolVersion pb)
+      <> toCBOR (protocolParametersUpdate pb)
+      <> toCBOR (softwareVersion pb)
+      <> toCBOR (metadata pb)
+      -- Encode empty Attributes
+      <> toCBOR (mempty :: Map Word8 LByteString)
 
-instance FromCBORAnnotated ProposalBody where
-  fromCBORAnnotated' = withSlice' . lift $ do
+instance FromCBOR ProposalBody where
+  fromCBOR = do
     enforceSize "ProposalBody" 5
-    ProposalBody'
+    ProposalBody
       <$> fromCBOR
       <*> fromCBOR
       <*> fromCBOR
       <*> fromCBOR
       <*  dropEmptyAttributes
 
-instance Decoded ProposalBody where
-  type BaseType ProposalBody = ProposalBody
-  recoverBytes = proposalBodySerialized
+-- | Prepend byte corresponding to `encodeListLen 5`, which was used during
+--   signing
+recoverProposalSignedBytes
+  :: Annotated ProposalBody ByteString -> Annotated ProposalBody ByteString
+recoverProposalSignedBytes = fmap ("\133" <>)

--- a/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
@@ -11,7 +11,8 @@
 module Cardano.Chain.Update.Proposal
   (
   -- * Proposal
-    Proposal(UnsafeProposal, proposalBody, proposalIssuer, proposalSignature, proposalSerialized)
+    Proposal(proposalBody, proposalIssuer, proposalSignature, proposalSerialized)
+  , pattern UnsafeProposal
   , UpId
 
   -- * Proposal Constructors
@@ -23,13 +24,13 @@ module Cardano.Chain.Update.Proposal
 
   -- * ProposalBody
   , ProposalBody
-    ( ProposalBody
-    , proposalBodyProtocolVersion
+    ( proposalBodyProtocolVersion
     , proposalBodyProtocolParametersUpdate
     , proposalBodySoftwareVersion
     , proposalBodyMetadata
     , proposalBodySerialized
     )
+  , pattern ProposalBody
   )
 where
 

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
@@ -39,7 +39,8 @@ import Data.Set (union)
 import qualified Data.Set as S
 
 import Cardano.Binary
-  ( Decoder
+  ( Annotated
+  , Decoder
   , DecoderError(..)
   , FromCBOR(..)
   , ToCBOR(..)
@@ -82,7 +83,7 @@ import Cardano.Crypto (ProtocolMagicId, hash)
 
 
 data Environment = Environment
-  { protocolMagic :: !ProtocolMagicId
+  { protocolMagic :: !(Annotated ProtocolMagicId ByteString)
   , k             :: !BlockCount
   -- ^ TODO: this is the chain security parameter, a.k.a. @stableAfter@, it is not part
   -- of our protocol parameters, so it seems that we need to pass it in the

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Registration.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Registration.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PatternSynonyms            #-}
 
 -- | Validation rules for registering updates
 --
@@ -27,7 +28,8 @@ import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as M
 
 import Cardano.Binary
-  ( Decoder
+  ( Annotated
+  , Decoder
   , DecoderError(..)
   , FromCBOR(..)
   , ToCBOR(..)
@@ -46,6 +48,7 @@ import qualified Cardano.Chain.Update.Proposal as Proposal
 import Cardano.Chain.Update.Proposal
   ( Proposal(..)
   , ProposalBody(..)
+  , pattern ProposalBody
   , UpId
   )
 import Cardano.Chain.Update.ProtocolParameters
@@ -73,7 +76,7 @@ import Cardano.Crypto
 
 
 data Environment = Environment
-  { protocolMagic             :: !ProtocolMagicId
+  { protocolMagic             :: !(Annotated ProtocolMagicId ByteString)
   , adoptedProtocolVersion    :: !ProtocolVersion
   , adoptedProtocolParameters :: !ProtocolParameters
   , appVersions               :: !ApplicationVersions

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Voting.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Voting.hs
@@ -24,7 +24,8 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as Set
 
 import Cardano.Binary
-  ( Decoder
+  ( Annotated
+  , Decoder
   , DecoderError(..)
   , FromCBOR(..)
   , ToCBOR(..)
@@ -110,7 +111,7 @@ instance FromCBOR Error where
 --   voting threshold. This corresponds to the @UPVOTE@ rules in the spec.
 registerVoteWithConfirmation
   :: MonadError Error m
-  => ProtocolMagicId
+  => Annotated ProtocolMagicId ByteString
   -> Environment
   -> State
   -> Vote
@@ -155,7 +156,7 @@ registerVoteWithConfirmation pm votingEnv vs vote = do
 --   This corresponds to the `ADDVOTE` rule in the spec.
 registerVote
   :: MonadError Error m
-  => ProtocolMagicId
+  => Annotated ProtocolMagicId ByteString
   -> RegistrationEnvironment
   -> RegisteredVotes
   -> Vote

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Voting.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Voting.hs
@@ -39,7 +39,7 @@ import qualified Cardano.Chain.Delegation as Delegation
 import Cardano.Chain.Slotting (SlotNumber)
 import Cardano.Chain.Update.Proposal (UpId)
 import Cardano.Chain.Update.Vote
-  ( Vote(..)
+  ( AVote(..)
   , recoverSignedBytes
   , proposalId
   )
@@ -114,7 +114,7 @@ registerVoteWithConfirmation
   => Annotated ProtocolMagicId ByteString
   -> Environment
   -> State
-  -> Vote
+  -> AVote ByteString
   -> m State
 registerVoteWithConfirmation pm votingEnv vs vote = do
 
@@ -159,7 +159,7 @@ registerVote
   => Annotated ProtocolMagicId ByteString
   -> RegistrationEnvironment
   -> RegisteredVotes
-  -> Vote
+  -> AVote ByteString
   -> m RegisteredVotes
 registerVote pm vre votes vote = do
   -- Check that the proposal being voted on is registered
@@ -172,7 +172,7 @@ registerVote pm vre votes vote = do
     Just d  -> pure d
 
   -- Check that the signature is valid
-  verifySignatureDecoded pm SignUSVote vk signedBytes (signature vote)
+  verifySignatureDecoded pm SignUSVote voterVK signedBytes signature
     `orThrowError` VotingInvalidSignature
 
   -- Add the delegators to the set of votes for this proposal
@@ -180,9 +180,9 @@ registerVote pm vre votes vote = do
  where
   RegistrationEnvironment registeredProposals delegationMap = vre
 
-  vk          = voterVK vote
+  UnsafeVote { voterVK, signature } = vote
 
-  voter       = hashKey vk
+  voter       = hashKey voterVK
 
   upId        = proposalId vote
 

--- a/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
@@ -13,13 +13,14 @@
 module Cardano.Chain.Update.Vote
   (
   -- * Vote
-    Vote(UnsafeVote, voterVK, proposalId, signature, serializeVote)
+    Vote(voterVK, proposalId, signature, serializeVote)
   , VoteId
 
   -- * Vote Constructors
   , mkVote
   , signVote
   , signatureForVote
+  , pattern UnsafeVote
 
   -- * Vote Accessors
   , aProposalId

--- a/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
@@ -1,30 +1,31 @@
 {-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveFunctor      #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE TypeFamilies       #-}
-{-# LANGUAGE PatternSynonyms    #-}
-{-# LANGUAGE ViewPatterns       #-}
-{-# LANGUAGE NamedFieldPuns     #-}
 
 module Cardano.Chain.Update.Vote
   (
   -- * Vote
-    Vote(voterVK, proposalId, signature, serializeVote)
+    AVote(..)
+  , Vote
   , VoteId
 
   -- * Vote Constructors
   , mkVote
   , signVote
   , signatureForVote
-  , pattern UnsafeVote
+  , unsafeVote
 
   -- * Vote Accessors
-  , aProposalId
+  , proposalId
   , voteId
+  , recoverVoteId
 
   -- * Vote Binary Serialization
   , recoverSignedBytes
@@ -43,15 +44,14 @@ import qualified Formatting.Buildable as B
 
 import Cardano.Binary
   ( Annotated(Annotated, unAnnotated)
+  , ByteSpan
+  , Decoded(..)
   , FromCBOR(..)
-  , FromCBORAnnotated(..)
   , ToCBOR(..)
+  , annotatedDecoder
+  , fromCBORAnnotated
   , encodeListLen
-  , encodePreEncoded
   , enforceSize
-  , serialize'
-  , serializeEncoding'
-  , withSlice'
   )
 import qualified Cardano.Binary as Binary (annotation)
 import Cardano.Chain.Common (addressHash)
@@ -65,6 +65,7 @@ import Cardano.Crypto
   , SignTag(SignUSVote)
   , Signature
   , hash
+  , hashDecoded
   , safeSign
   , safeToVerification
   , shortHashF
@@ -80,51 +81,26 @@ import Cardano.Crypto
 -- | An update proposal vote identifier (the 'Hash' of a 'Vote').
 type VoteId = Hash Vote
 
+type Vote = AVote ()
+
 -- | Vote for update proposal
 --
 --   Invariant: The signature is valid.
-data Vote = UnsafeVote'
-  { voterVK'    :: !VerificationKey
+data AVote a = UnsafeVote
+  { voterVK     :: !VerificationKey
   -- ^ Verification key casting the vote
-  , aProposalId':: !(Annotated UpId ByteString)
+  , aProposalId :: !(Annotated UpId a)
   -- ^ Proposal to which this vote applies
-  , signature'  :: !(Signature (UpId, Bool))
+  , signature   :: !(Signature (UpId, Bool))
   -- ^ Signature of (Update proposal, Approval/rejection bit)
-  , serializeVote  :: ByteString
-  } deriving (Generic, Show, Eq)
+  , annotation  :: !a
+  } deriving (Eq, Show, Generic, Functor)
     deriving anyclass NFData
 
 
 --------------------------------------------------------------------------------
 -- Vote Constructors
 --------------------------------------------------------------------------------
-
-
--- | Create a vote for the given update proposal id using the provided
--- signature.
---
--- For the meaning of the parameters see 'signVote'.
-{-# COMPLETE UnsafeVote #-}
-pattern UnsafeVote :: VerificationKey -> UpId -> Signature (UpId, Bool) -> Vote
-pattern UnsafeVote { voterVK, proposalId, signature } <- UnsafeVote'
-  voterVK
-  (unAnnotated -> proposalId)
-  signature
-  _
-  where
-  UnsafeVote  vk upId voteSignature =
-    let upIdBytes = serialize' upId
-        bytes = serializeEncoding' $
-          encodeListLen 4
-            <> toCBOR vk
-            <> encodePreEncoded upIdBytes
-            -- We encode @True@ here because we removed the decision bit. This is safe
-            -- because we know that all @Vote@s on mainnet use this encoding and any
-            -- changes to the encoding in our implementation will be picked up by
-            -- golden tests.
-            <> toCBOR True
-            <> toCBOR voteSignature
-    in  UnsafeVote' vk (Annotated upId upIdBytes) voteSignature bytes
 
 -- | A safe constructor for 'UnsafeVote'
 mkVote
@@ -138,8 +114,9 @@ mkVote
   -> Vote
 mkVote pm sk upId decision = UnsafeVote
   (toVerification sk)
-  upId
+  (Annotated upId ())
   (sign pm SignUSVote sk (upId, decision))
+  ()
 
 
 -- | Create a vote for the given update proposal id, signing it with the
@@ -154,7 +131,7 @@ signVote
   -- ^ The voter
   -> Vote
 signVote protocolMagicId upId decision safeSigner =
-  UnsafeVote
+  unsafeVote
     (safeToVerification safeSigner)
     upId
     (signatureForVote protocolMagicId upId decision safeSigner)
@@ -170,35 +147,69 @@ signatureForVote protocolMagicId upId decision safeSigner =
   safeSign protocolMagicId SignUSVote safeSigner (upId, decision)
 
 
+-- | Create a vote for the given update proposal id using the provided
+-- signature.
+--
+-- For the meaning of the parameters see 'signVote'.
+unsafeVote
+  :: VerificationKey
+  -> UpId
+  -> Signature (UpId, Bool)
+  -> Vote
+unsafeVote vk upId voteSignature =
+  UnsafeVote vk (Annotated upId ()) voteSignature ()
 
 
 --------------------------------------------------------------------------------
 -- Vote Accessors
 --------------------------------------------------------------------------------
 
-voteId :: Vote -> VoteId
-voteId = hash
+proposalId :: AVote a -> UpId
+proposalId = unAnnotated . aProposalId
 
-aProposalId :: Vote -> Annotated UpId ByteString
-aProposalId = aProposalId'
+voteId :: AVote a -> VoteId
+voteId = hash . void
+
+recoverVoteId :: AVote ByteString -> VoteId
+recoverVoteId = hashDecoded
+
 
 --------------------------------------------------------------------------------
 -- Vote Binary Serialization
 --------------------------------------------------------------------------------
 
 instance ToCBOR Vote where
-  toCBOR = encodePreEncoded . serializeVote
+  toCBOR uv =
+    encodeListLen 4
+      <> toCBOR (voterVK uv)
+      <> toCBOR (proposalId uv)
+      -- We encode @True@ here because we removed the decision bit. This is safe
+      -- because we know that all @Vote@s on mainnet use this encoding and any
+      -- changes to the encoding in our implementation will be picked up by
+      -- golden tests.
+      <> toCBOR True
+      <> toCBOR (signature uv)
 
-instance FromCBORAnnotated Vote where
-  fromCBORAnnotated' = withSlice' $
-    UnsafeVote' <$ lift (enforceSize "Vote" 4)
-      <*> lift fromCBOR
-      <*> fromCBORAnnotated'
+instance FromCBOR Vote where
+  fromCBOR = void <$> fromCBOR @(AVote ByteSpan)
+
+instance FromCBOR (AVote ByteSpan) where
+  fromCBOR = do
+    Annotated (voterVK, aProposalId, signature) byteSpan <- annotatedDecoder $ do
+      enforceSize "Vote" 4
+      voterVK     <- fromCBOR
+      aProposalId <- fromCBORAnnotated
       -- Drop the decision bit that previously allowed negative voting
-      <*  lift (fromCBOR @Bool)
-      <*> lift fromCBOR
+      void $ fromCBOR @Bool
+      signature <- fromCBOR
+      pure (voterVK, aProposalId, signature)
+    pure $ UnsafeVote voterVK aProposalId signature byteSpan
 
-recoverSignedBytes :: Vote -> Annotated (UpId, Bool) ByteString
+instance Decoded (AVote ByteString) where
+  type BaseType (AVote ByteString) = Vote
+  recoverBytes = annotation
+
+recoverSignedBytes :: AVote ByteString -> Annotated (UpId, Bool) ByteString
 recoverSignedBytes v =
   let
     bytes = mconcat
@@ -217,7 +228,7 @@ recoverSignedBytes v =
 -- Vote Formatting
 --------------------------------------------------------------------------------
 
-instance B.Buildable Vote where
+instance B.Buildable (AVote a) where
   build uv = bprint
     ( "Update Vote { voter: "
     . build

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
@@ -35,12 +36,14 @@ import Cardano.Binary
 import Cardano.Chain.Block
   ( BlockSignature(..)
   , Block
-  , Body (..)
+  , Body
+  , pattern Body
   , BoundaryBlock
   , BoundaryHeader
   , Header
   , HeaderHash
   , Proof(..)
+  , pattern Proof
   , ToSign(..)
   , dropBoundaryBody
   , fromCBORBoundaryConsensusData

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
@@ -22,19 +22,18 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import Cardano.Chain.Block
-  ( BlockSignature(..)
+  ( ABlockSignature(..)
   , Block
+  , BlockSignature
   , Body
-  , BoundaryBlock(..)
-  , pattern BoundaryBlock
-  , pattern BoundaryBody
-  , BoundaryHeader(..)
-  , mkBoundaryHeader
+  , ABoundaryBlock(..)
+  , ABoundaryBody(..)
+  , ABoundaryHeader(..)
+  , mkABoundaryHeader
   , pattern Body
   , Header
   , HeaderHash
   , Proof(..)
-  , pattern Proof
   , ToSign(..)
   , hashHeader
   , mkBlockExplicit
@@ -83,7 +82,7 @@ genBlockSignature pm epochSlots =
         signCertificate pm (toVerification delegateSK) epoch issuerSafeSigner
       issuerVK = safeToVerification issuerSafeSigner
       sig      = sign pm (SignBlock issuerVK) delegateSK toSign
-    in BlockSignature cert sig
+    in ABlockSignature cert sig
 
 genHeaderHash :: Gen HeaderHash
 genHeaderHash = coerce <$> genTextHash
@@ -143,12 +142,15 @@ genProof pm =
 genToSign :: ProtocolMagicId -> EpochSlots -> Gen ToSign
 genToSign pm epochSlots =
   ToSign
-    <$> (hashHeader <$> genHeader pm epochSlots)
+    <$> (mkAbstractHash <$> genHeader pm epochSlots)
     <*> genProof pm
     <*> genEpochAndSlotCount epochSlots
     <*> genChainDifficulty
     <*> Update.genProtocolVersion
     <*> Update.genSoftwareVersion
+ where
+  mkAbstractHash :: Header -> HeaderHash
+  mkAbstractHash = hashHeader epochSlots
 
 genBlockWithEpochSlots :: ProtocolMagicId -> Gen (WithEpochSlots Block)
 genBlockWithEpochSlots pm = do
@@ -191,16 +193,18 @@ genBlock protocolMagicId epochSlots =
         )
         body
 
-genBoundaryBlock :: ProtocolMagicId -> Gen BoundaryBlock
-genBoundaryBlock pm =
-  BoundaryBlock
-    <$> genBoundaryHeader pm
-    <*> pure BoundaryBody
+genBoundaryBlock :: Gen (ABoundaryBlock ())
+genBoundaryBlock =
+  ABoundaryBlock
+    <$> pure 0
+    <*> genBoundaryHeader
+    <*> pure (ABoundaryBody ())
+    <*> pure ()
 
-genBoundaryHeader :: ProtocolMagicId -> Gen BoundaryHeader
-genBoundaryHeader pm = do
+genBoundaryHeader :: Gen (ABoundaryHeader ())
+genBoundaryHeader = do
   epoch <- Gen.word64 (Range.exponential 0 maxBound)
-  mkBoundaryHeader pm
+  mkABoundaryHeader
     <$> ( if epoch == 0
           then Left . GenesisHash . coerce <$> genTextHash
           else Gen.choice [ Right <$> genHeaderHash
@@ -209,3 +213,4 @@ genBoundaryHeader pm = do
         )
     <*> pure epoch
     <*> genChainDifficulty
+    <*> pure ()

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Gen.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 
 module Test.Cardano.Chain.Block.Gen
   ( genBlockSignature
@@ -23,14 +24,17 @@ import qualified Hedgehog.Range as Range
 import Cardano.Chain.Block
   ( BlockSignature(..)
   , Block
-  , Body (..)
+  , Body
   , BoundaryBlock(..)
-  , BoundaryBody(..)
+  , pattern BoundaryBlock
+  , pattern BoundaryBody
   , BoundaryHeader(..)
   , mkBoundaryHeader
+  , pattern Body
   , Header
   , HeaderHash
   , Proof(..)
+  , pattern Proof
   , ToSign(..)
   , hashHeader
   , mkBlockExplicit

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Model.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Model.hs
@@ -51,7 +51,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import Cardano.Chain.Block
-  ( Block
+  ( ABlock
   , BlockValidationMode(..)
   , ChainValidationError(ChainValidationBlockTooLarge,
                      ChainValidationHeaderTooLarge, ChainValidationProofValidationError)
@@ -142,7 +142,7 @@ import qualified Ledger.Update.Test as Update.Test
 import Test.Cardano.Chain.Elaboration.Block
   ( AbstractToConcreteIdMaps
   , abEnvToCfg
-  , elaborate
+  , elaborateBS
   , rcDCert
   , transactionIds
   )
@@ -194,7 +194,7 @@ elaborateAndUpdate
 elaborateAndUpdate config (cvs, abstractToConcreteIdMaps) (ast, ab) =
   (, abstractToConcreteIdMaps') <$> runReaderT (updateBlock config cvs concreteBlock) vMode
  where
-  (concreteBlock, abstractToConcreteIdMaps') = elaborate abstractToConcreteIdMaps config dCert cvs ab
+  (concreteBlock, abstractToConcreteIdMaps') = elaborateBS abstractToConcreteIdMaps config dCert cvs ab
 
   dCert = rcDCert (ab ^. Abstract.bHeader . Abstract.bhIssuer) stableAfter ast
 
@@ -209,7 +209,7 @@ elaborateBlock
   -> AbstractToConcreteIdMaps
   -> State CHAIN
   -> Abstract.Block
-  -> Block
+  -> ABlock ByteString
 elaborateBlock
   config
   chainValidationState
@@ -217,7 +217,7 @@ elaborateBlock
   abstractState
   abstractBlock = concreteBlock
   where
-    (concreteBlock, _) = elaborate
+    (concreteBlock, _) = elaborateBS
                            abstractToConcreteIdMaps
                            config
                            dCert
@@ -536,7 +536,7 @@ invalidSizesAreRejected
   -- ^ Function used to compute the size of the abstract-block's component.
   -> (ProtocolParameters -> Natural -> ProtocolParameters)
   -- ^ Setter for the concrete protocol parameters.
-  -> (Block -> Natural)
+  -> (ABlock ByteString -> Natural)
   -- ^ Function used to compute the size of the concrete-block's component.
   -> ([[PredicateFailure CHAIN]] -> ChainValidationError -> PropertyT IO ())
   -- ^ Function to check agreement of concrete and abstract failures.

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/CBOR.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE PatternSynonyms #-}
 
 module Test.Cardano.Chain.Delegation.CBOR
   ( tests
@@ -13,10 +12,10 @@ import Data.List ((!!))
 
 import Hedgehog (Property)
 
-import Cardano.Chain.Delegation (pattern UnsafePayload)
+import Cardano.Chain.Delegation (unsafePayload)
 
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBORAnnotated, roundTripsCBORAnnotatedBuildable, roundTripsCBORShow)
+  (goldenTestCBOR, roundTripsCBORBuildable, roundTripsCBORShow)
 import Test.Cardano.Chain.Delegation.Example (exampleCertificates)
 import Test.Cardano.Chain.Delegation.Gen
   (genCertificate, genError, genPayload)
@@ -29,14 +28,14 @@ import Test.Options (TSGroup, TSProperty, concatTSGroups, eachOfTS)
 --------------------------------------------------------------------------------
 
 goldenCertificate :: Property
-goldenCertificate = goldenTestCBORAnnotated
+goldenCertificate = goldenTestCBOR
   cert
   "test/golden/cbor/delegation/Certificate"
   where cert = exampleCertificates !! 0
 
 ts_roundTripCertificateCBOR :: TSProperty
 ts_roundTripCertificateCBOR =
-  eachOfTS 200 (feedPM genCertificate) roundTripsCBORAnnotatedBuildable
+  eachOfTS 200 (feedPM genCertificate) roundTripsCBORBuildable
 
 
 --------------------------------------------------------------------------------
@@ -44,12 +43,12 @@ ts_roundTripCertificateCBOR =
 --------------------------------------------------------------------------------
 
 goldenDlgPayload :: Property
-goldenDlgPayload = goldenTestCBORAnnotated dp "test/golden/cbor/delegation/DlgPayload"
-  where dp = UnsafePayload (take 4 exampleCertificates)
+goldenDlgPayload = goldenTestCBOR dp "test/golden/cbor/delegation/DlgPayload"
+  where dp = unsafePayload (take 4 exampleCertificates)
 
 ts_roundTripDlgPayloadCBOR :: TSProperty
 ts_roundTripDlgPayloadCBOR =
-  eachOfTS 100 (feedPM genPayload) roundTripsCBORAnnotatedBuildable
+  eachOfTS 100 (feedPM genPayload) roundTripsCBORBuildable
 
 
 --------------------------------------------------------------------------------

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/CBOR.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Test.Cardano.Chain.Delegation.CBOR
   ( tests
@@ -12,7 +13,7 @@ import Data.List ((!!))
 
 import Hedgehog (Property)
 
-import Cardano.Chain.Delegation (Payload(..))
+import Cardano.Chain.Delegation (pattern UnsafePayload)
 
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
   (goldenTestCBORAnnotated, roundTripsCBORAnnotatedBuildable, roundTripsCBORShow)

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/Certificate.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/Certificate.hs
@@ -41,7 +41,7 @@ prop_certificateCorrect = property $ do
     <*> genEpochNumber
     <*> genSafeSigner
 
-  assert $ isValid Dummy.protocolMagicId cert
+  assert $ isValid Dummy.annotatedProtocolMagicId cert
 
 -- | Cannot validate 'Certificate's with incorrect verification keys
 prop_certificateIncorrect :: Property
@@ -57,4 +57,4 @@ prop_certificateIncorrect = property $ do
   let
     badCert  = cert { delegateVK = badDelegateVK }
 
-  assert . not $ isValid Dummy.protocolMagicId badCert
+  assert . not $ isValid Dummy.annotatedProtocolMagicId badCert

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/Gen.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 module Test.Cardano.Chain.Delegation.Gen
   ( genCanonicalCertificate
   , genCertificate
@@ -16,8 +17,9 @@ import qualified Hedgehog.Range as Range
 
 import Cardano.Chain.Delegation
   ( Certificate(delegateVK, issuerVK)
-  , Payload(..)
+  , Payload
   , signCertificate
+  , pattern UnsafePayload
   )
 import Cardano.Chain.Delegation.Validation.Scheduling (Error(..))
 import Cardano.Chain.Slotting (EpochNumber(..))

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/Gen.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE PatternSynonyms #-}
 module Test.Cardano.Chain.Delegation.Gen
   ( genCanonicalCertificate
   , genCertificate
@@ -16,10 +15,11 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import Cardano.Chain.Delegation
-  ( Certificate(delegateVK, issuerVK)
+  ( ACertificate(delegateVK, issuerVK)
+  , Certificate
   , Payload
   , signCertificate
-  , pattern UnsafePayload
+  , unsafePayload
   )
 import Cardano.Chain.Delegation.Validation.Scheduling (Error(..))
 import Cardano.Chain.Slotting (EpochNumber(..))
@@ -77,4 +77,4 @@ genError = Gen.choice
 
 genPayload :: ProtocolMagicId -> Gen Payload
 genPayload pm =
-  UnsafePayload <$> Gen.list (Range.linear 0 5) (genCertificate pm)
+  unsafePayload <$> Gen.list (Range.linear 0 5) (genCertificate pm)

--- a/cardano-ledger/test/Test/Cardano/Chain/Delegation/Model.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Delegation/Model.hs
@@ -118,7 +118,7 @@ commandSDELEG concreteRef abstractEnv = Command gen execute callbacks
       result = Scheduling.scheduleCertificate
         (E.elaborateDSEnv abstractEnv)
         concreteState
-        (E.elaborateDCert Dummy.protocolMagicId cert)
+        (E.elaborateDCertAnnotated Dummy.protocolMagicId cert)
 
     liftIO . writeIORef concreteRef $ fromRight concreteState result
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE OverloadedLists    #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE PatternSynonyms    #-}
 
 -- | This module provides functionality for translating abstract blocks into
 -- concrete blocks. The abstract blocks are generated according the small-step
@@ -35,7 +36,7 @@ import Data.Time (Day(ModifiedJulianDay), UTCTime(UTCTime))
 import GHC.Generics (Generic)
 
 import qualified Cardano.Crypto.Hashing as H
-import Cardano.Crypto.ProtocolMagic (ProtocolMagic(..))
+import Cardano.Crypto.ProtocolMagic (AProtocolMagic(..))
 
 import qualified Cardano.Chain.Block as Concrete
 import qualified Cardano.Chain.Common as Common
@@ -252,7 +253,7 @@ abEnvToCfg (_currentSlot, _genesisUtxo, allowedDelegators, protocolParams, stabl
     , Genesis.configUTxOConfiguration = UTxO.defaultUTxOConfiguration
     }
  where
-  rnm = getRequiresNetworkMagic Dummy.protocolMagic
+  rnm = getRequiresNetworkMagic Dummy.aProtocolMagic
 
   genesisData = Genesis.GenesisData
     { Genesis.gdGenesisKeyHashes = Genesis.GenesisKeyHashes genesisKeyHashes

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE OverloadedLists    #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TypeApplications   #-}
-{-# LANGUAGE PatternSynonyms    #-}
 
 -- | This module provides functionality for translating abstract blocks into
 -- concrete blocks. The abstract blocks are generated according the small-step
@@ -14,6 +13,7 @@
 module Test.Cardano.Chain.Elaboration.Block
   ( abEnvToCfg
   , elaborate
+  , elaborateBS
   , rcDCert
   , AbstractToConcreteIdMaps
     ( AbstractToConcreteIdMaps
@@ -28,6 +28,7 @@ import Cardano.Prelude hiding (to)
 import Control.Arrow ((&&&))
 import Control.Lens ((^.), to, (^..))
 import Data.Bimap (Bimap)
+import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce (coerce)
 import qualified Data.Map as Map
 import Data.Monoid.Generic (GenericSemigroup (GenericSemigroup), GenericMonoid (GenericMonoid))
@@ -35,6 +36,7 @@ import qualified Data.Set as Set
 import Data.Time (Day(ModifiedJulianDay), UTCTime(UTCTime))
 import GHC.Generics (Generic)
 
+import qualified Cardano.Binary as Binary
 import qualified Cardano.Crypto.Hashing as H
 import Cardano.Crypto.ProtocolMagic (AProtocolMagic(..))
 
@@ -92,7 +94,11 @@ elaborate
   -> Abstract.Block
   -> (Concrete.Block, AbstractToConcreteIdMaps)
 elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
-  ( Concrete.Block (recomputeHashes bh0) bb0
+  ( Concrete.ABlock
+    { Concrete.blockHeader = recomputeHashes bh0
+    , Concrete.blockBody = bb0
+    , Concrete.blockAnnotation = ()
+    }
   , AbstractToConcreteIdMaps
     { transactionIds = txIdMap'
     , proposalIds = proposalsIdMap'
@@ -103,13 +109,11 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
 
   pm = Genesis.configProtocolMagicId config
 
-  epochSlots = Genesis.configEpochSlots config
-
   bh0 = Concrete.mkHeaderExplicit
     pm
     prevHash
     (ChainDifficulty 0)
-    epochSlots
+    (Genesis.configEpochSlots config)
     sid
     ssk
     cDCert
@@ -132,11 +136,12 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
   cDCert :: Delegation.Certificate
   cDCert = elaborateDCert pm dCert
 
-  bb0    = Concrete.Body
-             (UTxO.TxPayload txPayload)
-             Ssc.SscPayload
-             (Delegation.UnsafePayload dcerts)
-             updatePayload
+  bb0    = Concrete.ABody
+    { Concrete.bodyTxPayload     = UTxO.ATxPayload txPayload
+    , Concrete.bodySscPayload    = Ssc.SscPayload
+    , Concrete.bodyDlgPayload    = Delegation.UnsafeAPayload dcerts ()
+    , Concrete.bodyUpdatePayload = updatePayload
+    }
 
   dcerts =
     abstractBlock
@@ -144,18 +149,19 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
             (elaborateDCert pm)
           )
 
-  (txPayload, txIdMap') = elaborateTxWitnesses
+  (txPayload, txIdMap') = first (fmap void) $ elaborateTxWitnesses
     txIdMap
     (abstractBlock ^. Abstract.bBody . Abstract.bUtxo)
 
-  updatePayload :: Update.Payload
+  updatePayload :: Update.APayload ()
   updatePayload =
-    Update.Payload
+    Update.APayload
       (fmap snd maybeProposals)
       (fmap (elaborateVote pm proposalsIdMap')
       $ Abstract._bUpdVotes
       $ Abstract._bBody abstractBlock
       )
+      () -- Update payload annotation
 
   maybeProposals :: Maybe (Abstract.Update.UProp, Update.Proposal)
   maybeProposals
@@ -175,9 +181,9 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
 
   -- | Recompute the block header hashes (which correspond to the block
   -- payload) if the abstract hashes don't match the abstract payload.
-  recomputeHashes :: Concrete.Header -> Concrete.Header
+  recomputeHashes :: Concrete.AHeader () -> Concrete.AHeader ()
   recomputeHashes concreteHeader =
-    concreteHeader {Concrete.headerProof = alteredHdrProof}
+    concreteHeader {Concrete.aHeaderProof = Binary.Annotated alteredHdrProof ()}
     where
       alteredHdrProof :: Concrete.Proof
       alteredHdrProof =
@@ -188,7 +194,8 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
           }
         where
           originalHeaderProof :: Concrete.Proof
-          originalHeaderProof = Concrete.headerProof concreteHeader
+          originalHeaderProof =
+            Binary.unAnnotated (Concrete.aHeaderProof concreteHeader)
 
           possiblyAlteredUTxOProof :: UTxO.TxProof
           possiblyAlteredUTxOProof =
@@ -213,6 +220,42 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
 
       dummyHash :: H.Hash Int
       dummyHash = H.hash 0
+
+elaborateBS
+  :: AbstractToConcreteIdMaps
+  -> Genesis.Config -- TODO: Do we want this to come from the abstract
+                    -- environment? (in such case we wouldn't need this
+                    -- parameter)
+  -> DCert
+  -> Concrete.ChainValidationState
+  -> Abstract.Block
+  -> (Concrete.ABlock ByteString, AbstractToConcreteIdMaps)
+elaborateBS txIdMap config dCert st ab =
+  first (annotateBlock (Genesis.configEpochSlots config))
+    $ elaborate txIdMap config dCert st ab
+
+annotateBlock :: Slotting.EpochSlots -> Concrete.Block -> Concrete.ABlock ByteString
+annotateBlock epochSlots block =
+  let
+    decodedABlockOrBoundary =
+      case
+          Binary.decodeFullDecoder
+            "Block"
+            (Concrete.fromCBORABlockOrBoundary epochSlots) bytes
+        of
+          Left err ->
+            panic
+              $  "This function should be able to decode the block it encoded"
+              <> ". Instead I got: "
+              <> show err
+          Right abobb -> map (LBS.toStrict . Binary.slice bytes) abobb
+  in
+    case decodedABlockOrBoundary of
+      Concrete.ABOBBlock bk -> bk
+      Concrete.ABOBBoundary _ ->
+        panic "This function should have decoded a block."
+  where bytes = Binary.serializeEncoding (Concrete.toCBORABOBBlock epochSlots block)
+
 -- | Re-construct an abstract delegation certificate from the abstract state.
 --
 -- We need to do this because the delegation certificate is included in the

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Delegation.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Delegation.hs
@@ -14,6 +14,7 @@ import Test.Cardano.Prelude
 import qualified Data.Set as Set
 import Hedgehog (assert, forAll, property, success, cover)
 
+import Cardano.Binary (Annotated(..), serialize')
 import Cardano.Chain.Common (hashKey)
 import qualified Cardano.Chain.Common as Concrete
 import qualified Cardano.Chain.Delegation as Concrete
@@ -69,7 +70,7 @@ ts_prop_elaboratedCertsValid =
           Just cert ->
             let concreteCert = elaborateDCert pm cert in
             assert
-              $ Concrete.Certificate.isValid pm concreteCert
+              $ Concrete.Certificate.isValid (Annotated pm (serialize' pm)) concreteCert
  where
   env = DSEnv
     { _dSEnvAllowedDelegators = Set.fromList
@@ -99,7 +100,7 @@ elaborateDCert pm cert = Concrete.signCertificate
 
 elaborateDSEnv :: DSEnv -> Scheduling.Environment
 elaborateDSEnv abstractEnv = Scheduling.Environment
-  { Scheduling.protocolMagic = Dummy.protocolMagicId
+  { Scheduling.protocolMagic = Dummy.annotatedProtocolMagicId
   , Scheduling.allowedDelegators = Set.fromList
     $   hashKey
     .   elaborateVKeyGenesis

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Delegation.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Delegation.hs
@@ -3,6 +3,7 @@
 
 module Test.Cardano.Chain.Elaboration.Delegation
   ( elaborateDCert
+  , elaborateDCertAnnotated
   , elaborateDSEnv
   , tests
   )
@@ -68,7 +69,7 @@ ts_prop_elaboratedCertsValid =
                     -- fails. Coverage testing ensures we will not generate a
                     -- large portion of 'Nothing'.
           Just cert ->
-            let concreteCert = elaborateDCert pm cert in
+            let concreteCert = elaborateDCertAnnotated pm cert in
             assert
               $ Concrete.Certificate.isValid (Annotated pm (serialize' pm)) concreteCert
  where
@@ -97,6 +98,19 @@ elaborateDCert pm cert = Concrete.signCertificate
 
   epochNo :: Concrete.EpochNumber
   epochNo = fromIntegral e
+
+
+elaborateDCertAnnotated
+  :: ProtocolMagicId -> DCert -> Concrete.ACertificate ByteString
+elaborateDCertAnnotated pm = annotateDCert . elaborateDCert pm
+ where
+  annotateDCert :: Concrete.Certificate -> Concrete.ACertificate ByteString
+  annotateDCert cert = cert
+    { Concrete.Certificate.aEpoch = Annotated omega (serialize' omega)
+    , Concrete.Certificate.annotation = serialize' cert
+    }
+    where omega = Concrete.Certificate.epoch cert
+
 
 elaborateDSEnv :: DSEnv -> Scheduling.Environment
 elaborateDSEnv abstractEnv = Scheduling.Environment

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
@@ -38,7 +38,7 @@ import qualified Test.Cardano.Crypto.Dummy as Dummy
 
 elaborateUTxOEnv :: Abstract.UTxOEnv -> Concrete.UTxO.Environment
 elaborateUTxOEnv _abstractEnv = Concrete.UTxO.Environment
-  { Concrete.UTxO.protocolMagic      = Dummy.protocolMagic
+  { Concrete.UTxO.protocolMagic      = Dummy.aProtocolMagic
   , Concrete.UTxO.protocolParameters = dummyProtocolParameters
     { Concrete.ppTxFeePolicy =
       Concrete.TxFeePolicyTxSizeLinear $ Concrete.TxSizeLinear

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
@@ -8,18 +8,20 @@ module Test.Cardano.Chain.Elaboration.UTxO
   ( elaborateUTxOEnv
   , elaborateUTxO
   , elaborateTx
+  , elaborateTxWitsBS
   , elaborateTxOut
-  , elaborateTxWits
   )
 where
 
 import Cardano.Prelude
 
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Vector as V
 import Formatting hiding (bytes)
 
+import qualified Cardano.Binary as CBOR
 import qualified Cardano.Chain.Common as Concrete
 import qualified Cardano.Chain.UTxO as Concrete
 import qualified Cardano.Chain.UTxO.UTxO as Concrete.UTxO
@@ -68,21 +70,36 @@ elaborateUTxOEntry elaborateTxId (abstractTxIn, abstractTxOut) =
   concreteTxOut = elaborateTxOut abstractTxOut
   concreteTxIn  = elaborateTxIn elaborateTxId abstractTxIn
 
+elaborateTxWitsBS
+  :: (Abstract.TxId -> Concrete.TxId)
+  -> Abstract.TxWits
+  -> Concrete.ATxAux ByteString
+elaborateTxWitsBS elaborateTxId =
+  annotateTxAux . elaborateTxWits elaborateTxId
+ where
+  annotateTxAux :: Concrete.TxAux -> Concrete.ATxAux ByteString
+  annotateTxAux txAux =
+    map (LBS.toStrict . CBOR.slice bytes)
+      . fromRight (panic "elaborateTxWitsBS: Error decoding TxAux")
+      $ CBOR.decodeFull bytes
+    where bytes = CBOR.serialize txAux
+
 elaborateTxWits
   :: (Abstract.TxId -> Concrete.TxId) -> Abstract.TxWits -> Concrete.TxAux
 elaborateTxWits elaborateTxId (Abstract.TxWits tx witnesses) =
-  Concrete.TxAux concreteTx (elaborateWitnesses concreteTx witnesses)
+  Concrete.mkTxAux concreteTx (elaborateWitnesses concreteTx witnesses)
   where concreteTx = elaborateTx elaborateTxId tx
 
 elaborateTx :: (Abstract.TxId -> Concrete.TxId) -> Abstract.Tx -> Concrete.Tx
 elaborateTx elaborateTxId (Abstract.Tx inputs outputs) =
-  Concrete.Tx
-    (elaborateTxIns elaborateTxId inputs)
-    (elaborateTxOuts outputs)
-    (Concrete.mkAttributes ())
+  Concrete.UnsafeTx
+    { Concrete.txInputs     = elaborateTxIns elaborateTxId inputs
+    , Concrete.txOutputs    = elaborateTxOuts outputs
+    , Concrete.txAttributes = Concrete.mkAttributes ()
+    }
 
 elaborateWitnesses :: Concrete.Tx -> [Abstract.Wit] -> Concrete.TxWitness
-elaborateWitnesses concreteTx = Concrete.TxWitness . V.fromList . fmap (elaborateWitness concreteTx)
+elaborateWitnesses concreteTx = V.fromList . fmap (elaborateWitness concreteTx)
 
 elaborateWitness :: Concrete.Tx -> Abstract.Wit -> Concrete.TxInWitness
 elaborateWitness concreteTx (Abstract.Wit key _) = Concrete.VKWitness

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
@@ -112,9 +112,9 @@ elaborateSoftwareVersion abstractVersion =
 elaborateUpdateProposal
   :: ProtocolMagicId
   -> Abstract.UProp
-  -> Concrete.Proposal
+  -> Concrete.AProposal ()
 elaborateUpdateProposal protocolMagicId abstractProposal =
-  Concrete.UnsafeProposal
+  Concrete.unsafeProposal
     body
     issuer
     proposalSignature
@@ -153,10 +153,15 @@ elaborateUpSD ( protocolVersion
               , systemTags
               , _metadata) =
   Proposal.ProposalBody
-      (elaborateProtocolVersion protocolVersion)
-      (justifyProtocolParameters $ elaboratePParams protocolParameters)
-      (elaborateSoftwareVersion softwareVersion)
-      (Map.fromList $ zip concreteSystemTags concreteSystemHashes)
+  { Proposal.protocolVersion =
+      elaborateProtocolVersion protocolVersion
+  , Proposal.protocolParametersUpdate =
+      justifyProtocolParameters $ elaboratePParams protocolParameters
+  , Proposal.softwareVersion =
+      elaborateSoftwareVersion softwareVersion
+  , Proposal.metadata =
+      Map.fromList $ zip concreteSystemTags concreteSystemHashes
+  }
   where
     concreteSystemTags =
       fmap elaborateSystemTag $ Set.toList systemTags
@@ -198,9 +203,9 @@ elaborateVote
   :: ProtocolMagicId
   -> Map Abstract.UpId Concrete.UpId
   -> Abstract.Vote
-  -> Concrete.Vote
+  -> Concrete.AVote ()
 elaborateVote protocolMagicId proposalsIdMap abstractVote =
-  Concrete.UnsafeVote
+  Concrete.unsafeVote
     issuer
     (elaborateProposalId proposalsIdMap abstractProposalId)
     voteSignature

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE TypeApplications          #-}
-{-# LANGUAGE PatternSynonyms           #-}
 
 module Test.Cardano.Chain.Genesis.Example
   ( exampleGenesisAvvmBalances
@@ -30,7 +29,7 @@ import Cardano.Chain.Common
   , mkKnownLovelacePortion
   , hashKey
   )
-import Cardano.Chain.Delegation (pattern UnsafeCertificate)
+import Cardano.Chain.Delegation (unsafeCertificate)
 import Cardano.Chain.Genesis
   ( FakeAvvmOptions(..)
   , GenesisNonAvvmBalances(..)
@@ -100,7 +99,7 @@ exampleGenesisDelegation :: GenesisDelegation
 exampleGenesisDelegation = UnsafeGenesisDelegation
   (M.fromList
     [ ( hashKey issueVerKey
-      , UnsafeCertificate
+      , unsafeCertificate
         (EpochNumber 68300481033)
         issueVerKey
         (VerificationKey

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE PatternSynonyms           #-}
 
 module Test.Cardano.Chain.Genesis.Example
   ( exampleGenesisAvvmBalances
@@ -21,6 +22,7 @@ import Data.Maybe (fromJust)
 import qualified Data.Set as Set
 import Data.Time (UTCTime(..), Day(..), secondsToDiffTime)
 
+import Cardano.Binary (Annotated(..))
 import Cardano.Chain.Common
   ( BlockCount(..)
   , LovelacePortion(..)
@@ -28,7 +30,7 @@ import Cardano.Chain.Common
   , mkKnownLovelacePortion
   , hashKey
   )
-import Cardano.Chain.Delegation (Certificate(..))
+import Cardano.Chain.Delegation (pattern UnsafeCertificate)
 import Cardano.Chain.Genesis
   ( FakeAvvmOptions(..)
   , GenesisNonAvvmBalances(..)
@@ -42,7 +44,7 @@ import Cardano.Chain.Genesis
   )
 import Cardano.Chain.Slotting (EpochNumber(..))
 import Cardano.Crypto
-  ( ProtocolMagic(..)
+  ( AProtocolMagic(..)
   , ProtocolMagicId(..)
   , CompactRedeemVerificationKey
   , RequiresNetworkMagic(..)
@@ -69,7 +71,7 @@ exampleGenesisSpec = UnsafeGenesisSpec
   exampleGenesisDelegation
   exampleProtocolParameters
   (BlockCount 37)
-  (ProtocolMagic (ProtocolMagicId 1783847074) RequiresMagic)
+  (AProtocolMagic (Annotated (ProtocolMagicId 1783847074) ()) RequiresMagic)
   exampleGenesisInitializer
 
 exampleGenesisAvvmBalances :: GenesisAvvmBalances

--- a/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/CBOR.hs
@@ -11,10 +11,24 @@ where
 import Cardano.Prelude
 import Test.Cardano.Prelude
 
-import Hedgehog (Property)
+import qualified Data.ByteString.Lazy as LBS
+import Hedgehog (Property, tripping)
+
+import Cardano.Binary
+    ( ByteSpan
+    , Decoder
+    , FromCBOR(..)
+    , ToCBOR
+    , decodeFull
+    , decodeFullDecoder
+    , fromCBOR
+    , serialize
+    , slice
+    , toCBOR
+    )
 
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBORAnnotated, roundTripsCBORAnnotatedShow)
+  (goldenTestCBOR, goldenTestCBORExplicit, roundTripsCBORShow)
 import Test.Cardano.Chain.MempoolPayload.Example
     ( exampleMempoolPayload
     , exampleMempoolPayload1
@@ -27,52 +41,98 @@ import Test.Options (TSGroup, TSProperty, concatTSGroups, eachOfTS)
 
 
 --------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+-- | Serialises @f ()@ and uses that 'ByteString' as the annotation to splice
+-- in.
+fillInByteString
+  :: forall f. (FromCBOR (f ByteSpan), ToCBOR (f ()), Functor f)
+  => f () -> f ByteString
+fillInByteString a =
+    either (panic . show) identity $ decodeFullDecoder mempty dec bytes
+  where
+    bytes :: LByteString
+    bytes = serialize a
+
+    dec :: Decoder s (f ByteString)
+    dec = fmap (LBS.toStrict . slice bytes) <$> fromCBOR
+
+-- | Variant of 'goldenTestCBOR' that does not use the @'ToCBOR' (f ())@
+-- instance, but the @'ToCBOR' (f ByteString)@ instance. The latter instance
+-- allows reusing the annotation when serialising instead of reserialising
+-- from scratch.
+filledInGoldenTestCBOR
+  :: forall f
+  . ( FromCBOR (f ())
+    , ToCBOR (f ())
+    , FromCBOR (f ByteSpan)
+    , ToCBOR (f ByteString)
+    , Functor f
+    , Eq (f ())
+    , Show (f ())
+    , HasCallStack
+    )
+  => f ()
+  -> FilePath
+  -> Property
+filledInGoldenTestCBOR = goldenTestCBORExplicit
+  (label $ Proxy @(f ()))
+  (toCBOR . fillInByteString)
+  fromCBOR
+
+--------------------------------------------------------------------------------
 -- MempoolPayload
 --------------------------------------------------------------------------------
 
 goldenMempoolPayload :: Property
-goldenMempoolPayload = goldenTestCBORAnnotated
+goldenMempoolPayload = goldenTestCBOR
   exampleMempoolPayload
   "test/golden/cbor/mempoolpayload/MempoolPayload"
 
 goldenMempoolPayloadFilledIn :: Property
-goldenMempoolPayloadFilledIn = goldenTestCBORAnnotated
+goldenMempoolPayloadFilledIn = filledInGoldenTestCBOR
   exampleMempoolPayload
   "test/golden/cbor/mempoolpayload/MempoolPayload"
 
 goldenMempoolPayload1 :: Property
-goldenMempoolPayload1 = goldenTestCBORAnnotated
+goldenMempoolPayload1 = goldenTestCBOR
   exampleMempoolPayload1
   "test/golden/cbor/mempoolpayload/MempoolPayload1"
 
 goldenMempoolPayload1FilledIn :: Property
-goldenMempoolPayload1FilledIn = goldenTestCBORAnnotated
+goldenMempoolPayload1FilledIn = filledInGoldenTestCBOR
   exampleMempoolPayload1
   "test/golden/cbor/mempoolpayload/MempoolPayload1"
 
 goldenMempoolPayload2 :: Property
-goldenMempoolPayload2 = goldenTestCBORAnnotated
+goldenMempoolPayload2 = goldenTestCBOR
   exampleMempoolPayload2
   "test/golden/cbor/mempoolpayload/MempoolPayload2"
 
 goldenMempoolPayload2FilledIn :: Property
-goldenMempoolPayload2FilledIn = goldenTestCBORAnnotated
+goldenMempoolPayload2FilledIn = filledInGoldenTestCBOR
   exampleMempoolPayload2
   "test/golden/cbor/mempoolpayload/MempoolPayload2"
 
 goldenMempoolPayload3 :: Property
-goldenMempoolPayload3 = goldenTestCBORAnnotated
+goldenMempoolPayload3 = goldenTestCBOR
   exampleMempoolPayload3
   "test/golden/cbor/mempoolpayload/MempoolPayload3"
 
 goldenMempoolPayload3FilledIn :: Property
-goldenMempoolPayload3FilledIn = goldenTestCBORAnnotated
+goldenMempoolPayload3FilledIn = filledInGoldenTestCBOR
   exampleMempoolPayload3
   "test/golden/cbor/mempoolpayload/MempoolPayload3"
 
 ts_roundTripMempoolPayload :: TSProperty
 ts_roundTripMempoolPayload =
-  eachOfTS 200 (feedPM genMempoolPayload) roundTripsCBORAnnotatedShow
+  eachOfTS 200 (feedPM genMempoolPayload) roundTripsCBORShow
+
+ts_roundTripMempoolPayloadFilledIn :: TSProperty
+ts_roundTripMempoolPayloadFilledIn =
+  eachOfTS 200 (feedPM genMempoolPayload) $ \x ->
+    tripping x (serialize . fillInByteString) decodeFull
 
 tests :: TSGroup
 tests = concatTSGroups [const $$discoverGolden, $$discoverRoundTripArg]

--- a/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/Example.hs
@@ -10,7 +10,7 @@ where
 
 import Data.List ((!!))
 
-import Cardano.Chain.MempoolPayload (MempoolPayload (..), MempoolPayload)
+import Cardano.Chain.MempoolPayload (AMempoolPayload (..), MempoolPayload)
 
 import Test.Cardano.Chain.Delegation.Example as Delegation
     (exampleCertificates)

--- a/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/MempoolPayload/Gen.hs
@@ -8,7 +8,7 @@ import Cardano.Prelude
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 
-import Cardano.Chain.MempoolPayload (MempoolPayload (..))
+import Cardano.Chain.MempoolPayload (AMempoolPayload (..), MempoolPayload)
 import Cardano.Crypto (ProtocolMagicId)
 
 import Test.Cardano.Chain.Delegation.Gen as Delegation (genCertificate)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE PatternSynonyms   #-}
 
 module Test.Cardano.Chain.UTxO.CBOR
   ( tests
@@ -21,12 +20,12 @@ import qualified Hedgehog as H
 import Cardano.Binary (ToCBOR, Case(..), LengthOf, SizeOverride(..), szCases)
 import Cardano.Chain.Common (AddrAttributes(..), Attributes(..), mkAttributes)
 import Cardano.Chain.UTxO
-  (Tx(..), pattern Tx,  TxIn(..), TxInWitness(..), TxOut(..), TxSigData(..), taTx, taWitness, txInWitnesses)
+  (Tx(..), TxIn(..), TxInWitness(..), TxOut(..), TxSigData(..), taTx, taWitness)
 import Cardano.Crypto (ProtocolMagicId(..), SignTag(..), Signature, sign)
 
 import Test.Cardano.Binary.Helpers (SizeTestConfig(..), scfg, sizeTest)
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBOR, goldenTestCBORAnnotated, roundTripsCBORBuildable, roundTripsCBORAnnotatedBuildable, roundTripsCBORShow, roundTripsCBORAnnotatedShow)
+  (goldenTestCBOR, roundTripsCBORBuildable, roundTripsCBORShow)
 import Test.Cardano.Chain.UTxO.Example
   ( exampleHashTx
   , exampleRedeemSignature
@@ -73,11 +72,11 @@ import Test.Options (TSGroup, TSProperty, concatTSGroups, eachOfTS)
 --------------------------------------------------------------------------------
 
 goldenTx :: Property
-goldenTx = goldenTestCBORAnnotated tx "test/golden/cbor/utxo/Tx"
-  where tx = Tx exampleTxInList exampleTxOutList (mkAttributes ())
+goldenTx = goldenTestCBOR tx "test/golden/cbor/utxo/Tx"
+  where tx = UnsafeTx exampleTxInList exampleTxOutList (mkAttributes ())
 
 ts_roundTripTx :: TSProperty
-ts_roundTripTx = eachOfTS 50 genTx roundTripsCBORAnnotatedBuildable
+ts_roundTripTx = eachOfTS 50 genTx roundTripsCBORBuildable
 
 
 --------------------------------------------------------------------------------
@@ -97,7 +96,7 @@ ts_roundTripTxAttributes = eachOfTS 10 genTxAttributes roundTripsCBORBuildable
 --------------------------------------------------------------------------------
 
 ts_roundTripTxAux :: TSProperty
-ts_roundTripTxAux = eachOfTS 100 (feedPM genTxAux) roundTripsCBORAnnotatedBuildable
+ts_roundTripTxAux = eachOfTS 100 (feedPM genTxAux) roundTripsCBORBuildable
 
 
 --------------------------------------------------------------------------------
@@ -199,10 +198,10 @@ ts_roundTripTxOut = eachOfTS 50 genTxOut roundTripsCBORBuildable
 
 goldenTxPayload1 :: Property
 goldenTxPayload1 =
-  goldenTestCBORAnnotated exampleTxPayload1 "test/golden/cbor/utxo/TxPayload1"
+  goldenTestCBOR exampleTxPayload1 "test/golden/cbor/utxo/TxPayload1"
 
 ts_roundTripTxPayload :: TSProperty
-ts_roundTripTxPayload = eachOfTS 50 (feedPM genTxPayload) roundTripsCBORAnnotatedShow
+ts_roundTripTxPayload = eachOfTS 50 (feedPM genTxPayload) roundTripsCBORShow
 
 
 --------------------------------------------------------------------------------
@@ -210,10 +209,10 @@ ts_roundTripTxPayload = eachOfTS 50 (feedPM genTxPayload) roundTripsCBORAnnotate
 --------------------------------------------------------------------------------
 
 goldenTxProof :: Property
-goldenTxProof = goldenTestCBORAnnotated exampleTxProof "test/golden/cbor/utxo/TxProof"
+goldenTxProof = goldenTestCBOR exampleTxProof "test/golden/cbor/utxo/TxProof"
 
 ts_roundTripTxProof :: TSProperty
-ts_roundTripTxProof = eachOfTS 50 (feedPM genTxProof) roundTripsCBORAnnotatedBuildable
+ts_roundTripTxProof = eachOfTS 50 (feedPM genTxProof) roundTripsCBORBuildable
 
 
 --------------------------------------------------------------------------------
@@ -251,7 +250,7 @@ ts_roundTripTxSigData = eachOfTS 50 genTxSigData roundTripsCBORShow
 
 ts_roundTripTxValidationError :: TSProperty
 ts_roundTripTxValidationError =
-  eachOfTS 50 genTxValidationError roundTripsCBORAnnotatedShow
+  eachOfTS 50 genTxValidationError roundTripsCBORShow
 
 
 --------------------------------------------------------------------------------
@@ -260,10 +259,10 @@ ts_roundTripTxValidationError =
 
 goldenTxWitness :: Property
 goldenTxWitness =
-  goldenTestCBORAnnotated exampleTxWitness "test/golden/cbor/utxo/TxWitness"
+  goldenTestCBOR exampleTxWitness "test/golden/cbor/utxo/TxWitness"
 
 ts_roundTripTxWitness :: TSProperty
-ts_roundTripTxWitness = eachOfTS 20 (feedPM genTxWitness) roundTripsCBORAnnotatedShow
+ts_roundTripTxWitness = eachOfTS 20 (feedPM genTxWitness) roundTripsCBORShow
 
 
 --------------------------------------------------------------------------------
@@ -281,7 +280,7 @@ ts_roundTripUTxOError =
 
 ts_roundTripUTxOValidationError :: TSProperty
 ts_roundTripUTxOValidationError =
-  eachOfTS 50 genUTxOValidationError roundTripsCBORAnnotatedShow
+  eachOfTS 50 genUTxOValidationError roundTripsCBORShow
 
 
 --------------------------------------------------------------------------------
@@ -333,7 +332,7 @@ sizeEstimates
               , SizeConstant (fromIntegral $ length $ txInputs $ taTx ta)
               )
             , ( typeRep (Proxy @(LengthOf (Vector TxInWitness)))
-              , SizeConstant (fromIntegral $ length $ txInWitnesses $ taWitness ta)
+              , SizeConstant (fromIntegral $ length $ taWitness ta)
               )
             , ( typeRep (Proxy @(LengthOf [TxOut]))
               , SizeConstant (fromIntegral $ length $ txOutputs $ taTx ta)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/CBOR.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE PatternSynonyms   #-}
 
 module Test.Cardano.Chain.UTxO.CBOR
   ( tests
@@ -20,7 +21,7 @@ import qualified Hedgehog as H
 import Cardano.Binary (ToCBOR, Case(..), LengthOf, SizeOverride(..), szCases)
 import Cardano.Chain.Common (AddrAttributes(..), Attributes(..), mkAttributes)
 import Cardano.Chain.UTxO
-  (Tx(..), TxIn(..), TxInWitness(..), TxOut(..), TxSigData(..), taTx, taWitness, txInWitnesses)
+  (Tx(..), pattern Tx,  TxIn(..), TxInWitness(..), TxOut(..), TxSigData(..), taTx, taWitness, txInWitnesses)
 import Cardano.Crypto (ProtocolMagicId(..), SignTag(..), Signature, sign)
 
 import Test.Cardano.Binary.Helpers (SizeTestConfig(..), scfg, sizeTest)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE PatternSynonyms  #-}
 
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 
@@ -40,7 +41,8 @@ import Cardano.Chain.Common
   , mtRoot
   )
 import Cardano.Chain.UTxO
-  ( Tx(..)
+  ( Tx
+  , pattern Tx
   , TxAux(..)
   , TxId
   , TxIn(..)
@@ -50,7 +52,8 @@ import Cardano.Chain.UTxO
   , TxProof(..)
   , TxSig
   , TxSigData(..)
-  , TxWitness(..)
+  , TxWitness
+  , pattern TxWitness
   )
 import Cardano.Crypto
   ( AbstractHash(..)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE PatternSynonyms  #-}
 
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 
@@ -41,19 +40,19 @@ import Cardano.Chain.Common
   , mtRoot
   )
 import Cardano.Chain.UTxO
-  ( Tx
-  , pattern Tx
-  , TxAux(..)
+  ( Tx(..)
+  , TxAux
   , TxId
   , TxIn(..)
   , TxInWitness(..)
   , TxOut(..)
-  , TxPayload(..)
+  , TxPayload
   , TxProof(..)
   , TxSig
   , TxSigData(..)
   , TxWitness
-  , pattern TxWitness
+  , mkTxAux
+  , mkTxPayload
   )
 import Cardano.Crypto
   ( AbstractHash(..)
@@ -74,12 +73,12 @@ import Test.Cardano.Crypto.Example (exampleVerificationKey, exampleSigningKey)
 
 
 exampleTxAux :: TxAux
-exampleTxAux = TxAux tx exampleTxWitness
-  where tx = Tx exampleTxInList exampleTxOutList (mkAttributes ())
+exampleTxAux = mkTxAux tx exampleTxWitness
+  where tx = UnsafeTx exampleTxInList exampleTxOutList (mkAttributes ())
 
 exampleTxAux1 :: TxAux
-exampleTxAux1 = TxAux tx exampleTxWitness
-  where tx = Tx exampleTxInList1 exampleTxOutList1 (mkAttributes ())
+exampleTxAux1 = mkTxAux tx exampleTxWitness
+  where tx = UnsafeTx exampleTxInList1 exampleTxOutList1 (mkAttributes ())
 
 exampleTxId :: TxId
 exampleTxId = exampleHashTx
@@ -112,17 +111,17 @@ exampleTxOutList1 :: (NonEmpty TxOut)
 exampleTxOutList1 = fromList [exampleTxOut, exampleTxOut1]
 
 exampleTxPayload :: TxPayload
-exampleTxPayload = TxPayload [exampleTxAux]
+exampleTxPayload = mkTxPayload [exampleTxAux]
 
 exampleTxPayload1 :: TxPayload
-exampleTxPayload1 = TxPayload [exampleTxAux, exampleTxAux1]
+exampleTxPayload1 = mkTxPayload [exampleTxAux, exampleTxAux1]
 
 exampleTxProof :: TxProof
 exampleTxProof = TxProof 32 mroot hashWit
  where
   mroot = mtRoot $ mkMerkleTree
-    [(Tx exampleTxInList exampleTxOutList (mkAttributes ()))]
-  hashWit = hash $ TxWitness <$> [(V.fromList [(VKWitness exampleVerificationKey exampleTxSig)])]
+    [(UnsafeTx exampleTxInList exampleTxOutList (mkAttributes ()))]
+  hashWit = hash $ [(V.fromList [(VKWitness exampleVerificationKey exampleTxSig)])]
 
 exampleTxSig :: TxSig
 exampleTxSig =
@@ -132,7 +131,7 @@ exampleTxSigData :: TxSigData
 exampleTxSigData = TxSigData exampleHashTx
 
 exampleTxWitness :: TxWitness
-exampleTxWitness = TxWitness $ V.fromList [(VKWitness exampleVerificationKey exampleTxSig)]
+exampleTxWitness = V.fromList [(VKWitness exampleVerificationKey exampleTxSig)]
 
 exampleRedeemSignature :: RedeemSignature TxSigData
 exampleRedeemSignature = redeemSign

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE PatternSynonyms #-}
-
 module Test.Cardano.Chain.UTxO.Gen
   ( genCompactTxId
   , genCompactTxIn
@@ -45,26 +43,26 @@ import Cardano.Chain.UTxO
   ( CompactTxId
   , CompactTxIn
   , CompactTxOut
-  , Tx
-  , pattern Tx
+  , Tx(..)
   , TxAttributes
-  , TxAux(..)
+  , TxAux
   , TxId
   , TxIn(..)
   , TxInWitness(..)
   , TxOut(..)
-  , TxPayload(..)
+  , TxPayload
   , TxProof(..)
   , TxSig
   , TxSigData(..)
   , TxValidationError(..)
   , TxWitness
-  , pattern TxWitness
   , UTxOConfiguration(..)
   , UTxO
   , UTxOError(..)
   , UTxOValidationError(..)
   , fromList
+  , mkTxAux
+  , mkTxPayload
   , mkUTxOConfiguration
   , toCompactTxId
   , toCompactTxIn
@@ -103,13 +101,13 @@ genRedeemWitness pm =
   RedeemWitness <$> genRedeemVerificationKey <*> genRedeemSignature pm genTxSigData
 
 genTx :: Gen Tx
-genTx = Tx <$> genTxInList <*> genTxOutList <*> genTxAttributes
+genTx = UnsafeTx <$> genTxInList <*> genTxOutList <*> genTxAttributes
 
 genTxAttributes :: Gen TxAttributes
 genTxAttributes = pure $ mkAttributes ()
 
 genTxAux :: ProtocolMagicId -> Gen TxAux
-genTxAux pm = TxAux <$> genTx <*> (genTxWitness pm)
+genTxAux pm = mkTxAux <$> genTx <*> (genTxWitness pm)
 
 genTxHash :: Gen (Hash Tx)
 genTxHash = coerce <$> genTextHash
@@ -139,7 +137,7 @@ genUTxOConfiguration =
     <$> Gen.list (Range.linear 0 50) genAddress
 
 genTxPayload :: ProtocolMagicId -> Gen TxPayload
-genTxPayload pm = TxPayload <$> Gen.list (Range.linear 0 10) (genTxAux pm)
+genTxPayload pm = mkTxPayload <$> Gen.list (Range.linear 0 10) (genTxAux pm)
 
 genTxProof :: ProtocolMagicId -> Gen TxProof
 genTxProof pm =
@@ -181,7 +179,7 @@ genTxInWitness pm = Gen.choice [genVKWitness pm, genRedeemWitness pm]
 
 genTxWitness :: ProtocolMagicId -> Gen TxWitness
 genTxWitness pm =
-  TxWitness . V.fromList <$> Gen.list (Range.linear 1 10) (genTxInWitness pm)
+  V.fromList <$> Gen.list (Range.linear 1 10) (genTxInWitness pm)
 
 genUTxO :: Gen UTxO
 genUTxO = fromList <$> Gen.list (Range.constant 0 1000) genTxInTxOut

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Test.Cardano.Chain.UTxO.Gen
   ( genCompactTxId
   , genCompactTxIn
@@ -43,7 +45,8 @@ import Cardano.Chain.UTxO
   ( CompactTxId
   , CompactTxIn
   , CompactTxOut
-  , Tx(..)
+  , Tx
+  , pattern Tx
   , TxAttributes
   , TxAux(..)
   , TxId
@@ -55,7 +58,8 @@ import Cardano.Chain.UTxO
   , TxSig
   , TxSigData(..)
   , TxValidationError(..)
-  , TxWitness(..)
+  , TxWitness
+  , pattern TxWitness
   , UTxOConfiguration(..)
   , UTxO
   , UTxOError(..)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Model.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Model.hs
@@ -28,7 +28,7 @@ import Cardano.Chain.UTxO
 import qualified Cardano.Chain.UTxO as Concrete
 import qualified Cardano.Chain.UTxO.UTxO as Concrete.UTxO
 import Cardano.Chain.ValidationMode (ValidationMode (..))
-import Cardano.Crypto (hash)
+import Cardano.Crypto (hash, hashDecoded)
 
 import qualified Cardano.Ledger.Spec.STS.UTXO as Abstract
 import Cardano.Ledger.Spec.STS.UTXOW (UTXOW)
@@ -121,21 +121,21 @@ elaborateAndUpdate abstractEnv (utxo, txIdMap) abstractTxWits =
 elaborateTxWitnesses
   :: Map Abstract.TxId Concrete.TxId
   -> [Abstract.TxWits]
-  -> ([Concrete.TxAux], Map Abstract.TxId Concrete.TxId)
+  -> ([Concrete.ATxAux ByteString], Map Abstract.TxId Concrete.TxId)
 elaborateTxWitnesses txIdMap = first reverse . foldl' step ([], txIdMap)
   where step (acc, m) = first (: acc) . elaborateTxWitsBSWithMap m
 
 elaborateTxWitsBSWithMap
   :: Map Abstract.TxId Concrete.TxId
   -> Abstract.TxWits
-  -> (Concrete.TxAux, Map Abstract.TxId Concrete.TxId)
+  -> (Concrete.ATxAux ByteString, Map Abstract.TxId Concrete.TxId)
 elaborateTxWitsBSWithMap txIdMap abstractTxWits = (concreteTxWitness, txIdMap')
  where
-  concreteTxWitness = E.elaborateTxWits
+  concreteTxWitness = E.elaborateTxWitsBS
     (elaborateTxId txIdMap)
     abstractTxWits
 
-  concreteTxId = hash $ Concrete.taTx concreteTxWitness
+  concreteTxId = hashDecoded $ Concrete.aTaTx concreteTxWitness
 
   txIdMap'     = M.insert
     (Abstract.txid $ Abstract.body abstractTxWits)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/ValidationMode.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/ValidationMode.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE PatternSynonyms   #-}
 
 module Test.Cardano.Chain.UTxO.ValidationMode
   ( tests
@@ -26,7 +27,7 @@ import Cardano.Chain.UTxO
   ( TxAux (..)
   , Environment (..)
   , TxId
-  , TxWitness (..)
+  , pattern TxWitness
   , TxValidationError (..)
   , TxValidationMode (..)
   , UTxOValidationError (..)
@@ -79,7 +80,7 @@ ts_prop_updateUTxO_Valid =
             abstractTxWits
 
       -- Validate the generated concrete transaction
-      let pm = Dummy.protocolMagic
+      let pm = Dummy.aProtocolMagic
           env = Environment pm pparams UTxO.defaultUTxOConfiguration
       vMode <- forAll $ ValidationMode BlockValidation <$> genValidationMode
       updateRes <- (`runReaderT` vMode) . runExceptT $
@@ -113,7 +114,7 @@ ts_prop_updateUTxO_InvalidWit =
 
       -- Generate an invalid 'TxWitness' and utilize it in the valid
       -- transaction generated above.
-      let pm = Dummy.protocolMagic
+      let pm = Dummy.aProtocolMagic
       invalidWitness <- forAll $
         TxWitness
           <$> V.fromList

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/CBOR.hs
@@ -17,7 +17,7 @@ import Cardano.Chain.Update (ApplicationName(..), SoftforkRule(..))
 import Cardano.Crypto (Hash, abstractHash)
 
 import Test.Cardano.Binary.Helpers.GoldenRoundTrip
-  (goldenTestCBOR, goldenTestCBORAnnotated, roundTripsCBORBuildable, roundTripsCBORShow, roundTripsCBORAnnotatedShow, roundTripsCBORAnnotatedBuildable)
+  (goldenTestCBOR, roundTripsCBORBuildable, roundTripsCBORShow)
 import Test.Cardano.Chain.Update.Example
   ( exampleProtocolParametersUpdate
   , examplePayload
@@ -184,11 +184,11 @@ ts_roundTripInstallerHash = eachOfTS 20 genInstallerHash roundTripsCBORBuildable
 
 goldenUpdatePayload :: Property
 goldenUpdatePayload =
-  goldenTestCBORAnnotated examplePayload "test/golden/cbor/update/Payload"
+  goldenTestCBOR examplePayload "test/golden/cbor/update/Payload"
 
 ts_roundTripUpdatePayload :: TSProperty
 ts_roundTripUpdatePayload =
-  eachOfTS 20 (feedPM genPayload) roundTripsCBORAnnotatedBuildable
+  eachOfTS 20 (feedPM genPayload) roundTripsCBORBuildable
 
 
 --------------------------------------------------------------------------------
@@ -208,11 +208,11 @@ ts_roundTripUpdateProof = eachOfTS 20 (feedPM genProof) roundTripsCBORBuildable
 
 goldenUpdateProposal :: Property
 goldenUpdateProposal =
-  goldenTestCBORAnnotated exampleProposal "test/golden/cbor/update/Proposal"
+  goldenTestCBOR exampleProposal "test/golden/cbor/update/Proposal"
 
 ts_roundTripUpdateProposal :: TSProperty
 ts_roundTripUpdateProposal =
-  eachOfTS 20 (feedPM genProposal) roundTripsCBORAnnotatedBuildable
+  eachOfTS 20 (feedPM genProposal) roundTripsCBORBuildable
 
 
 --------------------------------------------------------------------------------
@@ -221,10 +221,10 @@ ts_roundTripUpdateProposal =
 
 goldenProposalBody :: Property
 goldenProposalBody =
-  goldenTestCBORAnnotated exampleProposalBody "test/golden/cbor/update/ProposalBody"
+  goldenTestCBOR exampleProposalBody "test/golden/cbor/update/ProposalBody"
 
 ts_roundTripProposalBody :: TSProperty
-ts_roundTripProposalBody = eachOfTS 20 genProposalBody roundTripsCBORAnnotatedShow
+ts_roundTripProposalBody = eachOfTS 20 genProposalBody roundTripsCBORShow
 
 
 --------------------------------------------------------------------------------
@@ -232,10 +232,10 @@ ts_roundTripProposalBody = eachOfTS 20 genProposalBody roundTripsCBORAnnotatedSh
 --------------------------------------------------------------------------------
 
 goldenUpdateVote :: Property
-goldenUpdateVote = goldenTestCBORAnnotated exampleVote "test/golden/cbor/update/Vote"
+goldenUpdateVote = goldenTestCBOR exampleVote "test/golden/cbor/update/Vote"
 
 ts_roundTripUpdateVote :: TSProperty
-ts_roundTripUpdateVote = eachOfTS 20 (feedPM genVote) roundTripsCBORAnnotatedBuildable
+ts_roundTripUpdateVote = eachOfTS 20 (feedPM genVote) roundTripsCBORBuildable
 
 
 --------------------------------------------------------------------------------

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE PatternSynonyms  #-}
 
 module Test.Cardano.Chain.Update.Example
   ( exampleApplicationName
@@ -33,11 +32,9 @@ import Cardano.Chain.Slotting (EpochNumber(..), SlotNumber(..))
 import Cardano.Chain.Update
   ( ApplicationName(..)
   , Payload
-  , pattern Payload
   , Proof
   , Proposal
   , ProposalBody(..)
-  , pattern ProposalBody
   , ProtocolParametersUpdate(..)
   , ProtocolParameters(..)
   , ProtocolVersion(..)
@@ -49,6 +46,7 @@ import Cardano.Chain.Update
   , Vote
   , mkProof
   , signVote
+  , payload
   , signProposal
   )
 import Cardano.Crypto (ProtocolMagicId(..), hash)
@@ -136,7 +134,7 @@ exampleUpId :: UpId
 exampleUpId = hash exampleProposal
 
 examplePayload :: Payload
-examplePayload = Payload up uv
+examplePayload = payload up uv
  where
   up = Just exampleProposal
   uv = [exampleVote]

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE PatternSynonyms  #-}
 
 module Test.Cardano.Chain.Update.Example
   ( exampleApplicationName
@@ -31,10 +32,12 @@ import Cardano.Chain.Common
 import Cardano.Chain.Slotting (EpochNumber(..), SlotNumber(..))
 import Cardano.Chain.Update
   ( ApplicationName(..)
-  , Payload(..)
+  , Payload
+  , pattern Payload
   , Proof
   , Proposal
   , ProposalBody(..)
+  , pattern ProposalBody
   , ProtocolParametersUpdate(..)
   , ProtocolParameters(..)
   , ProtocolVersion(..)

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Gen.hs
@@ -1,3 +1,5 @@
+{-# Language PatternSynonyms #-}
+
 module Test.Cardano.Chain.Update.Gen
   ( genCanonicalProtocolParameters
   , genApplicationName
@@ -27,10 +29,13 @@ import qualified Hedgehog.Range as Range
 
 import Cardano.Chain.Update
   ( ApplicationName(..)
-  , Payload(..)
+  , Payload
+  , pattern Payload
   , Proof
-  , Proposal(..)
+  , Proposal
+  , pattern UnsafeProposal
   , ProposalBody(..)
+  , pattern ProposalBody
   , ProtocolParametersUpdate(..)
   , ProtocolParameters(..)
   , ProtocolVersion(..)

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Gen.hs
@@ -1,5 +1,3 @@
-{-# Language PatternSynonyms #-}
-
 module Test.Cardano.Chain.Update.Gen
   ( genCanonicalProtocolParameters
   , genApplicationName
@@ -30,12 +28,9 @@ import qualified Hedgehog.Range as Range
 import Cardano.Chain.Update
   ( ApplicationName(..)
   , Payload
-  , pattern Payload
   , Proof
   , Proposal
-  , pattern UnsafeProposal
   , ProposalBody(..)
-  , pattern ProposalBody
   , ProtocolParametersUpdate(..)
   , ProtocolParameters(..)
   , ProtocolVersion(..)
@@ -46,7 +41,9 @@ import Cardano.Chain.Update
   , InstallerHash(..)
   , Vote
   , applicationNameMaxLength
+  , unsafeProposal
   , mkVote
+  , payload
   , systemTagMaxLength
   )
 import Cardano.Crypto (ProtocolMagicId)
@@ -153,7 +150,7 @@ genInstallerHash :: Gen InstallerHash
 genInstallerHash = InstallerHash <$> genHashRaw
 
 genPayload :: ProtocolMagicId -> Gen Payload
-genPayload pm = Payload <$> Gen.maybe (genProposal pm) <*> Gen.list
+genPayload pm = payload <$> Gen.maybe (genProposal pm) <*> Gen.list
   (Range.linear 0 10)
   (genVote pm)
 
@@ -162,7 +159,7 @@ genProof pm = genAbstractHash (genPayload pm)
 
 genProposal :: ProtocolMagicId -> Gen Proposal
 genProposal pm =
-  UnsafeProposal
+  unsafeProposal
     <$> genProposalBody
     <*> genVerificationKey
     <*> genSignature pm genProposalBody

--- a/crypto/src/Cardano/Crypto/Signing/Redeem/Signature.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Redeem/Signature.hs
@@ -21,7 +21,7 @@ import Data.Coerce (coerce)
 import qualified Formatting.Buildable as B (Buildable(..))
 
 import Cardano.Binary
-  (Decoded(..), FromCBOR, Raw, ToCBOR, serialize')
+  (Annotated, Decoded(..), FromCBOR, Raw, ToCBOR, serialize')
 import Cardano.Crypto.Orphans ()
 import Cardano.Crypto.ProtocolMagic (ProtocolMagicId)
 import Cardano.Crypto.Signing.Redeem.VerificationKey (RedeemVerificationKey(..))
@@ -77,7 +77,7 @@ verifyRedeemSig pm tag k x s =
 
 verifyRedeemSigDecoded
   :: Decoded t
-  => ProtocolMagicId
+  => Annotated ProtocolMagicId ByteString
   -> SignTag
   -> RedeemVerificationKey
   -> t

--- a/crypto/src/Cardano/Crypto/Signing/Signature.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Signature.hs
@@ -45,7 +45,8 @@ import Text.JSON.Canonical (JSValue(..), toJSString)
 import qualified Text.JSON.Canonical as TJC (FromJSON(..), ToJSON(..))
 
 import Cardano.Binary
-  ( Decoded(..)
+  ( Annotated(..)
+  , Decoded(..)
   , Decoder
   , Encoding
   , FromCBOR(..)
@@ -195,7 +196,7 @@ verifySignature toEnc pm tag vk x sig =
 -- | Verify a signature
 verifySignatureDecoded
   :: Decoded t
-  => ProtocolMagicId
+  => Annotated ProtocolMagicId ByteString
   -> SignTag
   -> VerificationKey
   -> t

--- a/crypto/src/Cardano/Crypto/Signing/Tag.hs
+++ b/crypto/src/Cardano/Crypto/Signing/Tag.hs
@@ -15,7 +15,7 @@ import qualified Cardano.Crypto.Wallet as CC
 import Formatting (bprint, shown)
 import Formatting.Buildable (Buildable(..))
 
-import Cardano.Binary (serialize')
+import Cardano.Binary (Annotated(..), serialize')
 import Cardano.Crypto.Signing.VerificationKey (VerificationKey(..))
 import Cardano.Crypto.ProtocolMagic (ProtocolMagicId(..))
 
@@ -62,8 +62,8 @@ instance Buildable SignTag where
 
 -- | Get magic bytes corresponding to a 'SignTag', taking `ProtocolMagic` bytes
 --   from the annotation
-signTagDecoded :: ProtocolMagicId -> SignTag -> ByteString
-signTagDecoded = signTagRaw . serialize'
+signTagDecoded :: Annotated ProtocolMagicId ByteString -> SignTag -> ByteString
+signTagDecoded = signTagRaw . annotation
 
 -- | Get magic bytes corresponding to a 'SignTag'. Guaranteed to be different
 --   (and begin with a different byte) for different tags.

--- a/crypto/test/Test/Cardano/Crypto/Dummy.hs
+++ b/crypto/test/Test/Cardano/Crypto/Dummy.hs
@@ -1,19 +1,32 @@
 -- | Dummy values used in tests (replacing `configuration.yaml`)
 
 module Test.Cardano.Crypto.Dummy
-  ( protocolMagic
+  ( annotatedProtocolMagicId
+  , aProtocolMagic
+  , protocolMagic
   , protocolMagicId
   )
 where
 
+import Cardano.Prelude
+
+import Cardano.Binary (Annotated(..), serialize')
 import Cardano.Crypto
-  ( ProtocolMagic(..)
+  ( AProtocolMagic(..)
+  , ProtocolMagic
   , ProtocolMagicId(..)
   , RequiresNetworkMagic(..)
   )
 
+aProtocolMagic :: AProtocolMagic ByteString
+aProtocolMagic = AProtocolMagic annotatedProtocolMagicId RequiresMagic
+
 protocolMagic :: ProtocolMagic
-protocolMagic = ProtocolMagic protocolMagicId RequiresMagic
+protocolMagic = AProtocolMagic (Annotated protocolMagicId ()) RequiresMagic
+
+annotatedProtocolMagicId :: Annotated ProtocolMagicId ByteString
+annotatedProtocolMagicId =
+  Annotated protocolMagicId (serialize' protocolMagicId)
 
 protocolMagicId :: ProtocolMagicId
 protocolMagicId = ProtocolMagicId 55550001

--- a/crypto/test/Test/Cardano/Crypto/Example.hs
+++ b/crypto/test/Test/Cardano/Crypto/Example.hs
@@ -23,8 +23,10 @@ import qualified Cardano.Crypto.Wallet as CC
 import Data.List ((!!))
 import Data.Maybe (fromJust)
 
+import Cardano.Binary (Annotated(..))
 import Cardano.Crypto
-  ( ProtocolMagic(..)
+  ( AProtocolMagic(..)
+  , ProtocolMagic
   , ProtocolMagicId(..)
   , VerificationKey(..)
   , RedeemVerificationKey
@@ -43,23 +45,23 @@ exampleProtocolMagicId0 = ProtocolMagicId 31337
 
 exampleProtocolMagic0 :: ProtocolMagic
 exampleProtocolMagic0 =
-  ProtocolMagic exampleProtocolMagicId0 RequiresMagic
+  AProtocolMagic (Annotated exampleProtocolMagicId0 ()) RequiresMagic
 
 exampleProtocolMagic1 :: ProtocolMagic
 exampleProtocolMagic1 =
-  ProtocolMagic (ProtocolMagicId 2147000001) RequiresMagic
+  AProtocolMagic (Annotated (ProtocolMagicId 2147000001) ()) RequiresMagic
 
 exampleProtocolMagic2 :: ProtocolMagic
 exampleProtocolMagic2 =
-  ProtocolMagic (ProtocolMagicId 58952) RequiresMagic
+  AProtocolMagic (Annotated (ProtocolMagicId 58952) ()) RequiresMagic
 
 exampleProtocolMagic3 :: ProtocolMagic
 exampleProtocolMagic3 =
-  ProtocolMagic (ProtocolMagicId 31337) RequiresMagic
+  AProtocolMagic (Annotated (ProtocolMagicId 31337) ()) RequiresMagic
 
 exampleProtocolMagic4 :: ProtocolMagic
 exampleProtocolMagic4 =
-  ProtocolMagic (ProtocolMagicId 500) RequiresNoMagic
+  AProtocolMagic (Annotated (ProtocolMagicId 500) ()) RequiresNoMagic
 
 exampleVerificationKey :: VerificationKey
 exampleVerificationKey = vk where [vk] = exampleVerificationKeys 16 1 -- 16 could be any number, as we take the first key

--- a/crypto/test/Test/Cardano/Crypto/Gen.hs
+++ b/crypto/test/Test/Cardano/Crypto/Gen.hs
@@ -49,12 +49,13 @@ import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-import Cardano.Binary (Raw(..), ToCBOR)
+import Cardano.Binary (Annotated(..), Raw(..), ToCBOR)
 import Cardano.Crypto (PassPhrase)
 import Cardano.Crypto.Hashing
   (AbstractHash(..), Hash, HashAlgorithm, abstractHash, hash)
 import Cardano.Crypto.ProtocolMagic
-  ( ProtocolMagic(..)
+  ( AProtocolMagic(..)
+  , ProtocolMagic
   , ProtocolMagicId(..)
   , RequiresNetworkMagic(..)
   )
@@ -87,8 +88,8 @@ import Test.Cardano.Crypto.Orphans ()
 
 genProtocolMagic :: Gen ProtocolMagic
 genProtocolMagic =
-  ProtocolMagic
-    <$> genProtocolMagicId
+  AProtocolMagic
+    <$> (Annotated <$> genProtocolMagicId <*> pure ())
     <*> genRequiresNetworkMagic
 
 -- | Whilst 'ProtocolMagicId' is represented as a 'Word32' in cardano-ledger,

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "057d8a9a3e751f88fc7677df5713c5ecc47a37c4";
-      sha256 = "1fr74v2p7d2r0rsvmb10zxl77v6vg5b3qbhwxd9pgflp4g7lwzkr";
+      rev = "d733bbc887d800c387b7ef4ed0a23225fca28d02";
+      sha256 = "1ndwi2vmaaf0x2jlmyikrvjgxmqif7v4bcyfxz6d8lq0clzck96y";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "057d8a9a3e751f88fc7677df5713c5ecc47a37c4";
-      sha256 = "1fr74v2p7d2r0rsvmb10zxl77v6vg5b3qbhwxd9pgflp4g7lwzkr";
+      rev = "d733bbc887d800c387b7ef4ed0a23225fca28d02";
+      sha256 = "1ndwi2vmaaf0x2jlmyikrvjgxmqif7v4bcyfxz6d8lq0clzck96y";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -48,8 +48,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "057d8a9a3e751f88fc7677df5713c5ecc47a37c4";
-      sha256 = "1fr74v2p7d2r0rsvmb10zxl77v6vg5b3qbhwxd9pgflp4g7lwzkr";
+      rev = "d733bbc887d800c387b7ef4ed0a23225fca28d02";
+      sha256 = "1ndwi2vmaaf0x2jlmyikrvjgxmqif7v4bcyfxz6d8lq0clzck96y";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "3c40edcf5bdba8721d3430d0aaaeea8770ce9bec";
-      sha256 = "1z77nwjxj0v9gxhs3mlmqfq705mkkcpnwgr0d8shykjvf0iqdkcn";
+      rev = "7a8755b6988a9dd137f3f61a77c6d51e4eafa781";
+      sha256 = "1h5x2hmwh6ppxpf8h2papypzdl59x87xcldfi6v50q90zjnd0l1i";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -25,6 +25,7 @@
           (hsPkgs.canonical-json)
           (hsPkgs.cborg)
           (hsPkgs.containers)
+          (hsPkgs.fingertree)
           (hsPkgs.formatting)
           (hsPkgs.ghc-heap)
           (hsPkgs.ghc-prim)
@@ -33,6 +34,7 @@
           (hsPkgs.mtl)
           (hsPkgs.nonempty-containers)
           (hsPkgs.protolude)
+          (hsPkgs.serialise)
           (hsPkgs.tagged)
           (hsPkgs.text)
           (hsPkgs.time)
@@ -71,7 +73,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "3c40edcf5bdba8721d3430d0aaaeea8770ce9bec";
-      sha256 = "1z77nwjxj0v9gxhs3mlmqfq705mkkcpnwgr0d8shykjvf0iqdkcn";
+      rev = "7a8755b6988a9dd137f3f61a77c6d51e4eafa781";
+      sha256 = "1h5x2hmwh6ppxpf8h2papypzdl59x87xcldfi6v50q90zjnd0l1i";
       });
     }

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "4956b32f039579a0e7e4fd10793f65b4c77d9044";
-      sha256 = "03lyb2m4i6p7rpjqarnhsx21nx48fwk6rzsrx15k6274a4bv0pix";
+      rev = "a71addb2c45a8e116c2a57385b67812d51352a7a";
+      sha256 = "1a2ma0nkwb78pivc6s5xjnpsxdy569ql02psxns7r9p2g5xpfd9a";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-blockchain.nix
+++ b/nix/.stack.nix/cs-blockchain.nix
@@ -50,8 +50,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "c1f9d85f50a6e71b2376618cb57656a1b7192ef1";
-      sha256 = "0waghgbr5f3x3fm2x1yx0ayrkmx1n0rah0mpgkjbbla9bhqpf5fg";
+      rev = "203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6";
+      sha256 = "06pgaabh8d330sra8060hplrhnkvlkm5iliz2sh76f3zvkbi918s";
       });
     postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -69,8 +69,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "c1f9d85f50a6e71b2376618cb57656a1b7192ef1";
-      sha256 = "0waghgbr5f3x3fm2x1yx0ayrkmx1n0rah0mpgkjbbla9bhqpf5fg";
+      rev = "203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6";
+      sha256 = "06pgaabh8d330sra8060hplrhnkvlkm5iliz2sh76f3zvkbi918s";
       });
     postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -73,8 +73,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "c1f9d85f50a6e71b2376618cb57656a1b7192ef1";
-      sha256 = "0waghgbr5f3x3fm2x1yx0ayrkmx1n0rah0mpgkjbbla9bhqpf5fg";
+      rev = "203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6";
+      sha256 = "06pgaabh8d330sra8060hplrhnkvlkm5iliz2sh76f3zvkbi918s";
       });
     postUnpack = "sourceRoot+=/byron/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/3c40edcf5bdba8721d3430d0aaaeea8770ce9bec/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/7a8755b6988a9dd137f3f61a77c6d51e4eafa781/snapshot.yaml
 
 packages:
   - cardano-ledger
@@ -15,20 +15,20 @@ extra-deps:
   - generic-monoid-0.1.0.0
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 3c40edcf5bdba8721d3430d0aaaeea8770ce9bec
+    commit: 7a8755b6988a9dd137f3f61a77c6d51e4eafa781
     subdirs:
       - .
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 057d8a9a3e751f88fc7677df5713c5ecc47a37c4
+    commit: d733bbc887d800c387b7ef4ed0a23225fca28d02
     subdirs:
       - binary
       - binary/test
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: c1f9d85f50a6e71b2376618cb57656a1b7192ef1
+    commit: 203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6
     subdirs:
       - byron/semantics/executable-spec
       - byron/ledger/executable-spec
@@ -41,7 +41,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 4956b32f039579a0e7e4fd10793f65b4c77d9044
+    commit: a71addb2c45a8e116c2a57385b67812d51352a7a
     subdirs:
       - contra-tracer
 


### PR DESCRIPTION
It turns out the annotation changes aren't compatible with `ouroboros-network`. We're working on a fix for this, but in the meanwhile this patch offers a way to back them out.