### PR TITLE
LovelacePortion simplification

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
@@ -43,6 +43,7 @@ module Cardano.Chain.Common.Lovelace
   , addLovelace
   , subLovelace
   , scaleLovelace
+  , scaleLovelaceRational
   , divLovelace
   , modLovelace
   )
@@ -201,6 +202,15 @@ subLovelace (Lovelace a) (Lovelace b)
 scaleLovelace :: Integral b => Lovelace -> b -> Either LovelaceError Lovelace
 scaleLovelace (Lovelace a) b = integerToLovelace $ toInteger a * toInteger b
 {-# INLINE scaleLovelace #-}
+
+-- | Scale a 'Lovelace' by a rational factor between @0..1@, rounding down.
+scaleLovelaceRational :: Lovelace -> Rational -> Lovelace
+scaleLovelaceRational (Lovelace a) b =
+    Lovelace $ fromInteger $ toInteger a * n `div` d
+  where
+    n, d :: Integer
+    n = numerator b
+    d = denominator b
 
 -- | Integer division of a 'Lovelace' by an 'Integral' factor
 divLovelace :: Integral b => Lovelace -> b -> Either LovelaceError Lovelace

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -27,6 +27,8 @@ module Cardano.Chain.Common.LovelacePortion
   , mkKnownLovelacePortion
   , lovelacePortionDenominator
   , lovelacePortionToDouble
+  , rationalToLovelacePortion
+  , lovelacePortionToRational
   )
 where
 
@@ -82,6 +84,16 @@ instance MonadError SchemaError m => FromJSON m LovelacePortion where
 -- | Denominator used by 'LovelacePortion'.
 lovelacePortionDenominator :: Word64
 lovelacePortionDenominator = 1e15
+
+rationalToLovelacePortion :: Rational -> LovelacePortion
+rationalToLovelacePortion r
+  | r >= 0 && r <= 1 = LovelacePortion
+                         (ceiling (r * toRational lovelacePortionDenominator))
+  | otherwise        = panic "rationalToLovelacePortion: out of range [0..1]"
+
+lovelacePortionToRational :: LovelacePortion -> Rational
+lovelacePortionToRational (LovelacePortion n) =
+  toInteger n % toInteger lovelacePortionDenominator
 
 data LovelacePortionError
   = LovelacePortionDoubleOutOfRange Double

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -1,24 +1,10 @@
-{-# LANGUAGE AllowAmbiguousTypes        #-}
-{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE ExplicitNamespaces         #-}
-{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE NumDecimals                #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
-{-# LANGUAGE ViewPatterns               #-}
-
--- This is for 'mkKnownLovelacePortion''s @n <= 45000000000000000@ constraint,
--- which is considered redundant. TODO: investigate this.
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Cardano.Chain.Common.LovelacePortion
   ( LovelacePortion
@@ -53,7 +39,7 @@ newtype LovelacePortion = LovelacePortion
   } deriving (Show, Ord, Eq, Generic, HeapWords, NFData, NoUnexpectedThunks)
 
 instance B.Buildable LovelacePortion where
-  build cp@(getLovelacePortion -> x) = bprint
+  build cp@(LovelacePortion x) = bprint
     (int . "/" . int . " (approx. " . float . ")")
     x
     lovelacePortionDenominator

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -62,7 +62,7 @@ instance B.Buildable LovelacePortion where
     (int . "/" . int . " (approx. " . float . ")")
     x
     lovelacePortionDenominator
-    (lovelacePortionToDouble cp)
+    (fromRational (lovelacePortionToRational cp) :: Double)
 
 instance ToCBOR LovelacePortion where
   toCBOR = toCBOR . getLovelacePortion

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -29,7 +29,6 @@ module Cardano.Chain.Common.LovelacePortion
   , lovelacePortionFromDouble
   , lovelacePortionToDouble
   , applyLovelacePortionDown
-  , applyLovelacePortionUp
   )
 where
 
@@ -155,18 +154,3 @@ applyLovelacePortionDown (getLovelacePortion -> p) (unsafeGetLovelace -> c) =
       *     toInteger c
       `div` toInteger lovelacePortionDenominator
 
--- | Apply LovelacePortion to Lovelace (with rounding up)
---
---   Use it for calculating thresholds.
-applyLovelacePortionUp :: LovelacePortion -> Lovelace -> Lovelace
-applyLovelacePortionUp (getLovelacePortion -> p) (unsafeGetLovelace -> c) =
-  case mkLovelace c' of
-    Right lovelace -> lovelace
-    Left  err      -> panic $ sformat
-      ("The impossible happened in applyLovelacePortionUp: " . build)
-      err
- where
-  (d, m) =
-    divMod (toInteger p * toInteger c) (toInteger lovelacePortionDenominator)
-  c' :: Word64
-  c' = if m > 0 then fromInteger (d + 1) else fromInteger d

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -87,10 +87,6 @@ instance MonadError SchemaError m => FromJSON m LovelacePortion where
 lovelacePortionDenominator :: Word64
 lovelacePortionDenominator = 1e15
 
-instance Bounded LovelacePortion where
-  minBound = LovelacePortion 0
-  maxBound = LovelacePortion lovelacePortionDenominator
-
 data LovelacePortionError
   = LovelacePortionDoubleOutOfRange Double
   | LovelacePortionTooLarge Word64

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -27,20 +27,18 @@ module Cardano.Chain.Common.LovelacePortion
   , mkKnownLovelacePortion
   , lovelacePortionDenominator
   , lovelacePortionToDouble
-  , applyLovelacePortionDown
   )
 where
 
 import Cardano.Prelude
 
 import Control.Monad.Except (MonadError(..))
-import Formatting (bprint, build, float, int, sformat)
+import Formatting (bprint, build, float, int)
 import qualified Formatting.Buildable as B
 import GHC.TypeLits (type (<=))
 import Text.JSON.Canonical (FromJSON(..), ToJSON(..))
 
 import Cardano.Binary (FromCBOR(..), ToCBOR(..))
-import Cardano.Chain.Common.Lovelace
 
 
 -- | LovelacePortion is some portion of Lovelace; it is interpreted as a fraction with
@@ -121,22 +119,4 @@ lovelacePortionToDouble :: LovelacePortion -> Double
 lovelacePortionToDouble (getLovelacePortion -> x) =
   realToFrac x / realToFrac lovelacePortionDenominator
 {-# INLINE lovelacePortionToDouble #-}
-
--- | Apply LovelacePortion to Lovelace (with rounding down)
---
---   Use it for calculating lovelace amounts.
-applyLovelacePortionDown :: LovelacePortion -> Lovelace -> Lovelace
-applyLovelacePortionDown (getLovelacePortion -> p) (unsafeGetLovelace -> c) =
-  case c' of
-    Right lovelace -> lovelace
-    Left  err      -> panic $ sformat
-      ("The impossible happened in applyLovelacePortionDown: " . build)
-      err
- where
-  c' =
-    mkLovelace
-      .     fromInteger
-      $     toInteger p
-      *     toInteger c
-      `div` toInteger lovelacePortionDenominator
 

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -26,7 +26,6 @@ module Cardano.Chain.Common.LovelacePortion
   , mkLovelacePortion
   , mkKnownLovelacePortion
   , lovelacePortionDenominator
-  , lovelacePortionFromDouble
   , lovelacePortionToDouble
   , applyLovelacePortionDown
   )
@@ -117,20 +116,7 @@ mkKnownLovelacePortion
   :: forall n . (KnownNat n, n <= 1000000000000000) => LovelacePortion
 mkKnownLovelacePortion = LovelacePortion . fromIntegral . natVal $ Proxy @n
 
--- | Make LovelacePortion from Double. Caller must ensure that value is in [0..1].
---   Internally 'LovelacePortion' stores 'Word64' which is divided by
---   'lovelacePortionDenominator' to get actual value. So some rounding may take
---   place.
-lovelacePortionFromDouble
-  :: Double -> Either LovelacePortionError LovelacePortion
-lovelacePortionFromDouble x
-  | 0 <= x && x <= 1 = Right (LovelacePortion v)
-  | otherwise        = Left (LovelacePortionDoubleOutOfRange x)
- where
-  v :: Word64
-  v = round $ realToFrac lovelacePortionDenominator * x
-{-# INLINE lovelacePortionFromDouble #-}
-
+--FIXME: Use of 'Double' here is highly dubious.
 lovelacePortionToDouble :: LovelacePortion -> Double
 lovelacePortionToDouble (getLovelacePortion -> x) =
   realToFrac x / realToFrac lovelacePortionDenominator

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
@@ -37,13 +37,13 @@ import Cardano.Chain.Common
   , Lovelace
   , LovelaceError
   , addLovelace
-  , applyLovelacePortionDown
   , divLovelace
   , makeVerKeyAddress
   , mkKnownLovelace
   , hashKey
   , modLovelace
   , scaleLovelace
+  , scaleLovelaceRational
   , subLovelace
   , sumLovelace
   )
@@ -189,7 +189,7 @@ generateGenesisData startTime genesisSpec = do
   let
     applyAvvmBalanceFactor :: Map k Lovelace -> Map k Lovelace
     applyAvvmBalanceFactor =
-      map (applyLovelacePortionDown $ giAvvmBalanceFactor gi)
+      map (flip scaleLovelaceRational (giAvvmBalanceFactor gi))
 
     realAvvmMultiplied :: GenesisAvvmBalances
     realAvvmMultiplied =
@@ -394,5 +394,4 @@ genTestnetDistribution tbo testBalance = do
  where
   TestnetBalanceOptions { tboPoors, tboRichmen } = tbo
 
-  desiredRichBalance =
-    applyLovelacePortionDown (tboRichmenShare tbo) testBalance
+  desiredRichBalance = scaleLovelaceRational testBalance (tboRichmenShare tbo)

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Initializer.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Initializer.hs
@@ -10,13 +10,13 @@ where
 
 import Cardano.Prelude
 
-import Cardano.Chain.Common (Lovelace, LovelacePortion)
+import Cardano.Chain.Common (Lovelace)
 
 -- | Options determining generated genesis stakes, balances, and delegation
 data GenesisInitializer = GenesisInitializer
   { giTestBalance       :: !TestnetBalanceOptions
   , giFakeAvvmBalance   :: !FakeAvvmOptions
-  , giAvvmBalanceFactor :: !LovelacePortion
+  , giAvvmBalanceFactor :: !Rational
   -- ^ Avvm balances will be multiplied by this factor
   , giUseHeavyDlg       :: !Bool
   -- ^ Whether to use heavyweight delegation for genesis keys
@@ -37,7 +37,7 @@ data TestnetBalanceOptions = TestnetBalanceOptions
   -- ^ Number of rich nodes (with huge balance).
   , tboTotalBalance   :: !Lovelace
   -- ^ Total balance owned by these nodes.
-  , tboRichmenShare   :: !LovelacePortion
+  , tboRichmenShare   :: !Rational
   -- ^ Portion of stake owned by all richmen together.
   } deriving (Eq, Show)
 

--- a/cardano-ledger/src/Cardano/Chain/Update/ProtocolParameters.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/ProtocolParameters.hs
@@ -24,7 +24,7 @@ import Text.JSON.Canonical (FromJSON(..), ToJSON(..), fromJSField, mkObject)
 
 import Cardano.Binary (FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize)
 import Cardano.Chain.Common
-  (LovelacePortion, TxFeePolicy, lovelacePortionToDouble)
+  (LovelacePortion, TxFeePolicy, lovelacePortionToRational)
 import Cardano.Chain.Slotting (EpochNumber, SlotNumber(..), isBootstrapEra)
 import Cardano.Chain.Update.SoftforkRule
 
@@ -178,10 +178,12 @@ isBootstrapEraPP adoptedPP = isBootstrapEra (ppUnlockStakeEpoch adoptedPP)
 -- | In Byron we do not have a @upAdptThd@ protocol parameter, so we have to
 --   use the existing ones.
 --
---   @lovelacePortionToDouble . srMinThd . ppSoftforkRule@ will give us the
+--   @lovelacePortionToRational . srMinThd . ppSoftforkRule@ will give us the
 --   ratio (in the interval @[0, 1]@) of the total stake that has to endorse a
 --   protocol version to become adopted. In genesis configuration, this ratio
 --   will evaluate to @0.6@, so if we have 7 genesis keys, @upAdptThd = 4@.
 upAdptThd :: Word8 -> ProtocolParameters -> Int
-upAdptThd numGenKeys pps = floor $ stakeRatio * fromIntegral numGenKeys
-  where stakeRatio = lovelacePortionToDouble . srMinThd . ppSoftforkRule $ pps
+upAdptThd numGenKeys pps =
+    floor $ stakeRatio * toRational numGenKeys
+  where
+    stakeRatio = lovelacePortionToRational . srMinThd . ppSoftforkRule $ pps

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
@@ -24,7 +24,6 @@ import Cardano.Chain.Common
   , Attributes(..)
   , BlockCount(..)
   , ChainDifficulty(..)
-  , LovelacePortion(..)
   , TxFeePolicy(..)
   , TxSizeLinear(..)
   , isRedeemAddress
@@ -34,6 +33,7 @@ import Cardano.Chain.Common
   , mtRoot
   , decodeAddressBase58
   , encodeAddressBase58
+  , rationalToLovelacePortion
   )
 import Cardano.Crypto
   ( Hash
@@ -216,7 +216,7 @@ golden_LovelacePortion :: Property
 golden_LovelacePortion =
   goldenTestCBOR c "test/golden/cbor/common/LovelacePortion"
  where
-  c = LovelacePortion 9702
+  c = rationalToLovelacePortion 9702e-15
 
 ts_roundTripLovelacePortionCBOR :: TSProperty
 ts_roundTripLovelacePortionCBOR =

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
@@ -51,14 +51,14 @@ import Cardano.Chain.Common
   , CompactAddress
   , Lovelace
   , LovelaceError(..)
-  , LovelacePortion(..)
+  , LovelacePortion
   , MerkleRoot(..)
   , MerkleTree
   , NetworkMagic(..)
   , KeyHash
   , TxFeePolicy(..)
   , TxSizeLinear(..)
-  , lovelacePortionDenominator
+  , rationalToLovelacePortion
   , makeAddress
   , maxLovelaceVal
   , mkAttributes
@@ -169,7 +169,7 @@ genLovelaceWithRange r =
 
 genLovelacePortion :: Gen LovelacePortion
 genLovelacePortion =
-  LovelacePortion <$> Gen.word64 (Range.constant 0 lovelacePortionDenominator)
+  rationalToLovelacePortion . realToFrac <$> Gen.double (Range.constant 0 1)
 
 -- slow
 genMerkleTree :: ToCBOR a => Gen a -> Gen (MerkleTree a)

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
@@ -43,21 +43,21 @@ elaboratePParams pps = Concrete.ProtocolParameters
   , Concrete.ppMaxHeaderSize      = 95 * Abstract._maxHdrSz pps
   , Concrete.ppMaxTxSize          = 4096 * Abstract._maxTxSz pps
   , Concrete.ppMaxProposalSize    = 4096 * Abstract._maxPropSz pps
-  , Concrete.ppMpcThd             = Concrete.mkKnownLovelacePortion @0
-  , Concrete.ppHeavyDelThd        = Concrete.mkKnownLovelacePortion @0
-  , Concrete.ppUpdateVoteThd      = Concrete.mkKnownLovelacePortion @0
-  , Concrete.ppUpdateProposalThd  = Concrete.mkKnownLovelacePortion @0
+  , Concrete.ppMpcThd             = Concrete.rationalToLovelacePortion 0
+  , Concrete.ppHeavyDelThd        = Concrete.rationalToLovelacePortion 0
+  , Concrete.ppUpdateVoteThd      = Concrete.rationalToLovelacePortion 0
+  , Concrete.ppUpdateProposalThd  = Concrete.rationalToLovelacePortion 0
   , Concrete.ppUpdateProposalTTL  = Concrete.SlotNumber
                                   $ unSlotCount
                                   $ Abstract._upTtl pps
   , Concrete.ppSoftforkRule       =
     Concrete.SoftforkRule
-      { Concrete.srInitThd = Concrete.mkKnownLovelacePortion @0
+      { Concrete.srInitThd = Concrete.rationalToLovelacePortion 0
       -- See 'upAdptThd' in 'module Cardano.Chain.Update.ProtocolParameters'
       , Concrete.srMinThd = Concrete.rationalToLovelacePortion
                           $ realToFrac
                           $ Abstract._upAdptThd pps
-      , Concrete.srThdDecrement  = Concrete.mkKnownLovelacePortion @0
+      , Concrete.srThdDecrement  = Concrete.rationalToLovelacePortion 0
       }
   , Concrete.ppTxFeePolicy        =
       elaborateFeePolicy

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
@@ -13,7 +13,6 @@ where
 
 import Cardano.Prelude
 
-import Control.Arrow ((|||))
 import Data.Coerce (coerce)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -55,10 +54,9 @@ elaboratePParams pps = Concrete.ProtocolParameters
     Concrete.SoftforkRule
       { Concrete.srInitThd = Concrete.mkKnownLovelacePortion @0
       -- See 'upAdptThd' in 'module Cardano.Chain.Update.ProtocolParameters'
-      , Concrete.srMinThd = panic . show ||| identity
-                          $ Concrete.mkLovelacePortion
-                          $ floor
-                          $ Abstract._upAdptThd pps * 1e15
+      , Concrete.srMinThd = Concrete.rationalToLovelacePortion
+                          $ realToFrac
+                          $ Abstract._upAdptThd pps
       , Concrete.srThdDecrement  = Concrete.mkKnownLovelacePortion @0
       }
   , Concrete.ppTxFeePolicy        =

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
@@ -31,7 +31,7 @@ import Cardano.Chain.Common
   , TxFeePolicy(..)
   , TxSizeLinear(..)
   , mkKnownLovelace
-  , mkKnownLovelacePortion
+  , rationalToLovelacePortion
   )
 import Cardano.Chain.Genesis
   ( Config(..)
@@ -110,15 +110,16 @@ dummyProtocolParameters = ProtocolParameters
   , ppMaxHeaderSize     = 2000000
   , ppMaxTxSize         = 4096
   , ppMaxProposalSize   = 700
-  , ppMpcThd            = mkKnownLovelacePortion @10000000000000
-  , ppHeavyDelThd       = mkKnownLovelacePortion @5000000000000
-  , ppUpdateVoteThd     = mkKnownLovelacePortion @1000000000000
-  , ppUpdateProposalThd = mkKnownLovelacePortion @100000000000000
+  , ppMpcThd            = rationalToLovelacePortion 0.01
+  , ppHeavyDelThd       = rationalToLovelacePortion 0.005
+  , ppUpdateVoteThd     = rationalToLovelacePortion 0.001
+  , ppUpdateProposalThd = rationalToLovelacePortion 0.1
   , ppUpdateProposalTTL = 10
   , ppSoftforkRule      = SoftforkRule
-    (mkKnownLovelacePortion @900000000000000)
-    (mkKnownLovelacePortion @600000000000000)
-    (mkKnownLovelacePortion @50000000000000)
+    { srInitThd      = rationalToLovelacePortion 0.9
+    , srMinThd       = rationalToLovelacePortion 0.6
+    , srThdDecrement = rationalToLovelacePortion 0.05
+    }
   , ppTxFeePolicy       = TxFeePolicyTxSizeLinear
     (TxSizeLinear (mkKnownLovelace @155381) (mkKnownLovelace @44))
   , ppUnlockStakeEpoch  = EpochNumber maxBound

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
@@ -130,13 +130,13 @@ dummyGenesisInitializer = GenesisInitializer
     { tboPoors          = 12
     , tboRichmen        = 4
     , tboTotalBalance   = mkKnownLovelace @6000000000000000
-    , tboRichmenShare   = mkKnownLovelacePortion @990000000000000
+    , tboRichmenShare   = 0.99 :: Rational
     }
   , giFakeAvvmBalance = FakeAvvmOptions
     { faoCount      = 10
     , faoOneBalance = mkKnownLovelace @100000
     }
-  , giAvvmBalanceFactor = mkKnownLovelacePortion @1000000000000000
+  , giAvvmBalanceFactor = 1.0 :: Rational
   , giUseHeavyDlg = True
   , giSeed        = 0
   }

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
@@ -24,9 +24,7 @@ import Data.Time (UTCTime(..), Day(..), secondsToDiffTime)
 import Cardano.Binary (Annotated(..))
 import Cardano.Chain.Common
   ( BlockCount(..)
-  , LovelacePortion(..)
   , mkKnownLovelace
-  , mkKnownLovelacePortion
   , hashKey
   )
 import Cardano.Chain.Delegation (unsafeCertificate)
@@ -148,13 +146,13 @@ exampleGenesisInitializer = GenesisInitializer
     { tboPoors          = 2448641325904532856
     , tboRichmen        = 14071205313513960321
     , tboTotalBalance   = mkKnownLovelace @10953275486128625
-    , tboRichmenShare   = mkKnownLovelacePortion @366832547637728
+    , tboRichmenShare   = 0.366832547637728 :: Rational
     }
   , giFakeAvvmBalance = FakeAvvmOptions
     { faoCount      = 17853231730478779264
     , faoOneBalance = mkKnownLovelace @15087947214890024
     }
-  , giAvvmBalanceFactor = LovelacePortion {getLovelacePortion = 366832547637728}
+  , giAvvmBalanceFactor = 0.366832547637728 :: Rational
   , giUseHeavyDlg = False
   , giSeed        = 0
   }

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Gen.hs
@@ -47,7 +47,7 @@ import Cardano.Crypto (ProtocolMagicId, Signature(..))
 import qualified Cardano.Crypto.Wallet as CC
 
 import Test.Cardano.Chain.Common.Gen
-  (genAddress, genBlockCount, genLovelace, genLovelacePortion, genKeyHash)
+  (genAddress, genBlockCount, genLovelace, genKeyHash)
 import Test.Cardano.Chain.Delegation.Gen
   (genCanonicalCertificateDistinctList, genCertificateDistinctList)
 import Test.Cardano.Chain.Update.Gen
@@ -111,7 +111,7 @@ genGenesisInitializer =
   GenesisInitializer
     <$> genTestnetBalanceOptions
     <*> genFakeAvvmOptions
-    <*> genLovelacePortion
+    <*> (realToFrac <$> Gen.double (Range.constant 0 1))
     <*> Gen.bool
     <*> Gen.integral (Range.constant 0 10)
 
@@ -138,7 +138,7 @@ genTestnetBalanceOptions =
     <$> Gen.word Range.constantBounded
     <*> Gen.word Range.constantBounded
     <*> genLovelace
-    <*> genLovelacePortion
+    <*> (realToFrac <$> Gen.double (Range.constant 0 1))
 
 genGenesisAvvmBalances :: Gen GenesisAvvmBalances
 genGenesisAvvmBalances =

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/CBOR.hs
@@ -12,7 +12,7 @@ import Test.Cardano.Prelude
 import Hedgehog (Property)
 
 import Cardano.Binary (Raw(..))
-import Cardano.Chain.Common (LovelacePortion(..))
+import Cardano.Chain.Common (rationalToLovelacePortion)
 import Cardano.Chain.Update (ApplicationName(..), SoftforkRule(..))
 import Cardano.Crypto (Hash, abstractHash)
 
@@ -132,9 +132,9 @@ goldenSoftforkRule :: Property
 goldenSoftforkRule = goldenTestCBOR sfR "test/golden/cbor/update/SoftforkRule"
  where
   sfR = SoftforkRule
-    (LovelacePortion 99)
-    (LovelacePortion 99)
-    (LovelacePortion 99)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
 
 ts_roundTripSoftforkRule :: TSProperty
 ts_roundTripSoftforkRule = eachOfTS 10 genSoftforkRule roundTripsCBORBuildable

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
@@ -27,7 +27,8 @@ import qualified Data.Map.Strict as Map
 
 import Cardano.Binary (Raw(..))
 import Cardano.Chain.Common
-  (LovelacePortion(..), TxFeePolicy(..), TxSizeLinear(..), mkKnownLovelace)
+  ( mkKnownLovelace, rationalToLovelacePortion
+  , TxFeePolicy(..), TxSizeLinear(..) )
 import Cardano.Chain.Slotting (EpochNumber(..), SlotNumber(..))
 import Cardano.Chain.Update
   ( ApplicationName(..)
@@ -69,10 +70,10 @@ exampleProtocolParameters = ProtocolParameters
   (999 :: Natural)
   (999 :: Natural)
   (999 :: Natural)
-  (LovelacePortion 99)
-  (LovelacePortion 99)
-  (LovelacePortion 99)
-  (LovelacePortion 99)
+  (rationalToLovelacePortion 99e-15)
+  (rationalToLovelacePortion 99e-15)
+  (rationalToLovelacePortion 99e-15)
+  (rationalToLovelacePortion 99e-15)
   (SlotNumber 99)
   sfrule
   (TxFeePolicyTxSizeLinear tslin)
@@ -82,9 +83,9 @@ exampleProtocolParameters = ProtocolParameters
   c1'    = mkKnownLovelace @999
   c2'    = mkKnownLovelace @77
   sfrule = SoftforkRule
-    (LovelacePortion 99)
-    (LovelacePortion 99)
-    (LovelacePortion 99)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
 
 exampleProtocolParametersUpdate :: ProtocolParametersUpdate
 exampleProtocolParametersUpdate = ProtocolParametersUpdate
@@ -94,10 +95,10 @@ exampleProtocolParametersUpdate = ProtocolParametersUpdate
   (Just (999 :: Natural))
   (Just (999 :: Natural))
   (Just (999 :: Natural))
-  (Just $ LovelacePortion 99)
-  (Just $ LovelacePortion 99)
-  (Just $ LovelacePortion 99)
-  (Just $ LovelacePortion 99)
+  (Just $ rationalToLovelacePortion 99e-15)
+  (Just $ rationalToLovelacePortion 99e-15)
+  (Just $ rationalToLovelacePortion 99e-15)
+  (Just $ rationalToLovelacePortion 99e-15)
   (Just $ SlotNumber 99)
   (Just sfrule')
   (Just $ TxFeePolicyTxSizeLinear tslin')
@@ -107,9 +108,9 @@ exampleProtocolParametersUpdate = ProtocolParametersUpdate
   co1     = mkKnownLovelace @999
   co2     = mkKnownLovelace @77
   sfrule' = SoftforkRule
-    (LovelacePortion 99)
-    (LovelacePortion 99)
-    (LovelacePortion 99)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
 
 exampleSystemTag :: SystemTag
 exampleSystemTag = exampleSystemTags 0 1 !! 0


### PR DESCRIPTION
A bunch of patches to simplify the API, representation and use of `LovelacePortion`.

`LovelacePortion` is really for the legacy Byron protocol params used by the update system. As far as I can see only one of those params is now used. It should not be used for anything else. It has a weird representation (a rational represented as a nominator with an implicit denominator of 1e15).

This PR simplifies it as much as possible, and removes unnecessary uses, leaving it just for its legacy purpose.

Review advice: read it patch by patch, not the union of them all. Each one is a single logical change.