### PR TITLE
Change representation of Lovelace from Word64 to Natural

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
@@ -43,6 +43,7 @@ module Cardano.Chain.Common.Lovelace
   , addLovelace
   , subLovelace
   , scaleLovelace
+  , scaleLovelaceRational
   , divLovelace
   , modLovelace
   )
@@ -201,6 +202,15 @@ subLovelace (Lovelace a) (Lovelace b)
 scaleLovelace :: Integral b => Lovelace -> b -> Either LovelaceError Lovelace
 scaleLovelace (Lovelace a) b = integerToLovelace $ toInteger a * toInteger b
 {-# INLINE scaleLovelace #-}
+
+-- | Scale a 'Lovelace' by a rational factor between @0..1@, rounding down.
+scaleLovelaceRational :: Lovelace -> Rational -> Lovelace
+scaleLovelaceRational (Lovelace a) b =
+    Lovelace $ fromInteger $ toInteger a * n `div` d
+  where
+    n, d :: Integer
+    n = numerator b
+    d = denominator b
 
 -- | Integer division of a 'Lovelace' by an 'Integral' factor
 divLovelace :: Integral b => Lovelace -> b -> Either LovelaceError Lovelace

--- a/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
@@ -35,8 +35,10 @@ module Cardano.Chain.Common.Lovelace
   , lovelaceF
 
   -- * Conversions
-  , unsafeGetLovelace
+  , naturalToLovelace
+  , lovelaceToNatural
   , lovelaceToInteger
+  , unsafeGetLovelace
   , integerToLovelace
 
   -- * Arithmetic operations
@@ -102,6 +104,15 @@ instance Monad m => Canonical.ToJSON m Lovelace where
 instance Canonical.ReportSchemaErrors m => Canonical.FromJSON m Lovelace where
   fromJSON = fmap (Lovelace . (fromIntegral :: Word64 -> Natural))
            . Canonical.fromJSON
+
+naturalToLovelace :: Natural -> Lovelace
+naturalToLovelace = Lovelace
+
+lovelaceToNatural :: Lovelace -> Natural
+lovelaceToNatural (Lovelace n) = n
+
+lovelaceToInteger :: Lovelace -> Integer
+lovelaceToInteger = toInteger . lovelaceToNatural
 
 data LovelaceError
   = LovelaceOverflow Word64
@@ -181,10 +192,6 @@ unsafeGetLovelace = fromIntegral . getLovelace
 sumLovelace
   :: (Foldable t, Functor t) => t Lovelace -> Either LovelaceError Lovelace
 sumLovelace = integerToLovelace . sum . map lovelaceToInteger
-
-lovelaceToInteger :: Lovelace -> Integer
-lovelaceToInteger = toInteger . unsafeGetLovelace
-{-# INLINE lovelaceToInteger #-}
 
 -- | Addition of lovelace.
 addLovelace :: Lovelace -> Lovelace -> Either LovelaceError Lovelace

--- a/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
@@ -53,6 +53,7 @@ where
 import Cardano.Prelude
 
 import Data.Data (Data)
+import Data.Monoid (Monoid(..))
 import Formatting (Format, bprint, build, int, sformat)
 import qualified Formatting.Buildable as B
 import GHC.TypeLits (type (<=))
@@ -74,6 +75,12 @@ import Cardano.Binary
 newtype Lovelace = Lovelace
   { getLovelace :: Natural
   } deriving (Show, Ord, Eq, Generic, Data, NFData, NoUnexpectedThunks)
+
+instance Semigroup Lovelace where
+  Lovelace a <> Lovelace b = Lovelace (a + b)
+
+instance Monoid Lovelace where
+  mempty = Lovelace 0
 
 instance B.Buildable Lovelace where
   build (Lovelace n) = bprint (int . " lovelace") n

--- a/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
@@ -1,23 +1,14 @@
-{-# LANGUAGE AllowAmbiguousTypes        #-}
-{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE NumDecimals                #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
-
--- This is for 'mkKnownLovelace''s @n <= 45000000000000000@ constraint, which is
--- considered redundant. TODO: investigate this.
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Cardano.Chain.Common.Lovelace
   (
@@ -56,7 +47,8 @@ import qualified Text.JSON.Canonical as Canonical
   (FromJSON(..), ReportSchemaErrors, ToJSON(..))
 
 import Cardano.Binary
-  ( DecoderError(..)
+  ( Decoder
+  , DecoderError(..)
   , FromCBOR(..)
   , ToCBOR(..)
   , decodeListLen
@@ -143,7 +135,8 @@ instance ToCBOR LovelaceError where
 instance FromCBOR LovelaceError where
   fromCBOR = do
     len <- decodeListLen
-    let checkSize size = matchSize "LovelaceError" size len
+    let checkSize :: Int -> Decoder s ()
+        checkSize size = matchSize "LovelaceError" size len
     tag <- decodeWord8
     case tag of
       0 -> checkSize 2 >> LovelaceOverflow <$> fromCBOR

--- a/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
@@ -23,7 +23,9 @@ module Cardano.Chain.Common.Lovelace
   (
   -- * Lovelace
     Lovelace
-  , LovelaceError(..)
+
+    -- Only export the error cases that are still possible:
+  , LovelaceError(LovelaceTooSmall, LovelaceUnderflow)
 
   -- * Constructors
   , mkLovelace
@@ -149,9 +151,7 @@ maxLovelaceVal = 45e15
 -- | Constructor for 'Lovelace' returning 'LovelaceError' when @c@ exceeds
 --   'maxLovelaceVal'
 mkLovelace :: Word64 -> Either LovelaceError Lovelace
-mkLovelace c
-  | c <= maxLovelaceVal = Right (Lovelace (fromIntegral c))
-  | otherwise           = Left (LovelaceTooLarge (toInteger c))
+mkLovelace c = Right (Lovelace (fromIntegral c))
 {-# INLINE mkLovelace #-}
 
 -- | Construct a 'Lovelace' from a 'KnownNat', known to be less than
@@ -179,13 +179,9 @@ lovelaceToInteger :: Lovelace -> Integer
 lovelaceToInteger = toInteger . unsafeGetLovelace
 {-# INLINE lovelaceToInteger #-}
 
--- | Addition of lovelace, returning 'LovelaceError' in case of overflow
+-- | Addition of lovelace.
 addLovelace :: Lovelace -> Lovelace -> Either LovelaceError Lovelace
-addLovelace (Lovelace a) (Lovelace b)
-  | res >= a && res >= b && res <= fromIntegral maxLovelaceVal
-              = Right (Lovelace res)
-  | otherwise = Left (LovelaceOverflow (fromIntegral res))
-  where res = a + b
+addLovelace (Lovelace a) (Lovelace b) = Right (Lovelace (a + b))
 {-# INLINE addLovelace #-}
 
 -- | Subtraction of lovelace, returning 'LovelaceError' on underflow
@@ -222,6 +218,5 @@ modLovelace (Lovelace a) b = integerToLovelace $ toInteger a `mod` toInteger b
 integerToLovelace :: Integer -> Either LovelaceError Lovelace
 integerToLovelace n
   | n < 0 = Left (LovelaceTooSmall n)
-  | n <= fromIntegral maxLovelaceVal = Right
-  $ Lovelace (fromInteger n)
-  | otherwise = Left (LovelaceTooLarge n)
+  | otherwise = Right (Lovelace (fromInteger n))
+

--- a/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
@@ -27,13 +27,6 @@ module Cardano.Chain.Common.Lovelace
     -- Only export the error cases that are still possible:
   , LovelaceError(LovelaceTooSmall, LovelaceUnderflow)
 
-  -- * Constructors
-  , mkLovelace
-  , mkKnownLovelace
-
-  -- * Formatting
-  , lovelaceF
-
   -- * Conversions
   , naturalToLovelace
   , lovelaceToNatural
@@ -47,6 +40,9 @@ module Cardano.Chain.Common.Lovelace
   , scaleLovelaceRational
   , divLovelace
   , modLovelace
+
+  -- * Formatting
+  , lovelaceF
   )
 where
 
@@ -56,7 +52,6 @@ import Data.Data (Data)
 import Data.Monoid (Monoid(..))
 import Formatting (Format, bprint, build, int, sformat)
 import qualified Formatting.Buildable as B
-import GHC.TypeLits (type (<=))
 import qualified Text.JSON.Canonical as Canonical
   (FromJSON(..), ReportSchemaErrors, ToJSON(..))
 
@@ -169,11 +164,6 @@ maxLovelaceVal = 45e15
 mkLovelace :: Word64 -> Either LovelaceError Lovelace
 mkLovelace c = Right (Lovelace (fromIntegral c))
 {-# INLINE mkLovelace #-}
-
--- | Construct a 'Lovelace' from a 'KnownNat', known to be less than
---   'maxLovelaceVal'
-mkKnownLovelace :: forall n . (KnownNat n, n <= 45000000000000000) => Lovelace
-mkKnownLovelace = Lovelace . fromIntegral . natVal $ Proxy @n
 
 -- | Lovelace formatter which restricts type.
 lovelaceF :: Format r (Lovelace -> r)

--- a/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
@@ -38,8 +38,6 @@ module Cardano.Chain.Common.Lovelace
   , naturalToLovelace
   , lovelaceToNatural
   , lovelaceToInteger
-  , unsafeGetLovelace
-  , integerToLovelace
 
   -- * Arithmetic operations
   , sumLovelace

--- a/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
@@ -170,10 +170,10 @@ addLovelace :: Lovelace -> Lovelace -> Lovelace
 addLovelace (Lovelace a) (Lovelace b) = Lovelace (a + b)
 
 -- | Subtraction of lovelace, returning 'LovelaceError' on underflow
-subLovelace :: Lovelace -> Lovelace -> Either LovelaceError Lovelace
+subLovelace :: Lovelace -> Lovelace -> Maybe Lovelace
 subLovelace (Lovelace a) (Lovelace b)
-  | a >= b    = Right (Lovelace (a - b))
-  | otherwise = Left (LovelaceUnderflow (fromIntegral a) (fromIntegral b))
+  | a >= b    = Just $! Lovelace (a - b)
+  | otherwise = Nothing
 
 -- | Scale a 'Lovelace' by an 'Natural' factor.
 scaleLovelace :: Lovelace -> Natural -> Lovelace

--- a/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
@@ -24,7 +24,6 @@ module Cardano.Chain.Common.Lovelace
   -- * Lovelace
     Lovelace
   , LovelaceError(..)
-  , maxLovelaceVal
 
   -- * Constructors
   , mkLovelace
@@ -77,10 +76,6 @@ newtype Lovelace = Lovelace
 instance B.Buildable Lovelace where
   build (Lovelace n) = bprint (int . " lovelace") n
 
-instance Bounded Lovelace where
-  minBound = Lovelace 0
-  maxBound = Lovelace (fromIntegral maxLovelaceVal)
-
 instance ToCBOR Lovelace where
   toCBOR = toCBOR . unsafeGetLovelace
   encodedSizeExpr size _pxy = encodedSizeExpr size (Proxy :: Proxy Word64)
@@ -118,7 +113,7 @@ instance B.Buildable LovelaceError where
     LovelaceTooSmall c -> bprint
       ("Lovelace value, " . build . ", is less than minimum, " . build)
       c
-      (minBound :: Lovelace)
+      (Lovelace 0)
     LovelaceUnderflow c c' -> bprint
       ("Lovelace underflow when subtracting " . build . " from " . build)
       c'
@@ -227,6 +222,6 @@ modLovelace (Lovelace a) b = integerToLovelace $ toInteger a `mod` toInteger b
 integerToLovelace :: Integer -> Either LovelaceError Lovelace
 integerToLovelace n
   | n < 0 = Left (LovelaceTooSmall n)
-  | n <= lovelaceToInteger (maxBound :: Lovelace) = Right
+  | n <= fromIntegral maxLovelaceVal = Right
   $ Lovelace (fromInteger n)
   | otherwise = Left (LovelaceTooLarge n)

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -27,6 +27,8 @@ module Cardano.Chain.Common.LovelacePortion
   , mkKnownLovelacePortion
   , lovelacePortionDenominator
   , lovelacePortionToDouble
+  , rationalToLovelacePortion
+  , lovelacePortionToRational
   )
 where
 
@@ -82,6 +84,16 @@ instance MonadError SchemaError m => FromJSON m LovelacePortion where
 -- | Denominator used by 'LovelacePortion'.
 lovelacePortionDenominator :: Word64
 lovelacePortionDenominator = 1e15
+
+rationalToLovelacePortion :: Rational -> LovelacePortion
+rationalToLovelacePortion r
+  | r >= 0 && r <= 1 = LovelacePortion
+                         (ceiling (r * toRational lovelacePortionDenominator))
+  | otherwise        = panic "rationalToLovelacePortion: out of range [0..1]"
+
+lovelacePortionToRational :: LovelacePortion -> Rational
+lovelacePortionToRational (LovelacePortion n) =
+  toInteger n % toInteger lovelacePortionDenominator
 
 data LovelacePortionError
   = LovelacePortionDoubleOutOfRange Double

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -1,24 +1,10 @@
-{-# LANGUAGE AllowAmbiguousTypes        #-}
-{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE ExplicitNamespaces         #-}
-{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE NumDecimals                #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
-{-# LANGUAGE ViewPatterns               #-}
-
--- This is for 'mkKnownLovelacePortion''s @n <= 45000000000000000@ constraint,
--- which is considered redundant. TODO: investigate this.
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Cardano.Chain.Common.LovelacePortion
   ( LovelacePortion
@@ -53,7 +39,7 @@ newtype LovelacePortion = LovelacePortion
   } deriving (Show, Ord, Eq, Generic, HeapWords, NFData, NoUnexpectedThunks)
 
 instance B.Buildable LovelacePortion where
-  build cp@(getLovelacePortion -> x) = bprint
+  build cp@(LovelacePortion x) = bprint
     (int . "/" . int . " (approx. " . float . ")")
     x
     lovelacePortionDenominator

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -62,7 +62,7 @@ instance B.Buildable LovelacePortion where
     (int . "/" . int . " (approx. " . float . ")")
     x
     lovelacePortionDenominator
-    (lovelacePortionToDouble cp)
+    (fromRational (lovelacePortionToRational cp) :: Double)
 
 instance ToCBOR LovelacePortion where
   toCBOR = toCBOR . getLovelacePortion

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -29,7 +29,6 @@ module Cardano.Chain.Common.LovelacePortion
   , lovelacePortionFromDouble
   , lovelacePortionToDouble
   , applyLovelacePortionDown
-  , applyLovelacePortionUp
   )
 where
 
@@ -155,18 +154,3 @@ applyLovelacePortionDown (getLovelacePortion -> p) (unsafeGetLovelace -> c) =
       *     toInteger c
       `div` toInteger lovelacePortionDenominator
 
--- | Apply LovelacePortion to Lovelace (with rounding up)
---
---   Use it for calculating thresholds.
-applyLovelacePortionUp :: LovelacePortion -> Lovelace -> Lovelace
-applyLovelacePortionUp (getLovelacePortion -> p) (unsafeGetLovelace -> c) =
-  case mkLovelace c' of
-    Right lovelace -> lovelace
-    Left  err      -> panic $ sformat
-      ("The impossible happened in applyLovelacePortionUp: " . build)
-      err
- where
-  (d, m) =
-    divMod (toInteger p * toInteger c) (toInteger lovelacePortionDenominator)
-  c' :: Word64
-  c' = if m > 0 then fromInteger (d + 1) else fromInteger d

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -87,10 +87,6 @@ instance MonadError SchemaError m => FromJSON m LovelacePortion where
 lovelacePortionDenominator :: Word64
 lovelacePortionDenominator = 1e15
 
-instance Bounded LovelacePortion where
-  minBound = LovelacePortion 0
-  maxBound = LovelacePortion lovelacePortionDenominator
-
 data LovelacePortionError
   = LovelacePortionDoubleOutOfRange Double
   | LovelacePortionTooLarge Word64

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -27,20 +27,18 @@ module Cardano.Chain.Common.LovelacePortion
   , mkKnownLovelacePortion
   , lovelacePortionDenominator
   , lovelacePortionToDouble
-  , applyLovelacePortionDown
   )
 where
 
 import Cardano.Prelude
 
 import Control.Monad.Except (MonadError(..))
-import Formatting (bprint, build, float, int, sformat)
+import Formatting (bprint, build, float, int)
 import qualified Formatting.Buildable as B
 import GHC.TypeLits (type (<=))
 import Text.JSON.Canonical (FromJSON(..), ToJSON(..))
 
 import Cardano.Binary (FromCBOR(..), ToCBOR(..))
-import Cardano.Chain.Common.Lovelace
 
 
 -- | LovelacePortion is some portion of Lovelace; it is interpreted as a fraction with
@@ -121,22 +119,4 @@ lovelacePortionToDouble :: LovelacePortion -> Double
 lovelacePortionToDouble (getLovelacePortion -> x) =
   realToFrac x / realToFrac lovelacePortionDenominator
 {-# INLINE lovelacePortionToDouble #-}
-
--- | Apply LovelacePortion to Lovelace (with rounding down)
---
---   Use it for calculating lovelace amounts.
-applyLovelacePortionDown :: LovelacePortion -> Lovelace -> Lovelace
-applyLovelacePortionDown (getLovelacePortion -> p) (unsafeGetLovelace -> c) =
-  case c' of
-    Right lovelace -> lovelace
-    Left  err      -> panic $ sformat
-      ("The impossible happened in applyLovelacePortionDown: " . build)
-      err
- where
-  c' =
-    mkLovelace
-      .     fromInteger
-      $     toInteger p
-      *     toInteger c
-      `div` toInteger lovelacePortionDenominator
 

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -26,7 +26,6 @@ module Cardano.Chain.Common.LovelacePortion
   , mkLovelacePortion
   , mkKnownLovelacePortion
   , lovelacePortionDenominator
-  , lovelacePortionFromDouble
   , lovelacePortionToDouble
   , applyLovelacePortionDown
   )
@@ -117,20 +116,7 @@ mkKnownLovelacePortion
   :: forall n . (KnownNat n, n <= 1000000000000000) => LovelacePortion
 mkKnownLovelacePortion = LovelacePortion . fromIntegral . natVal $ Proxy @n
 
--- | Make LovelacePortion from Double. Caller must ensure that value is in [0..1].
---   Internally 'LovelacePortion' stores 'Word64' which is divided by
---   'lovelacePortionDenominator' to get actual value. So some rounding may take
---   place.
-lovelacePortionFromDouble
-  :: Double -> Either LovelacePortionError LovelacePortion
-lovelacePortionFromDouble x
-  | 0 <= x && x <= 1 = Right (LovelacePortion v)
-  | otherwise        = Left (LovelacePortionDoubleOutOfRange x)
- where
-  v :: Word64
-  v = round $ realToFrac lovelacePortionDenominator * x
-{-# INLINE lovelacePortionFromDouble #-}
-
+--FIXME: Use of 'Double' here is highly dubious.
 lovelacePortionToDouble :: LovelacePortion -> Double
 lovelacePortionToDouble (getLovelacePortion -> x) =
   realToFrac x / realToFrac lovelacePortionDenominator

--- a/cardano-ledger/src/Cardano/Chain/Common/TxSizeLinear.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/TxSizeLinear.hs
@@ -26,7 +26,6 @@ import Cardano.Binary
   )
 import Cardano.Chain.Common.Lovelace
   ( Lovelace
-  , LovelaceError
   , addLovelace
   , scaleLovelace
   , lovelaceToNatural
@@ -59,9 +58,9 @@ instance FromCBOR TxSizeLinear where
     !b <- naturalToLovelace . round <$> fromCBOR @Nano
     return $ TxSizeLinear a b
 
-calculateTxSizeLinear
-  :: TxSizeLinear -> Natural -> Either LovelaceError Lovelace
-calculateTxSizeLinear (TxSizeLinear a b) = addLovelace a <=< scaleLovelace b
+calculateTxSizeLinear :: TxSizeLinear -> Natural -> Lovelace
+calculateTxSizeLinear (TxSizeLinear a b) sz =
+  addLovelace a (scaleLovelace b sz)
 
 txSizeLinearMinValue :: TxSizeLinear -> Lovelace
 txSizeLinearMinValue (TxSizeLinear a _) = a

--- a/cardano-ledger/src/Cardano/Chain/Common/TxSizeLinear.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/TxSizeLinear.hs
@@ -15,13 +15,11 @@ where
 import Cardano.Prelude
 
 import Data.Fixed (Nano)
-import Formatting (bprint, build, sformat)
+import Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
 import Cardano.Binary
-  ( Decoder
-  , DecoderError(..)
-  , FromCBOR(..)
+  ( FromCBOR(..)
   , ToCBOR(..)
   , encodeListLen
   , enforceSize
@@ -30,9 +28,9 @@ import Cardano.Chain.Common.Lovelace
   ( Lovelace
   , LovelaceError
   , addLovelace
-  , mkLovelace
   , scaleLovelace
-  , unsafeGetLovelace
+  , lovelaceToNatural
+  , naturalToLovelace
   )
 
 
@@ -51,19 +49,15 @@ instance ToCBOR TxSizeLinear where
   -- We encode as 'Nano' for backwards compatibility
   toCBOR (TxSizeLinear a b) =
     encodeListLen 2
-      <> toCBOR (fromIntegral (unsafeGetLovelace a) :: Nano)
-      <> toCBOR (fromIntegral (unsafeGetLovelace b) :: Nano)
+      <> toCBOR (fromIntegral (lovelaceToNatural a) :: Nano)
+      <> toCBOR (fromIntegral (lovelaceToNatural b) :: Nano)
 
 instance FromCBOR TxSizeLinear where
   fromCBOR = do
     enforceSize "TxSizeLinear" 2
-    !a <- wrapLovelaceError . mkLovelace . round =<< fromCBOR @Nano
-    !b <- wrapLovelaceError . mkLovelace . round =<< fromCBOR @Nano
+    !a <- naturalToLovelace . round <$> fromCBOR @Nano
+    !b <- naturalToLovelace . round <$> fromCBOR @Nano
     return $ TxSizeLinear a b
-   where
-    wrapLovelaceError :: Either LovelaceError Lovelace -> Decoder s Lovelace
-    wrapLovelaceError =
-      toCborError . first (DecoderErrorCustom "TxSizeLinear" . sformat build)
 
 calculateTxSizeLinear
   :: TxSizeLinear -> Natural -> Either LovelaceError Lovelace

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
@@ -37,13 +37,13 @@ import Cardano.Chain.Common
   , Lovelace
   , LovelaceError
   , addLovelace
-  , applyLovelacePortionDown
   , divLovelace
   , makeVerKeyAddress
   , mkKnownLovelace
   , hashKey
   , modLovelace
   , scaleLovelace
+  , scaleLovelaceRational
   , subLovelace
   , sumLovelace
   )
@@ -189,7 +189,7 @@ generateGenesisData startTime genesisSpec = do
   let
     applyAvvmBalanceFactor :: Map k Lovelace -> Map k Lovelace
     applyAvvmBalanceFactor =
-      map (applyLovelacePortionDown $ giAvvmBalanceFactor gi)
+      map (flip scaleLovelaceRational (giAvvmBalanceFactor gi))
 
     realAvvmMultiplied :: GenesisAvvmBalances
     realAvvmMultiplied =
@@ -394,5 +394,4 @@ genTestnetDistribution tbo testBalance = do
  where
   TestnetBalanceOptions { tboPoors, tboRichmen } = tbo
 
-  desiredRichBalance =
-    applyLovelacePortionDown (tboRichmenShare tbo) testBalance
+  desiredRichBalance = scaleLovelaceRational testBalance (tboRichmenShare tbo)

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
@@ -145,6 +145,10 @@ instance B.Buildable GenesisDataGenerationError where
     GenesisDataGenerationRedeemKeyGen ->
       bprint "GenesisDataGenerationRedeemKeyGen"
 
+-- | In Cardano Byron, the total supply is always limited to 45e15 Lovelace.
+--
+genesisMaximumLovelaceSupply :: Lovelace
+genesisMaximumLovelaceSupply = mkKnownLovelace @ 45000000000000000
 
 generateGenesisData
   :: MonadError GenesisDataGenerationError m
@@ -228,7 +232,8 @@ generateGenesisData startTime genesisSpec = do
     sumLovelace (unGenesisAvvmBalances realAvvmMultiplied)
       `wrapError` GenesisDataGenerationLovelaceError
   maxTnBalance <-
-    subLovelace maxBound avvmSum `wrapError` GenesisDataGenerationLovelaceError
+    subLovelace genesisMaximumLovelaceSupply avvmSum
+      `wrapError` GenesisDataGenerationLovelaceError
   let tnBalance = min maxTnBalance (tboTotalBalance tbo)
 
   let

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
@@ -224,7 +224,7 @@ generateGenesisData startTime genesisSpec = do
   poorAddresses        <- mapM createAddressPoor poorSecrets
 
   ---- Balances
-  let totalFakeAvvmBalance = scaleLovelace (faoOneBalance fao) (fromIntegral (faoCount fao))
+  let totalFakeAvvmBalance = scaleLovelace (faoOneBalance fao) (faoCount fao)
 
   -- Compute total balance to generate
   let avvmSum = sumLovelace (unGenesisAvvmBalances realAvvmMultiplied)
@@ -363,8 +363,8 @@ genTestnetDistribution TestnetBalanceOptions {
                        } testBalance = do
 
     let desiredRichBalance  = scaleLovelaceRational testBalance tboRichmenShare
-        richmanBalance      = divLovelace desiredRichBalance (fromIntegral tboRichmen)
-        richmanBalanceExtra = modLovelace desiredRichBalance (fromIntegral tboRichmen)
+        richmanBalance      = divLovelace desiredRichBalance tboRichmen
+        richmanBalanceExtra = modLovelace desiredRichBalance tboRichmen
 
         richmanBalance'
           | tboRichmen == 0 = naturalToLovelace 0
@@ -375,16 +375,16 @@ genTestnetDistribution TestnetBalanceOptions {
                                   else naturalToLovelace 0
                                 )
 
-        totalRichBalance    = scaleLovelace richmanBalance' (fromIntegral tboRichmen)
+        totalRichBalance    = scaleLovelace richmanBalance' tboRichmen
 
     desiredPoorsBalance <- subLovelace testBalance totalRichBalance
                              `wrapError` GenesisDataGenerationLovelaceError
 
     let poorBalance
           | tboPoors == 0 = naturalToLovelace 0
-          | otherwise     = divLovelace desiredPoorsBalance (fromIntegral tboPoors)
+          | otherwise     = divLovelace desiredPoorsBalance tboPoors
 
-        totalPoorBalance  = scaleLovelace poorBalance (fromIntegral tboPoors)
+        totalPoorBalance  = scaleLovelace poorBalance tboPoors
 
         totalBalance      = addLovelace totalRichBalance totalPoorBalance
 

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NumDecimals       #-}
 {-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeApplications  #-}
 
@@ -148,7 +149,7 @@ instance B.Buildable GenesisDataGenerationError where
 -- | In Cardano Byron, the total supply is always limited to 45e15 Lovelace.
 --
 genesisMaximumLovelaceSupply :: Lovelace
-genesisMaximumLovelaceSupply = naturalToLovelace 45000000000000000
+genesisMaximumLovelaceSupply = naturalToLovelace 45e15
 
 generateGenesisData
   :: MonadError GenesisDataGenerationError m

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
@@ -36,10 +36,10 @@ import Cardano.Chain.Common
   ( Address
   , Lovelace
   , LovelaceError
+  , naturalToLovelace
   , addLovelace
   , divLovelace
   , makeVerKeyAddress
-  , mkKnownLovelace
   , hashKey
   , modLovelace
   , scaleLovelace
@@ -148,7 +148,7 @@ instance B.Buildable GenesisDataGenerationError where
 -- | In Cardano Byron, the total supply is always limited to 45e15 Lovelace.
 --
 genesisMaximumLovelaceSupply :: Lovelace
-genesisMaximumLovelaceSupply = mkKnownLovelace @ 45000000000000000
+genesisMaximumLovelaceSupply = naturalToLovelace 45000000000000000
 
 generateGenesisData
   :: MonadError GenesisDataGenerationError m
@@ -366,12 +366,12 @@ genTestnetDistribution tbo testBalance = do
       richmanBalanceExtra <- modLovelace desiredRichBalance tboRichmen
 
       richmanBalance'     <- if tboRichmen == 0
-        then pure $ mkKnownLovelace @0
+        then pure $ naturalToLovelace 0
         else addLovelace
           richmanBalance
-          (if richmanBalanceExtra > mkKnownLovelace @0
-            then mkKnownLovelace @1
-            else mkKnownLovelace @0
+          (if richmanBalanceExtra > naturalToLovelace 0
+            then naturalToLovelace 1
+            else naturalToLovelace 0
           )
 
       totalRichBalance    <- scaleLovelace richmanBalance' tboRichmen
@@ -379,7 +379,7 @@ genTestnetDistribution tbo testBalance = do
       desiredPoorsBalance <- subLovelace testBalance totalRichBalance
 
       poorBalance         <- if tboPoors == 0
-        then pure $ mkKnownLovelace @0
+        then pure $ naturalToLovelace 0
         else divLovelace desiredPoorsBalance tboPoors
 
       totalPoorBalance <- scaleLovelace poorBalance tboPoors

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Initializer.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Initializer.hs
@@ -10,13 +10,13 @@ where
 
 import Cardano.Prelude
 
-import Cardano.Chain.Common (Lovelace, LovelacePortion)
+import Cardano.Chain.Common (Lovelace)
 
 -- | Options determining generated genesis stakes, balances, and delegation
 data GenesisInitializer = GenesisInitializer
   { giTestBalance       :: !TestnetBalanceOptions
   , giFakeAvvmBalance   :: !FakeAvvmOptions
-  , giAvvmBalanceFactor :: !LovelacePortion
+  , giAvvmBalanceFactor :: !Rational
   -- ^ Avvm balances will be multiplied by this factor
   , giUseHeavyDlg       :: !Bool
   -- ^ Whether to use heavyweight delegation for genesis keys
@@ -37,7 +37,7 @@ data TestnetBalanceOptions = TestnetBalanceOptions
   -- ^ Number of rich nodes (with huge balance).
   , tboTotalBalance   :: !Lovelace
   -- ^ Total balance owned by these nodes.
-  , tboRichmenShare   :: !LovelacePortion
+  , tboRichmenShare   :: !Rational
   -- ^ Portion of stake owned by all richmen together.
   } deriving (Eq, Show)
 

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Initializer.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Initializer.hs
@@ -31,9 +31,9 @@ data GenesisInitializer = GenesisInitializer
 
 -- | These options determine balances of nodes specific for testnet
 data TestnetBalanceOptions = TestnetBalanceOptions
-  { tboPoors          :: !Word
+  { tboPoors          :: !Natural
   -- ^ Number of poor nodes (with small balance).
-  , tboRichmen        :: !Word
+  , tboRichmen        :: !Natural
   -- ^ Number of rich nodes (with huge balance).
   , tboTotalBalance   :: !Lovelace
   -- ^ Total balance owned by these nodes.
@@ -45,7 +45,7 @@ data TestnetBalanceOptions = TestnetBalanceOptions
 -- | These options determines balances of fake AVVM nodes which didn't really go
 --   through vending, but pretend they did
 data FakeAvvmOptions = FakeAvvmOptions
-  { faoCount      :: !Word
+  { faoCount      :: !Natural
   , faoOneBalance :: !Lovelace
   } deriving (Eq, Show, Generic)
 

--- a/cardano-ledger/src/Cardano/Chain/Genesis/NonAvvmBalances.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/NonAvvmBalances.hs
@@ -10,26 +10,19 @@
 
 module Cardano.Chain.Genesis.NonAvvmBalances
   ( GenesisNonAvvmBalances(..)
-  , convertNonAvvmDataToBalances
   )
 where
 
 import Cardano.Prelude
 
 import Control.Monad.Except (MonadError(..))
-import qualified Data.Map.Strict as M
-import Formatting (bprint, build)
+import Formatting (bprint)
 import qualified Formatting.Buildable as B
 import Text.JSON.Canonical (FromJSON(..), ToJSON(..))
 
-import Cardano.Binary (DecoderError)
 import Cardano.Chain.Common
   ( Address
   , Lovelace
-  , LovelaceError
-  , addLovelace
-  , decodeAddressBase58
-  , integerToLovelace
   )
 
 
@@ -51,45 +44,3 @@ instance Monad m => ToJSON m GenesisNonAvvmBalances where
 instance MonadError SchemaError m => FromJSON m GenesisNonAvvmBalances where
   fromJSON = fmap GenesisNonAvvmBalances . fromJSON
 
-data NonAvvmBalancesError
-  = NonAvvmBalancesLovelaceError LovelaceError
-  | NonAvvmBalancesDecoderError DecoderError
-
-instance B.Buildable NonAvvmBalancesError where
-  build = \case
-    NonAvvmBalancesLovelaceError err -> bprint
-      ("Failed to construct a lovelace in NonAvvmBalances.\n Error: " . build)
-      err
-    NonAvvmBalancesDecoderError err -> bprint
-      ("Failed to decode NonAvvmBalances.\n Error: " . build)
-      err
-
--- | Generate genesis address distribution out of avvm parameters. Txdistr of
---   the utxo is all empty. Redelegate it in calling function.
-convertNonAvvmDataToBalances
-  :: forall m
-   . MonadError NonAvvmBalancesError m
-  => Map Text Integer
-  -> m GenesisNonAvvmBalances
-convertNonAvvmDataToBalances balances = fmap GenesisNonAvvmBalances $ do
-  converted <- traverse convert (M.toList balances)
-  mkBalances converted
- where
-  mkBalances :: [(Address, Lovelace)] -> m (Map Address Lovelace)
-  mkBalances =
-    -- Pull 'LovelaceError's out of the 'Map' and lift them to
-    -- 'NonAvvmBalancesError's
-    (`wrapError` NonAvvmBalancesLovelaceError)
-    . sequence
-    -- Make map joining duplicate keys with 'addLovelace' lifted from 'Lovelace ->
-    -- Lovelace -> Either LovelaceError Lovelace' to 'Either LovelaceError Lovelace -> Either
-    -- LovelaceError Lovelace -> Either LovelaceError Lovelace'
-    . M.fromListWith (\c -> join . liftM2 addLovelace c)
-    -- Lift the 'Lovelace's to 'Either LovelaceError Lovelace's
-    . fmap (second Right)
-
-  convert :: (Text, Integer) -> m (Address, Lovelace)
-  convert (txt, i) = do
-    addr <- decodeAddressBase58 txt `wrapError` NonAvvmBalancesDecoderError
-    lovelace <-integerToLovelace i `wrapError` NonAvvmBalancesLovelaceError
-    return (addr, lovelace)

--- a/cardano-ledger/src/Cardano/Chain/UTxO/Compact.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/Compact.hs
@@ -28,6 +28,8 @@ module Cardano.Chain.UTxO.Compact
   , CompactTxOut(..)
   , toCompactTxOut
   , fromCompactTxOut
+  , compactTxOutAddress
+  , compactTxOutValue
   )
 where
 
@@ -41,6 +43,7 @@ import qualified Data.ByteArray as BA (convert)
 import qualified Data.ByteString.Lazy as BSL (fromStrict, toStrict)
 
 import Cardano.Binary (FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize)
+import Cardano.Chain.Common (Address)
 import Cardano.Chain.Common.Compact
   (CompactAddress, fromCompactAddress, toCompactAddress)
 import Cardano.Chain.Common.Lovelace
@@ -259,3 +262,10 @@ toCompactLovelace = CompactLovelace . fromIntegral . lovelaceToNatural
 
 fromCompactLovelace :: CompactLovelace -> Lovelace
 fromCompactLovelace (CompactLovelace n) = naturalToLovelace (fromIntegral n)
+
+compactTxOutAddress :: CompactTxOut -> Address
+compactTxOutAddress (CompactTxOut addr _) = fromCompactAddress addr
+
+compactTxOutValue :: CompactTxOut -> Lovelace
+compactTxOutValue (CompactTxOut _ lovelace) = fromCompactLovelace lovelace
+

--- a/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
@@ -55,6 +55,7 @@ import Cardano.Chain.UTxO.Compact
   , fromCompactTxOut
   , toCompactTxIn
   , toCompactTxOut
+  , compactTxOutValue
   )
 import Cardano.Crypto (hash)
 
@@ -137,9 +138,6 @@ concat = foldM union empty
 
 balance :: UTxO -> Lovelace
 balance = foldMap compactTxOutValue . unUTxO
- where
-  compactTxOutValue :: CompactTxOut -> Lovelace
-  compactTxOutValue = txOutValue . fromCompactTxOut
 
 (<|) :: Set TxIn -> UTxO -> UTxO
 (<|) inputs = UTxO . flip M.restrictKeys compactInputs . unUTxO

--- a/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
@@ -46,7 +46,7 @@ import Cardano.Binary
   , matchSize
   )
 import Cardano.Chain.Common
-  (Address, Lovelace, LovelaceError, isRedeemAddress, sumLovelace)
+  (Address, Lovelace, isRedeemAddress)
 import Cardano.Chain.UTxO.Tx (Tx(..), TxId, TxIn(..), TxOut(..))
 import Cardano.Chain.UTxO.Compact
   ( CompactTxIn
@@ -135,8 +135,8 @@ union (UTxO m) (UTxO m') = do
 concat :: MonadError UTxOError m => [UTxO] -> m UTxO
 concat = foldM union empty
 
-balance :: UTxO -> Either LovelaceError Lovelace
-balance = sumLovelace . fmap compactTxOutValue . M.elems . unUTxO
+balance :: UTxO -> Lovelace
+balance = foldMap compactTxOutValue . unUTxO
  where
   compactTxOutValue :: CompactTxOut -> Lovelace
   compactTxOutValue = txOutValue . fromCompactTxOut

--- a/cardano-ledger/src/Cardano/Chain/UTxO/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/Validation.hs
@@ -48,7 +48,7 @@ import Cardano.Chain.Common
   , checkVerKeyAddress
   , checkRedeemAddress
   , makeNetworkMagic
-  , mkKnownLovelace
+  , naturalToLovelace
   , subLovelace
   , unknownAttributesLength
   )
@@ -186,7 +186,7 @@ validateTx env utxo (Annotated tx txBytes) = do
 
   -- Calculate the minimum fee from the 'TxFeePolicy'
   minFee <- if isRedeemUTxO inputUTxO
-    then pure $ mkKnownLovelace @0
+    then pure $ naturalToLovelace 0
     else calculateMinimumFee feePolicy
 
   -- Calculate the balance of the output 'UTxO'

--- a/cardano-ledger/src/Cardano/Chain/Update/ProtocolParameters.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/ProtocolParameters.hs
@@ -24,7 +24,7 @@ import Text.JSON.Canonical (FromJSON(..), ToJSON(..), fromJSField, mkObject)
 
 import Cardano.Binary (FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize)
 import Cardano.Chain.Common
-  (LovelacePortion, TxFeePolicy, lovelacePortionToDouble)
+  (LovelacePortion, TxFeePolicy, lovelacePortionToRational)
 import Cardano.Chain.Slotting (EpochNumber, SlotNumber(..), isBootstrapEra)
 import Cardano.Chain.Update.SoftforkRule
 
@@ -178,10 +178,12 @@ isBootstrapEraPP adoptedPP = isBootstrapEra (ppUnlockStakeEpoch adoptedPP)
 -- | In Byron we do not have a @upAdptThd@ protocol parameter, so we have to
 --   use the existing ones.
 --
---   @lovelacePortionToDouble . srMinThd . ppSoftforkRule@ will give us the
+--   @lovelacePortionToRational . srMinThd . ppSoftforkRule@ will give us the
 --   ratio (in the interval @[0, 1]@) of the total stake that has to endorse a
 --   protocol version to become adopted. In genesis configuration, this ratio
 --   will evaluate to @0.6@, so if we have 7 genesis keys, @upAdptThd = 4@.
 upAdptThd :: Word8 -> ProtocolParameters -> Int
-upAdptThd numGenKeys pps = floor $ stakeRatio * fromIntegral numGenKeys
-  where stakeRatio = lovelacePortionToDouble . srMinThd . ppSoftforkRule $ pps
+upAdptThd numGenKeys pps =
+    floor $ stakeRatio * toRational numGenKeys
+  where
+    stakeRatio = lovelacePortionToRational . srMinThd . ppSoftforkRule $ pps

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
@@ -24,7 +24,6 @@ import Cardano.Chain.Common
   , Attributes(..)
   , BlockCount(..)
   , ChainDifficulty(..)
-  , LovelacePortion(..)
   , TxFeePolicy(..)
   , TxSizeLinear(..)
   , isRedeemAddress
@@ -34,6 +33,7 @@ import Cardano.Chain.Common
   , mtRoot
   , decodeAddressBase58
   , encodeAddressBase58
+  , rationalToLovelacePortion
   )
 import Cardano.Crypto
   ( Hash
@@ -216,7 +216,7 @@ golden_LovelacePortion :: Property
 golden_LovelacePortion =
   goldenTestCBOR c "test/golden/cbor/common/LovelacePortion"
  where
-  c = LovelacePortion 9702
+  c = rationalToLovelacePortion 9702e-15
 
 ts_roundTripLovelacePortionCBOR :: TSProperty
 ts_roundTripLovelacePortionCBOR =

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
@@ -28,11 +28,11 @@ import Cardano.Chain.Common
   , TxSizeLinear(..)
   , isRedeemAddress
   , mkAttributes
-  , mkKnownLovelace
   , mkMerkleTree
   , mtRoot
   , decodeAddressBase58
   , encodeAddressBase58
+  , naturalToLovelace
   , rationalToLovelacePortion
   )
 import Cardano.Crypto
@@ -197,7 +197,7 @@ ts_roundTripChainDifficultyCBOR =
 --------------------------------------------------------------------------------
 golden_Lovelace :: Property
 golden_Lovelace = goldenTestCBOR c "test/golden/cbor/common/Lovelace"
-  where c = mkKnownLovelace @9732
+  where c = naturalToLovelace 9732
 
 ts_roundTripLovelaceCBOR :: TSProperty
 ts_roundTripLovelaceCBOR = eachOfTS 1000 genLovelace roundTripsCBORBuildable
@@ -242,8 +242,8 @@ golden_TxFeePolicy_Linear =
   goldenTestCBOR tfp "test/golden/cbor/common/TxFeePolicy_Linear"
  where
   tfp = TxFeePolicyTxSizeLinear (TxSizeLinear c1 c2)
-  c1 = mkKnownLovelace @99
-  c2 = mkKnownLovelace @777
+  c1 = naturalToLovelace 99
+  c2 = naturalToLovelace 777
 
 ts_roundTripTxFeePolicyCBOR :: TSProperty
 ts_roundTripTxFeePolicyCBOR =
@@ -257,8 +257,8 @@ golden_TxSizeLinear =
   goldenTestCBOR tsl "test/golden/cbor/common/TxSizeLinear"
  where
   tsl = TxSizeLinear c1 c2
-  c1 = mkKnownLovelace @99
-  c2 = mkKnownLovelace @777
+  c1 = naturalToLovelace 99
+  c2 = naturalToLovelace 777
 
 ts_roundTripTxSizeLinearCBOR :: TSProperty
 ts_roundTripTxSizeLinearCBOR =

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/CBOR.hs
@@ -66,7 +66,6 @@ import Test.Cardano.Chain.Common.Gen
   , genBlockCount
   , genChainDifficulty
   , genLovelace
-  , genLovelaceError
   , genLovelacePortion
   , genMerkleTree
   , genMerkleRoot
@@ -201,13 +200,6 @@ golden_Lovelace = goldenTestCBOR c "test/golden/cbor/common/Lovelace"
 
 ts_roundTripLovelaceCBOR :: TSProperty
 ts_roundTripLovelaceCBOR = eachOfTS 1000 genLovelace roundTripsCBORBuildable
-
---------------------------------------------------------------------------------
--- LovelaceError
---------------------------------------------------------------------------------
-ts_roundTripLovelaceErrorCBOR :: TSProperty
-ts_roundTripLovelaceErrorCBOR =
-  eachOfTS 1000 genLovelaceError roundTripsCBORBuildable
 
 --------------------------------------------------------------------------------
 -- LovelacePortion

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
@@ -51,14 +51,14 @@ import Cardano.Chain.Common
   , CompactAddress
   , Lovelace
   , LovelaceError(..)
-  , LovelacePortion(..)
+  , LovelacePortion
   , MerkleRoot(..)
   , MerkleTree
   , NetworkMagic(..)
   , KeyHash
   , TxFeePolicy(..)
   , TxSizeLinear(..)
-  , lovelacePortionDenominator
+  , rationalToLovelacePortion
   , makeAddress
   , maxLovelaceVal
   , mkAttributes
@@ -169,7 +169,7 @@ genLovelaceWithRange r =
 
 genLovelacePortion :: Gen LovelacePortion
 genLovelacePortion =
-  LovelacePortion <$> Gen.word64 (Range.constant 0 lovelacePortionDenominator)
+  rationalToLovelacePortion . realToFrac <$> Gen.double (Range.constant 0 1)
 
 -- slow
 genMerkleTree :: ToCBOR a => Gen a -> Gen (MerkleTree a)

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
@@ -137,23 +137,10 @@ genLovelace = genLovelaceWithRange (Range.constant minBound maxBound)
 
 genLovelaceError :: Gen LovelaceError
 genLovelaceError = Gen.choice
-  [ LovelaceOverflow <$> Gen.word64 overflowRange
-  , LovelaceTooLarge <$> Gen.integral tooLargeRange
-  , LovelaceTooSmall <$> Gen.integral tooSmallRange
+  [ LovelaceTooSmall <$> Gen.integral tooSmallRange
   , uncurry LovelaceUnderflow <$> genUnderflowErrorValues
   ]
  where
-  -- TODO: This will be removed soon since overflow will no longer be possible.
-  maxLovelaceVal :: Word64
-  maxLovelaceVal = 45e15
-
-  overflowRange :: Range Word64
-  overflowRange = Range.constant (maxLovelaceVal + 1) (maxBound :: Word64)
-
-  tooLargeRange :: Range Integer
-  tooLargeRange = Range.constant (fromIntegral (maxLovelaceVal + 1))
-                                 (fromIntegral (maxBound :: Word64))
-
   tooSmallRange :: Range Integer
   tooSmallRange = Range.constant (fromIntegral (minBound :: Int)) (- 1)
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
@@ -60,7 +60,6 @@ import Cardano.Chain.Common
   , TxSizeLinear(..)
   , rationalToLovelacePortion
   , makeAddress
-  , maxLovelaceVal
   , mkAttributes
   , mkLovelace
   , mkMerkleTree
@@ -134,7 +133,7 @@ genCustomLovelace :: Word64 -> Gen Lovelace
 genCustomLovelace size = genLovelaceWithRange (Range.linear 0 size)
 
 genLovelace :: Gen Lovelace
-genLovelace = genLovelaceWithRange (Range.constant 0 maxLovelaceVal)
+genLovelace = genLovelaceWithRange (Range.constant minBound maxBound)
 
 genLovelaceError :: Gen LovelaceError
 genLovelaceError = Gen.choice
@@ -144,6 +143,10 @@ genLovelaceError = Gen.choice
   , uncurry LovelaceUnderflow <$> genUnderflowErrorValues
   ]
  where
+  -- TODO: This will be removed soon since overflow will no longer be possible.
+  maxLovelaceVal :: Word64
+  maxLovelaceVal = 45e15
+
   overflowRange :: Range Word64
   overflowRange = Range.constant (maxLovelaceVal + 1) (maxBound :: Word64)
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
@@ -130,14 +130,9 @@ genLovelace :: Gen Lovelace
 genLovelace = genLovelaceWithRange (Range.constant minBound maxBound)
 
 genLovelaceError :: Gen LovelaceError
-genLovelaceError = Gen.choice
-  [ LovelaceTooSmall <$> Gen.integral tooSmallRange
-  , uncurry LovelaceUnderflow <$> genUnderflowErrorValues
-  ]
+genLovelaceError =
+  uncurry LovelaceUnderflow <$> genUnderflowErrorValues
  where
-  tooSmallRange :: Range Integer
-  tooSmallRange = Range.constant (fromIntegral (minBound :: Int)) (- 1)
-
   genUnderflowErrorValues :: Gen (Word64, Word64)
   genUnderflowErrorValues = do
     a <- Gen.word64 (Range.constant 0 (maxBound - 1))

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
@@ -16,7 +16,6 @@ module Test.Cardano.Chain.Common.Gen
   , genCompactAddress
   , genCustomLovelace
   , genLovelace
-  , genLovelaceError
   , genLovelaceWithRange
   , genLovelacePortion
   , genMerkleRoot
@@ -48,7 +47,6 @@ import Cardano.Chain.Common
   , ChainDifficulty(..)
   , CompactAddress
   , Lovelace
-  , LovelaceError(..)
   , LovelacePortion
   , MerkleRoot(..)
   , MerkleTree
@@ -128,16 +126,6 @@ genCustomLovelace size = genLovelaceWithRange (Range.linear 0 size)
 
 genLovelace :: Gen Lovelace
 genLovelace = genLovelaceWithRange (Range.constant minBound maxBound)
-
-genLovelaceError :: Gen LovelaceError
-genLovelaceError =
-  uncurry LovelaceUnderflow <$> genUnderflowErrorValues
- where
-  genUnderflowErrorValues :: Gen (Word64, Word64)
-  genUnderflowErrorValues = do
-    a <- Gen.word64 (Range.constant 0 (maxBound - 1))
-    b <- Gen.word64 (Range.constant a maxBound)
-    pure (a, b)
 
 genLovelaceWithRange :: Range Word64 -> Gen Lovelace
 genLovelaceWithRange r =

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/Gen.hs
@@ -32,8 +32,6 @@ where
 import Cardano.Prelude
 import Test.Cardano.Prelude (gen32Bytes)
 
-import Formatting (build, sformat)
-
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -61,7 +59,7 @@ import Cardano.Chain.Common
   , rationalToLovelacePortion
   , makeAddress
   , mkAttributes
-  , mkLovelace
+  , naturalToLovelace
   , mkMerkleTree
   , hashKey
   , mtRoot
@@ -109,13 +107,9 @@ genCanonicalTxSizeLinear = TxSizeLinear <$> genLovelace' <*> genLovelace'
  where
   genLovelace' :: Gen Lovelace
   genLovelace' =
-    mkLovelace
+    (naturalToLovelace . fromIntegral)
       <$> Gen.word64 (Range.constant 0 maxCanonicalLovelaceVal)
-      >>= \case
-            Right lovelace -> pure lovelace
-            Left  err      -> panic $ sformat
-              ("The impossible happened in genLovelace: " . build)
-              err
+
   -- | Maximal possible value of `Lovelace` in Canonical JSON (JSNum !Int54)
   -- This should be (2^53 - 1) ~ 9e15, however in the Canonical ToJSON instance of
   -- `TxFeePolicy` this number is multiplied by 1e9 to keep compatibility with 'Nano'
@@ -152,10 +146,7 @@ genLovelaceError = Gen.choice
 
 genLovelaceWithRange :: Range Word64 -> Gen Lovelace
 genLovelaceWithRange r =
-  mkLovelace <$> Gen.word64 r >>= \case
-    Right lovelace -> pure lovelace
-    Left err ->
-      panic $ sformat ("The impossible happened in genLovelace: " . build) err
+  (naturalToLovelace . fromIntegral) <$> Gen.word64 r
 
 genLovelacePortion :: Gen LovelacePortion
 genLovelacePortion =

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/Lovelace.hs
@@ -20,10 +20,10 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import Cardano.Chain.Common
-  ( LovelaceError(..)
+  ( Lovelace
+  , LovelaceError(..)
   , addLovelace
   , integerToLovelace
-  , maxLovelaceVal
   , mkKnownLovelace
   , mkLovelace
   , scaleLovelace
@@ -35,6 +35,15 @@ import Test.Cardano.Chain.Common.Gen (genLovelace, genCustomLovelace)
 import Test.Options (TSGroup, TSProperty, concatTSGroups, withTestsTS)
 
 
+-- TODO: This will be removed soon since overflow will no longer be possible.
+maxLovelaceVal :: Word64
+maxLovelaceVal = 45e15
+
+maxLovelace :: Lovelace
+maxLovelace = case mkLovelace maxLovelaceVal of
+                Right v -> v
+                Left  _ -> panic "maxLovelace: impossible"
+
 ts_prop_addLovelace :: TSProperty
 ts_prop_addLovelace = withTestsTS 1000 . property $ do
   a <- forAll genLovelace
@@ -45,7 +54,7 @@ ts_prop_addLovelace = withTestsTS 1000 . property $ do
 prop_addLovelaceOverflow :: Property
 prop_addLovelaceOverflow = property $ assertIsLeftConstr
   dummyLovelaceOverflow
-  (addLovelace (mkKnownLovelace @1) maxBound)
+  (addLovelace (mkKnownLovelace @1) maxLovelace)
 
 
 ts_prop_integerToLovelace :: TSProperty
@@ -81,7 +90,7 @@ prop_mkLovelaceTooLarge = property
 prop_scaleLovelaceTooLarge :: Property
 prop_scaleLovelaceTooLarge = property $ assertIsLeftConstr
   dummyLovelaceTooLarge
-  (scaleLovelace maxBound (2 :: Integer))
+  (scaleLovelace maxLovelace (2 :: Integer))
 
 
 ts_prop_subLovelace :: TSProperty

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/Lovelace.hs
@@ -23,11 +23,10 @@ import Cardano.Chain.Common
   ( Lovelace
   , LovelaceError(..)
   , addLovelace
-  , integerToLovelace
   , mkKnownLovelace
   , mkLovelace
   , subLovelace
-  , unsafeGetLovelace
+  , lovelaceToNatural
   )
 
 import Test.Cardano.Chain.Common.Gen (genLovelace, genCustomLovelace)
@@ -46,21 +45,10 @@ maxLovelace = case mkLovelace maxLovelaceVal of
 ts_prop_addLovelace :: TSProperty
 ts_prop_addLovelace = withTestsTS 1000 . property $ do
   a <- forAll genLovelace
-  let newRange = maxLovelaceVal - unsafeGetLovelace a
+  let newRange = maxLovelaceVal - fromIntegral (lovelaceToNatural a)
   b <- forAll $ genCustomLovelace newRange
   assertIsRight $ addLovelace a b
 
-
-ts_prop_integerToLovelace :: TSProperty
-ts_prop_integerToLovelace = withTestsTS 1000 . property $ do
-  testInt <- forAll
-    (Gen.integral $ Range.linear 0 (fromIntegral maxLovelaceVal :: Integer))
-  assertIsRight $ integerToLovelace testInt
-
-
-prop_integerToLovelaceTooSmall :: Property
-prop_integerToLovelaceTooSmall = property
-  $ assertIsLeftConstr dummyLovelaceTooSmall (integerToLovelace (negate 1))
 
 prop_maxLovelaceUnchanged :: Property
 prop_maxLovelaceUnchanged =
@@ -75,7 +63,7 @@ ts_prop_mkLovelace = withTestsTS 1000 . property $ do
 ts_prop_subLovelace :: TSProperty
 ts_prop_subLovelace = withTestsTS 1000 . property $ do
   a <- forAll genLovelace
-  b <- forAll $ genCustomLovelace (unsafeGetLovelace a)
+  b <- forAll $ genCustomLovelace (fromIntegral (lovelaceToNatural a))
   assertIsRight $ subLovelace a b
 
 ts_prop_subLovelaceUnderflow :: TSProperty

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/Lovelace.hs
@@ -12,13 +12,10 @@ where
 import Cardano.Prelude
 import Test.Cardano.Prelude
 
-import Data.Data (Constr, toConstr)
-
 import Hedgehog (discover, forAll, property)
 
 import Cardano.Chain.Common
-  ( LovelaceError(LovelaceUnderflow)
-  , addLovelace
+  ( addLovelace
   , subLovelace
   , naturalToLovelace
   , lovelaceToNatural
@@ -32,23 +29,15 @@ ts_prop_subLovelace :: TSProperty
 ts_prop_subLovelace = withTestsTS 1000 . property $ do
   a <- forAll genLovelace
   b <- forAll $ genCustomLovelace (fromIntegral (lovelaceToNatural a))
-  assertIsRight $ subLovelace a b
+  assertIsJust $ subLovelace a b
 
 ts_prop_subLovelaceUnderflow :: TSProperty
 ts_prop_subLovelaceUnderflow =
   withTestsTS 1000
     . property
     $ do a <- forAll genLovelace
-         assertIsLeftConstr dummyLovelaceUnderflow
-           (subLovelace a (addLovelace a (naturalToLovelace 1)))
+         assertIsNothing (subLovelace a (addLovelace a (naturalToLovelace 1)))
 
 tests :: TSGroup
 tests = concatTSGroups [const $$discover, $$discoverPropArg]
 
-
---------------------------------------------------------------------------------
--- Dummy values for constructor comparison in assertIsLeftConstr tests
---------------------------------------------------------------------------------
-
-dummyLovelaceUnderflow :: Constr
-dummyLovelaceUnderflow = toConstr $ LovelaceUnderflow 1 1

--- a/cardano-ledger/test/Test/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Common/Lovelace.hs
@@ -23,9 +23,8 @@ import Cardano.Chain.Common
   ( Lovelace
   , LovelaceError(..)
   , addLovelace
-  , mkKnownLovelace
-  , mkLovelace
   , subLovelace
+  , naturalToLovelace
   , lovelaceToNatural
   )
 
@@ -36,11 +35,6 @@ import Test.Options (TSGroup, TSProperty, concatTSGroups, withTestsTS)
 -- TODO: This will be removed soon since overflow will no longer be possible.
 maxLovelaceVal :: Word64
 maxLovelaceVal = 45e15
-
-maxLovelace :: Lovelace
-maxLovelace = case mkLovelace maxLovelaceVal of
-                Right v -> v
-                Left  _ -> panic "maxLovelace: impossible"
 
 ts_prop_addLovelace :: TSProperty
 ts_prop_addLovelace = withTestsTS 1000 . property $ do
@@ -54,12 +48,6 @@ prop_maxLovelaceUnchanged :: Property
 prop_maxLovelaceUnchanged =
   property $ (fromIntegral maxLovelaceVal :: Integer) === 45e15
 
-ts_prop_mkLovelace :: TSProperty
-ts_prop_mkLovelace = withTestsTS 1000 . property $ do
-  testWrd <- forAll (Gen.word64 $ Range.linear 0 maxLovelaceVal)
-  assertIsRight $ mkLovelace testWrd
-
-
 ts_prop_subLovelace :: TSProperty
 ts_prop_subLovelace = withTestsTS 1000 . property $ do
   a <- forAll genLovelace
@@ -72,7 +60,7 @@ ts_prop_subLovelaceUnderflow =
     . property
     $ do
         a <- forAll genLovelace
-        case addLovelace a (mkKnownLovelace @1) of
+        case addLovelace a (naturalToLovelace 1) of
           Right added ->
             assertIsLeftConstr dummyLovelaceUnderflow (subLovelace a added)
           Left err -> panic $ sformat

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
@@ -19,7 +19,6 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Vector as V
-import Formatting hiding (bytes)
 
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Chain.Common as Concrete
@@ -44,8 +43,8 @@ elaborateUTxOEnv _abstractEnv = Concrete.UTxO.Environment
   , Concrete.UTxO.protocolParameters = dummyProtocolParameters
     { Concrete.ppTxFeePolicy =
       Concrete.TxFeePolicyTxSizeLinear $ Concrete.TxSizeLinear
-        (Concrete.mkKnownLovelace @0)
-        (Concrete.mkKnownLovelace @0)
+        (Concrete.naturalToLovelace 0)
+        (Concrete.naturalToLovelace 0)
     }
   , Concrete.UTxO.utxoConfiguration = Concrete.defaultUTxOConfiguration
   }
@@ -137,12 +136,9 @@ elaborateTxOut abstractTxOut = Concrete.TxOut
   { Concrete.txOutAddress = Concrete.makeVerKeyAddress
     (Concrete.makeNetworkMagic Dummy.protocolMagic)
     (elaborateVKey abstractVK)
-  , Concrete.txOutValue   = lovelaceValue
+  , Concrete.txOutValue   = Concrete.naturalToLovelace (fromIntegral value)
   }
  where
   Abstract.TxOut (Abstract.Addr abstractVK) (Abstract.Lovelace value) =
     abstractTxOut
 
-  lovelaceValue = case Concrete.mkLovelace (fromIntegral value) of
-    Left  err -> panic $ sformat build err
-    Right l   -> l

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
@@ -43,21 +43,21 @@ elaboratePParams pps = Concrete.ProtocolParameters
   , Concrete.ppMaxHeaderSize      = 95 * Abstract._maxHdrSz pps
   , Concrete.ppMaxTxSize          = 4096 * Abstract._maxTxSz pps
   , Concrete.ppMaxProposalSize    = 4096 * Abstract._maxPropSz pps
-  , Concrete.ppMpcThd             = Concrete.mkKnownLovelacePortion @0
-  , Concrete.ppHeavyDelThd        = Concrete.mkKnownLovelacePortion @0
-  , Concrete.ppUpdateVoteThd      = Concrete.mkKnownLovelacePortion @0
-  , Concrete.ppUpdateProposalThd  = Concrete.mkKnownLovelacePortion @0
+  , Concrete.ppMpcThd             = Concrete.rationalToLovelacePortion 0
+  , Concrete.ppHeavyDelThd        = Concrete.rationalToLovelacePortion 0
+  , Concrete.ppUpdateVoteThd      = Concrete.rationalToLovelacePortion 0
+  , Concrete.ppUpdateProposalThd  = Concrete.rationalToLovelacePortion 0
   , Concrete.ppUpdateProposalTTL  = Concrete.SlotNumber
                                   $ unSlotCount
                                   $ Abstract._upTtl pps
   , Concrete.ppSoftforkRule       =
     Concrete.SoftforkRule
-      { Concrete.srInitThd = Concrete.mkKnownLovelacePortion @0
+      { Concrete.srInitThd = Concrete.rationalToLovelacePortion 0
       -- See 'upAdptThd' in 'module Cardano.Chain.Update.ProtocolParameters'
       , Concrete.srMinThd = Concrete.rationalToLovelacePortion
                           $ realToFrac
                           $ Abstract._upAdptThd pps
-      , Concrete.srThdDecrement  = Concrete.mkKnownLovelacePortion @0
+      , Concrete.srThdDecrement  = Concrete.rationalToLovelacePortion 0
       }
   , Concrete.ppTxFeePolicy        =
       elaborateFeePolicy

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
@@ -13,7 +13,6 @@ where
 
 import Cardano.Prelude
 
-import Control.Arrow ((|||))
 import Data.Coerce (coerce)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -55,10 +54,9 @@ elaboratePParams pps = Concrete.ProtocolParameters
     Concrete.SoftforkRule
       { Concrete.srInitThd = Concrete.mkKnownLovelacePortion @0
       -- See 'upAdptThd' in 'module Cardano.Chain.Update.ProtocolParameters'
-      , Concrete.srMinThd = panic . show ||| identity
-                          $ Concrete.mkLovelacePortion
-                          $ floor
-                          $ Abstract._upAdptThd pps * 1e15
+      , Concrete.srMinThd = Concrete.rationalToLovelacePortion
+                          $ realToFrac
+                          $ Abstract._upAdptThd pps
       , Concrete.srThdDecrement  = Concrete.mkKnownLovelacePortion @0
       }
   , Concrete.ppTxFeePolicy        =

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
@@ -79,10 +79,7 @@ elaborateFeePolicy (Abstract.FactorA a) (Abstract.FactorB b) =
        $ fromIntegral b / (fromIntegral GP.c :: Double)
 
     intToLovelace :: Int -> Concrete.Lovelace
-    intToLovelace x =
-      case Concrete.mkLovelace (fromIntegral x) of
-        Left err -> panic $ "intToLovelace: " <> show err
-        Right l -> l
+    intToLovelace = Concrete.naturalToLovelace  . fromIntegral
 
 elaborateProtocolVersion
   :: Abstract.ProtVer

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
@@ -31,7 +31,7 @@ import Cardano.Chain.Common
   , TxFeePolicy(..)
   , TxSizeLinear(..)
   , mkKnownLovelace
-  , mkKnownLovelacePortion
+  , rationalToLovelacePortion
   )
 import Cardano.Chain.Genesis
   ( Config(..)
@@ -110,15 +110,16 @@ dummyProtocolParameters = ProtocolParameters
   , ppMaxHeaderSize     = 2000000
   , ppMaxTxSize         = 4096
   , ppMaxProposalSize   = 700
-  , ppMpcThd            = mkKnownLovelacePortion @10000000000000
-  , ppHeavyDelThd       = mkKnownLovelacePortion @5000000000000
-  , ppUpdateVoteThd     = mkKnownLovelacePortion @1000000000000
-  , ppUpdateProposalThd = mkKnownLovelacePortion @100000000000000
+  , ppMpcThd            = rationalToLovelacePortion 0.01
+  , ppHeavyDelThd       = rationalToLovelacePortion 0.005
+  , ppUpdateVoteThd     = rationalToLovelacePortion 0.001
+  , ppUpdateProposalThd = rationalToLovelacePortion 0.1
   , ppUpdateProposalTTL = 10
   , ppSoftforkRule      = SoftforkRule
-    (mkKnownLovelacePortion @900000000000000)
-    (mkKnownLovelacePortion @600000000000000)
-    (mkKnownLovelacePortion @50000000000000)
+    { srInitThd      = rationalToLovelacePortion 0.9
+    , srMinThd       = rationalToLovelacePortion 0.6
+    , srThdDecrement = rationalToLovelacePortion 0.05
+    }
   , ppTxFeePolicy       = TxFeePolicyTxSizeLinear
     (TxSizeLinear (mkKnownLovelace @155381) (mkKnownLovelace @44))
   , ppUnlockStakeEpoch  = EpochNumber maxBound

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
@@ -130,13 +130,13 @@ dummyGenesisInitializer = GenesisInitializer
     { tboPoors          = 12
     , tboRichmen        = 4
     , tboTotalBalance   = mkKnownLovelace @6000000000000000
-    , tboRichmenShare   = mkKnownLovelacePortion @990000000000000
+    , tboRichmenShare   = 0.99 :: Rational
     }
   , giFakeAvvmBalance = FakeAvvmOptions
     { faoCount      = 10
     , faoOneBalance = mkKnownLovelace @100000
     }
-  , giAvvmBalanceFactor = mkKnownLovelacePortion @1000000000000000
+  , giAvvmBalanceFactor = 1.0 :: Rational
   , giUseHeavyDlg = True
   , giSeed        = 0
   }

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Dummy.hs
@@ -30,7 +30,7 @@ import Cardano.Chain.Common
   ( BlockCount (..)
   , TxFeePolicy(..)
   , TxSizeLinear(..)
-  , mkKnownLovelace
+  , naturalToLovelace
   , rationalToLovelacePortion
   )
 import Cardano.Chain.Genesis
@@ -121,7 +121,7 @@ dummyProtocolParameters = ProtocolParameters
     , srThdDecrement = rationalToLovelacePortion 0.05
     }
   , ppTxFeePolicy       = TxFeePolicyTxSizeLinear
-    (TxSizeLinear (mkKnownLovelace @155381) (mkKnownLovelace @44))
+    (TxSizeLinear (naturalToLovelace 155381) (naturalToLovelace 44))
   , ppUnlockStakeEpoch  = EpochNumber maxBound
   }
 
@@ -130,12 +130,12 @@ dummyGenesisInitializer = GenesisInitializer
   { giTestBalance = TestnetBalanceOptions
     { tboPoors          = 12
     , tboRichmen        = 4
-    , tboTotalBalance   = mkKnownLovelace @6000000000000000
+    , tboTotalBalance   = naturalToLovelace 6000000000000000
     , tboRichmenShare   = 0.99 :: Rational
     }
   , giFakeAvvmBalance = FakeAvvmOptions
     { faoCount      = 10
-    , faoOneBalance = mkKnownLovelace @100000
+    , faoOneBalance = naturalToLovelace 100000
     }
   , giAvvmBalanceFactor = 1.0 :: Rational
   , giUseHeavyDlg = True

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
@@ -24,9 +24,7 @@ import Data.Time (UTCTime(..), Day(..), secondsToDiffTime)
 import Cardano.Binary (Annotated(..))
 import Cardano.Chain.Common
   ( BlockCount(..)
-  , LovelacePortion(..)
   , mkKnownLovelace
-  , mkKnownLovelacePortion
   , hashKey
   )
 import Cardano.Chain.Delegation (unsafeCertificate)
@@ -148,13 +146,13 @@ exampleGenesisInitializer = GenesisInitializer
     { tboPoors          = 2448641325904532856
     , tboRichmen        = 14071205313513960321
     , tboTotalBalance   = mkKnownLovelace @10953275486128625
-    , tboRichmenShare   = mkKnownLovelacePortion @366832547637728
+    , tboRichmenShare   = 0.366832547637728 :: Rational
     }
   , giFakeAvvmBalance = FakeAvvmOptions
     { faoCount      = 17853231730478779264
     , faoOneBalance = mkKnownLovelace @15087947214890024
     }
-  , giAvvmBalanceFactor = LovelacePortion {getLovelacePortion = 366832547637728}
+  , giAvvmBalanceFactor = 0.366832547637728 :: Rational
   , giUseHeavyDlg = False
   , giSeed        = 0
   }

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Example.hs
@@ -24,7 +24,7 @@ import Data.Time (UTCTime(..), Day(..), secondsToDiffTime)
 import Cardano.Binary (Annotated(..))
 import Cardano.Chain.Common
   ( BlockCount(..)
-  , mkKnownLovelace
+  , naturalToLovelace
   , hashKey
   )
 import Cardano.Chain.Delegation (unsafeCertificate)
@@ -73,8 +73,8 @@ exampleGenesisSpec = UnsafeGenesisSpec
 
 exampleGenesisAvvmBalances :: GenesisAvvmBalances
 exampleGenesisAvvmBalances = GenesisAvvmBalances $ M.fromList
-  [ (exampleCompactRVK' (0, 32) , mkKnownLovelace @36524597913081152)
-  , (exampleCompactRVK' (32, 32), mkKnownLovelace @37343863242999412)
+  [ (exampleCompactRVK' (0, 32) , naturalToLovelace 36524597913081152)
+  , (exampleCompactRVK' (32, 32), naturalToLovelace 37343863242999412)
   ]
  where
   exampleCompactRVK' :: (Int, Int) -> CompactRedeemVerificationKey
@@ -145,12 +145,12 @@ exampleGenesisInitializer = GenesisInitializer
   { giTestBalance = TestnetBalanceOptions
     { tboPoors          = 2448641325904532856
     , tboRichmen        = 14071205313513960321
-    , tboTotalBalance   = mkKnownLovelace @10953275486128625
+    , tboTotalBalance   = naturalToLovelace 10953275486128625
     , tboRichmenShare   = 0.366832547637728 :: Rational
     }
   , giFakeAvvmBalance = FakeAvvmOptions
     { faoCount      = 17853231730478779264
-    , faoOneBalance = mkKnownLovelace @15087947214890024
+    , faoOneBalance = naturalToLovelace 15087947214890024
     }
   , giAvvmBalanceFactor = 0.366832547637728 :: Rational
   , giUseHeavyDlg = False
@@ -161,8 +161,8 @@ exampleGenesisNonAvvmBalances0 :: GenesisNonAvvmBalances
 exampleGenesisNonAvvmBalances0 = GenesisNonAvvmBalances
   $ M.fromList [(exampleAddress, coin), (exampleAddress1, coin1)]
  where
-  coin  = mkKnownLovelace @36524597913081152
-  coin1 = mkKnownLovelace @37343863242999412
+  coin  = naturalToLovelace 36524597913081152
+  coin1 = naturalToLovelace 37343863242999412
 
 exampleGenesisKeyHashes :: GenesisKeyHashes
 exampleGenesisKeyHashes = GenesisKeyHashes (Set.singleton exampleKeyHash)

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Gen.hs
@@ -47,7 +47,7 @@ import Cardano.Crypto (ProtocolMagicId, Signature(..))
 import qualified Cardano.Crypto.Wallet as CC
 
 import Test.Cardano.Chain.Common.Gen
-  (genAddress, genBlockCount, genLovelace, genLovelacePortion, genKeyHash)
+  (genAddress, genBlockCount, genLovelace, genKeyHash)
 import Test.Cardano.Chain.Delegation.Gen
   (genCanonicalCertificateDistinctList, genCertificateDistinctList)
 import Test.Cardano.Chain.Update.Gen
@@ -111,7 +111,7 @@ genGenesisInitializer =
   GenesisInitializer
     <$> genTestnetBalanceOptions
     <*> genFakeAvvmOptions
-    <*> genLovelacePortion
+    <*> (realToFrac <$> Gen.double (Range.constant 0 1))
     <*> Gen.bool
     <*> Gen.integral (Range.constant 0 10)
 
@@ -138,7 +138,7 @@ genTestnetBalanceOptions =
     <$> Gen.word Range.constantBounded
     <*> Gen.word Range.constantBounded
     <*> genLovelace
-    <*> genLovelacePortion
+    <*> (realToFrac <$> Gen.double (Range.constant 0 1))
 
 genGenesisAvvmBalances :: Gen GenesisAvvmBalances
 genGenesisAvvmBalances =

--- a/cardano-ledger/test/Test/Cardano/Chain/Genesis/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Genesis/Gen.hs
@@ -98,7 +98,8 @@ genGenesisHash = GenesisHash . coerce <$> genTextHash
 
 genFakeAvvmOptions :: Gen FakeAvvmOptions
 genFakeAvvmOptions =
-  FakeAvvmOptions <$> Gen.word Range.constantBounded <*> genLovelace
+  FakeAvvmOptions <$> (fromIntegral <$> Gen.word Range.constantBounded)
+                  <*> genLovelace
 
 genGenesisDelegation :: ProtocolMagicId -> Gen GenesisDelegation
 genGenesisDelegation pm = mkGenesisDelegation' <$> genCertificateDistinctList pm
@@ -135,8 +136,8 @@ genGenesisSpec pm = either (panic . toS) identity <$> mkGenSpec
 genTestnetBalanceOptions :: Gen TestnetBalanceOptions
 genTestnetBalanceOptions =
   TestnetBalanceOptions
-    <$> Gen.word Range.constantBounded
-    <*> Gen.word Range.constantBounded
+    <$> (fromIntegral <$> Gen.word Range.constantBounded)
+    <*> (fromIntegral <$> Gen.word Range.constantBounded)
     <*> genLovelace
     <*> (realToFrac <$> Gen.double (Range.constant 0 1))
 

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
@@ -35,7 +35,7 @@ import Cardano.Chain.Common
   ( NetworkMagic(..)
   , makeVerKeyAddress
   , mkAttributes
-  , mkKnownLovelace
+  , naturalToLovelace
   , mkMerkleTree
   , mtRoot
   )
@@ -97,11 +97,12 @@ exampleTxInUtxo1 = TxInUtxo exampleHashTx 74
 
 exampleTxOut :: TxOut
 exampleTxOut = TxOut (makeVerKeyAddress NetworkMainOrStage vkey)
-                     (mkKnownLovelace @47)
+                     (naturalToLovelace 47)
   where Right vkey = VerificationKey <$> CC.xpub (getBytes 0 64)
 
 exampleTxOut1 :: TxOut
-exampleTxOut1 = TxOut (makeVerKeyAddress (NetworkTestnet 74) vkey) (mkKnownLovelace @47)
+exampleTxOut1 = TxOut (makeVerKeyAddress (NetworkTestnet 74) vkey)
+                      (naturalToLovelace 47)
   where Right vkey = VerificationKey <$> CC.xpub (getBytes 0 64)
 
 exampleTxOutList :: (NonEmpty TxOut)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
@@ -60,6 +60,7 @@ import Cardano.Chain.UTxO
   , UTxO
   , UTxOError(..)
   , UTxOValidationError(..)
+  , LovelaceError(..)
   , fromList
   , mkTxAux
   , mkTxPayload
@@ -72,7 +73,7 @@ import Cardano.Crypto
   (Hash, ProtocolMagicId, decodeHash, getProtocolMagicId, sign)
 
 import Test.Cardano.Chain.Common.Gen
-  (genAddress, genLovelace, genLovelaceError, genMerkleRoot, genNetworkMagic)
+  (genAddress, genLovelace, genMerkleRoot, genNetworkMagic)
 import Test.Cardano.Crypto.Gen
   ( genAbstractHash
   , genProtocolMagic
@@ -173,6 +174,16 @@ genTxValidationError = do
     , pure TxValidationUnknownAddressAttributes
     , pure TxValidationUnknownAttributes
     ]
+
+genLovelaceError :: Gen LovelaceError
+genLovelaceError =
+  uncurry LovelaceUnderflow <$> genUnderflowErrorValues
+ where
+  genUnderflowErrorValues :: Gen (Word64, Word64)
+  genUnderflowErrorValues = do
+    a <- Gen.word64 (Range.constant 0 (maxBound - 1))
+    b <- Gen.word64 (Range.constant a maxBound)
+    pure (a, b)
 
 genTxInWitness :: ProtocolMagicId -> Gen TxInWitness
 genTxInWitness pm = Gen.choice [genVKWitness pm, genRedeemWitness pm]

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
@@ -60,7 +60,6 @@ import Cardano.Chain.UTxO
   , UTxO
   , UTxOError(..)
   , UTxOValidationError(..)
-  , LovelaceError(..)
   , fromList
   , mkTxAux
   , mkTxPayload
@@ -159,7 +158,8 @@ genTxValidationError = do
   Gen.choice
     [ TxValidationLovelaceError
         <$> Gen.text (Range.constant 0 1000) Gen.alphaNum
-        <*> genLovelaceError
+        <*> Gen.word64 (Range.constant minBound maxBound)
+        <*> Gen.word64 (Range.constant minBound maxBound)
     , TxValidationFeeTooSmall <$> genTx <*> genLovelace <*> genLovelace
     , TxValidationWitnessWrongSignature
         <$> genTxInWitness pmi
@@ -174,16 +174,6 @@ genTxValidationError = do
     , pure TxValidationUnknownAddressAttributes
     , pure TxValidationUnknownAttributes
     ]
-
-genLovelaceError :: Gen LovelaceError
-genLovelaceError =
-  uncurry LovelaceUnderflow <$> genUnderflowErrorValues
- where
-  genUnderflowErrorValues :: Gen (Word64, Word64)
-  genUnderflowErrorValues = do
-    a <- Gen.word64 (Range.constant 0 (maxBound - 1))
-    b <- Gen.word64 (Range.constant a maxBound)
-    pure (a, b)
 
 genTxInWitness :: ProtocolMagicId -> Gen TxInWitness
 genTxInWitness pm = Gen.choice [genVKWitness pm, genRedeemWitness pm]

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Gen.hs
@@ -156,10 +156,7 @@ genTxValidationError = do
   let pmi = getProtocolMagicId pm
       nm  = makeNetworkMagic pm
   Gen.choice
-    [ TxValidationLovelaceError
-        <$> Gen.text (Range.constant 0 1000) Gen.alphaNum
-        <*> Gen.word64 (Range.constant minBound maxBound)
-        <*> Gen.word64 (Range.constant minBound maxBound)
+    [ TxValidationBalanceError <$> genLovelace <*> genLovelace
     , TxValidationFeeTooSmall <$> genTx <*> genLovelace <*> genLovelace
     , TxValidationWitnessWrongSignature
         <$> genTxInWitness pmi

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/ValidationMode.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/ValidationMode.hs
@@ -219,11 +219,9 @@ abstractTxFee txIdMap tfp aUtxo aTx = do
         aTxWits
       cLovelace = case tfp of
         TxFeePolicyTxSizeLinear txSizeLinear ->
-          either (panic . show)
-                  (\x -> x)
-                  (calculateTxSizeLinear
-                    txSizeLinear
-                    (fromIntegral $ BS.length txBytes))
+          calculateTxSizeLinear
+            txSizeLinear
+            (fromIntegral $ BS.length txBytes)
   Abstract.Lovelace (lovelaceToInteger cLovelace)
 
 elaborateTxId :: Map Abstract.TxId UTxO.TxId -> Abstract.TxId -> TxId

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/CBOR.hs
@@ -12,7 +12,7 @@ import Test.Cardano.Prelude
 import Hedgehog (Property)
 
 import Cardano.Binary (Raw(..))
-import Cardano.Chain.Common (LovelacePortion(..))
+import Cardano.Chain.Common (rationalToLovelacePortion)
 import Cardano.Chain.Update (ApplicationName(..), SoftforkRule(..))
 import Cardano.Crypto (Hash, abstractHash)
 
@@ -132,9 +132,9 @@ goldenSoftforkRule :: Property
 goldenSoftforkRule = goldenTestCBOR sfR "test/golden/cbor/update/SoftforkRule"
  where
   sfR = SoftforkRule
-    (LovelacePortion 99)
-    (LovelacePortion 99)
-    (LovelacePortion 99)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
 
 ts_roundTripSoftforkRule :: TSProperty
 ts_roundTripSoftforkRule = eachOfTS 10 genSoftforkRule roundTripsCBORBuildable

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
@@ -27,7 +27,8 @@ import qualified Data.Map.Strict as Map
 
 import Cardano.Binary (Raw(..))
 import Cardano.Chain.Common
-  (LovelacePortion(..), TxFeePolicy(..), TxSizeLinear(..), mkKnownLovelace)
+  ( mkKnownLovelace, rationalToLovelacePortion
+  , TxFeePolicy(..), TxSizeLinear(..) )
 import Cardano.Chain.Slotting (EpochNumber(..), SlotNumber(..))
 import Cardano.Chain.Update
   ( ApplicationName(..)
@@ -69,10 +70,10 @@ exampleProtocolParameters = ProtocolParameters
   (999 :: Natural)
   (999 :: Natural)
   (999 :: Natural)
-  (LovelacePortion 99)
-  (LovelacePortion 99)
-  (LovelacePortion 99)
-  (LovelacePortion 99)
+  (rationalToLovelacePortion 99e-15)
+  (rationalToLovelacePortion 99e-15)
+  (rationalToLovelacePortion 99e-15)
+  (rationalToLovelacePortion 99e-15)
   (SlotNumber 99)
   sfrule
   (TxFeePolicyTxSizeLinear tslin)
@@ -82,9 +83,9 @@ exampleProtocolParameters = ProtocolParameters
   c1'    = mkKnownLovelace @999
   c2'    = mkKnownLovelace @77
   sfrule = SoftforkRule
-    (LovelacePortion 99)
-    (LovelacePortion 99)
-    (LovelacePortion 99)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
 
 exampleProtocolParametersUpdate :: ProtocolParametersUpdate
 exampleProtocolParametersUpdate = ProtocolParametersUpdate
@@ -94,10 +95,10 @@ exampleProtocolParametersUpdate = ProtocolParametersUpdate
   (Just (999 :: Natural))
   (Just (999 :: Natural))
   (Just (999 :: Natural))
-  (Just $ LovelacePortion 99)
-  (Just $ LovelacePortion 99)
-  (Just $ LovelacePortion 99)
-  (Just $ LovelacePortion 99)
+  (Just $ rationalToLovelacePortion 99e-15)
+  (Just $ rationalToLovelacePortion 99e-15)
+  (Just $ rationalToLovelacePortion 99e-15)
+  (Just $ rationalToLovelacePortion 99e-15)
   (Just $ SlotNumber 99)
   (Just sfrule')
   (Just $ TxFeePolicyTxSizeLinear tslin')
@@ -107,9 +108,9 @@ exampleProtocolParametersUpdate = ProtocolParametersUpdate
   co1     = mkKnownLovelace @999
   co2     = mkKnownLovelace @77
   sfrule' = SoftforkRule
-    (LovelacePortion 99)
-    (LovelacePortion 99)
-    (LovelacePortion 99)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
+    (rationalToLovelacePortion 99e-15)
 
 exampleSystemTag :: SystemTag
 exampleSystemTag = exampleSystemTags 0 1 !! 0

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
@@ -27,7 +27,7 @@ import qualified Data.Map.Strict as Map
 
 import Cardano.Binary (Raw(..))
 import Cardano.Chain.Common
-  ( mkKnownLovelace, rationalToLovelacePortion
+  ( naturalToLovelace, rationalToLovelacePortion
   , TxFeePolicy(..), TxSizeLinear(..) )
 import Cardano.Chain.Slotting (EpochNumber(..), SlotNumber(..))
 import Cardano.Chain.Update
@@ -80,8 +80,8 @@ exampleProtocolParameters = ProtocolParameters
   (EpochNumber 99)
  where
   tslin  = TxSizeLinear c1' c2'
-  c1'    = mkKnownLovelace @999
-  c2'    = mkKnownLovelace @77
+  c1'    = naturalToLovelace 999
+  c2'    = naturalToLovelace 77
   sfrule = SoftforkRule
     (rationalToLovelacePortion 99e-15)
     (rationalToLovelacePortion 99e-15)
@@ -105,8 +105,8 @@ exampleProtocolParametersUpdate = ProtocolParametersUpdate
   (Just $ EpochNumber 99)
  where
   tslin'  = TxSizeLinear co1 co2
-  co1     = mkKnownLovelace @999
-  co2     = mkKnownLovelace @77
+  co1     = naturalToLovelace 999
+  co2     = naturalToLovelace 77
   sfrule' = SoftforkRule
     (rationalToLovelacePortion 99e-15)
     (rationalToLovelacePortion 99e-15)


### PR DESCRIPTION
The motivation is that by changing most of the arithmetic operations from being partial to total it simplifies `Lovelace` calculations in many places elsewhere in the code.

Also do a bunch of other cleaning and tidying.

This is still a draft because having changed the representation, we need to change the representation of a "compact" utxo entry to still use `Word64`, otherwise we'll inflate their size with the change to `Natural` (which cannot be unpacked since it's a two-constructor type). So that'll need another patch to adjust the compact utxo representation, and add a validation check that each tx output value is less than 2^64 so that the conversion is guaranteed (this should be a redundant check since the CBOR on-chain tx representation is already a word64).

This PR builds on #692, and should probably be re-targeted to `master` once that one is merged.