### PR TITLE
Update to latest versions of dependent repos

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,30 +11,30 @@ constraints:
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 7a8755b6988a9dd137f3f61a77c6d51e4eafa781
+  tag: 00487726c4bc21b4744e59d913334ebfeac7d68e
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 7a8755b6988a9dd137f3f61a77c6d51e4eafa781
+  tag: 00487726c4bc21b4744e59d913334ebfeac7d68e
   subdir: test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: d733bbc887d800c387b7ef4ed0a23225fca28d02
+  tag: 80deee31f8d9422b8e090e55b17e1a714153180b
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: d733bbc887d800c387b7ef4ed0a23225fca28d02
+  tag: 80deee31f8d9422b8e090e55b17e1a714153180b
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: d733bbc887d800c387b7ef4ed0a23225fca28d02
+  tag: 80deee31f8d9422b8e090e55b17e1a714153180b
   subdir: binary/test
 
 source-repository-package
@@ -45,26 +45,26 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6
+  tag: 607e37de698198c7f06c8f9d1c6628f8af4b4c51
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6
+  tag: 607e37de698198c7f06c8f9d1c6628f8af4b4c51
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6
+  tag: 607e37de698198c7f06c8f9d1c6628f8af4b4c51
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   contra-tracer
-  tag: a71addb2c45a8e116c2a57385b67812d51352a7a
+  tag: dbd932704fa4520bc24e45b2c00407c5f437c12a
 
 source-repository-package
   type: git

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/Model.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/Model.hs
@@ -161,7 +161,7 @@ ts_prop_generatedChainsAreValidated :: TSProperty
 ts_prop_generatedChainsAreValidated =
   withTestsTS 300  $ property $ do
     let (traceLength, step) = (200 :: Word64, 10 :: Word64)
-    tr <- forAll $ trace @CHAIN traceLength
+    tr <- forAll $ trace @CHAIN () traceLength
     classifyTraceLength tr traceLength step
     printAdditionalInfoOnFailure tr
     passConcreteValidation tr
@@ -305,7 +305,7 @@ invalidChainTracesAreRejected
 invalidChainTracesAreRejected numberOfTests failureProfile onFailureAgreement =
   withTestsTS numberOfTests $ property $ do
     let traceLength = 100 :: Word64
-    tr <- forAll $ invalidTrace @CHAIN traceLength failureProfile
+    tr <- forAll $ invalidTrace @CHAIN () traceLength failureProfile
     let ValidationOutput { elaboratedConfig, result } =
           applyTrace (Invalid.Trace.validPrefix tr)
     case result of
@@ -548,7 +548,7 @@ invalidSizesAreRejected
   concreteBlockComponentSize
   checkFailures =
   withTestsTS 300 $ property $ do
-  tr <- forAll $ trace @CHAIN 100 `ofLengthAtLeast` 1
+  tr <- forAll $ trace @CHAIN () 100 `ofLengthAtLeast` 1
   let
     ValidationOutput { elaboratedConfig, result } =
       applyTrace initTr

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/ValidationMode.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/ValidationMode.hs
@@ -82,7 +82,7 @@ ts_prop_updateBlock_Valid =
       let traceLength = 10 :: Word64 -- TODO: check that the @k@ value is not important
                            -- in this test, in that case we can get away with
                            -- generating small traces.
-      sampleTrace <- forAll $ trace @CHAIN traceLength
+      sampleTrace <- forAll $ trace @CHAIN () traceLength
       let
         lastState = Trace.lastState sampleTrace
         chainEnv@( _currentSlot
@@ -129,7 +129,7 @@ ts_prop_updateBlock_InvalidProof =
     . property
     $ do
       let traceLength = 10 :: Word64
-      sampleTrace <- forAll $ trace @CHAIN traceLength
+      sampleTrace <- forAll $ trace @CHAIN () traceLength
       let
         chainEnv@(_, abstractInitialUTxO, _, _, stableAfter) = Trace._traceEnv sampleTrace
         lastState = Trace.lastState sampleTrace

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Model.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Model.hs
@@ -51,7 +51,7 @@ tests = $$discoverPropArg
 ts_prop_generatedUTxOChainsAreValidated :: TSProperty
 ts_prop_generatedUTxOChainsAreValidated =
   withTestsTS 300 $ property $ do
-    tr <- forAll $ trace @UTXOW 500
+    tr <- forAll $ trace @UTXOW () 500
     classifyTraceLength tr 200 50
     passConcreteValidation tr
 

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "d733bbc887d800c387b7ef4ed0a23225fca28d02";
-      sha256 = "1ndwi2vmaaf0x2jlmyikrvjgxmqif7v4bcyfxz6d8lq0clzck96y";
+      rev = "80deee31f8d9422b8e090e55b17e1a714153180b";
+      sha256 = "0jzv074hc8kq0r0k47bw8hvziyi16mfyv5gcyngd1d0mbrc0j2k1";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "d733bbc887d800c387b7ef4ed0a23225fca28d02";
-      sha256 = "1ndwi2vmaaf0x2jlmyikrvjgxmqif7v4bcyfxz6d8lq0clzck96y";
+      rev = "80deee31f8d9422b8e090e55b17e1a714153180b";
+      sha256 = "0jzv074hc8kq0r0k47bw8hvziyi16mfyv5gcyngd1d0mbrc0j2k1";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -48,8 +48,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "d733bbc887d800c387b7ef4ed0a23225fca28d02";
-      sha256 = "1ndwi2vmaaf0x2jlmyikrvjgxmqif7v4bcyfxz6d8lq0clzck96y";
+      rev = "80deee31f8d9422b8e090e55b17e1a714153180b";
+      sha256 = "0jzv074hc8kq0r0k47bw8hvziyi16mfyv5gcyngd1d0mbrc0j2k1";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "7a8755b6988a9dd137f3f61a77c6d51e4eafa781";
-      sha256 = "1h5x2hmwh6ppxpf8h2papypzdl59x87xcldfi6v50q90zjnd0l1i";
+      rev = "00487726c4bc21b4744e59d913334ebfeac7d68e";
+      sha256 = "0v4fcq5kdd2r5dgwys8kv46ff33qp756n26ycxrca10wq14zkwm5";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -27,6 +27,7 @@
           (hsPkgs.containers)
           (hsPkgs.fingertree)
           (hsPkgs.formatting)
+          (hsPkgs.generic-deriving)
           (hsPkgs.ghc-heap)
           (hsPkgs.ghc-prim)
           (hsPkgs.hashable)
@@ -73,7 +74,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "7a8755b6988a9dd137f3f61a77c6d51e4eafa781";
-      sha256 = "1h5x2hmwh6ppxpf8h2papypzdl59x87xcldfi6v50q90zjnd0l1i";
+      rev = "00487726c4bc21b4744e59d913334ebfeac7d68e";
+      sha256 = "0v4fcq5kdd2r5dgwys8kv46ff33qp756n26ycxrca10wq14zkwm5";
       });
     }

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "a71addb2c45a8e116c2a57385b67812d51352a7a";
-      sha256 = "1a2ma0nkwb78pivc6s5xjnpsxdy569ql02psxns7r9p2g5xpfd9a";
+      rev = "dbd932704fa4520bc24e45b2c00407c5f437c12a";
+      sha256 = "03qml7bfhvs0spc6w3hlg215vjx9a2fhlhdbjh6w9m59gsl8mlg6";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-blockchain.nix
+++ b/nix/.stack.nix/cs-blockchain.nix
@@ -50,8 +50,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6";
-      sha256 = "06pgaabh8d330sra8060hplrhnkvlkm5iliz2sh76f3zvkbi918s";
+      rev = "607e37de698198c7f06c8f9d1c6628f8af4b4c51";
+      sha256 = "04a9kz985ygjahbk22y923wjliaw7xlaw4nmxij686ycyj306cs1";
       });
     postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -69,8 +69,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6";
-      sha256 = "06pgaabh8d330sra8060hplrhnkvlkm5iliz2sh76f3zvkbi918s";
+      rev = "607e37de698198c7f06c8f9d1c6628f8af4b4c51";
+      sha256 = "04a9kz985ygjahbk22y923wjliaw7xlaw4nmxij686ycyj306cs1";
       });
     postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -57,11 +57,13 @@
             (hsPkgs.base)
             (hsPkgs.containers)
             (hsPkgs.hedgehog)
+            (hsPkgs.mtl)
             (hsPkgs.tasty)
             (hsPkgs.tasty-hedgehog)
             (hsPkgs.tasty-expected-failure)
             (hsPkgs.QuickCheck)
             (hsPkgs.tasty-quickcheck)
+            (hsPkgs.tasty-hunit)
             (hsPkgs.Unique)
             (hsPkgs.cardano-crypto-class)
             (hsPkgs.cardano-binary)
@@ -73,8 +75,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6";
-      sha256 = "06pgaabh8d330sra8060hplrhnkvlkm5iliz2sh76f3zvkbi918s";
+      rev = "607e37de698198c7f06c8f9d1c6628f8af4b4c51";
+      sha256 = "04a9kz985ygjahbk22y923wjliaw7xlaw4nmxij686ycyj306cs1";
       });
     postUnpack = "sourceRoot+=/byron/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/7a8755b6988a9dd137f3f61a77c6d51e4eafa781/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/00487726c4bc21b4744e59d913334ebfeac7d68e/snapshot.yaml
 
 packages:
   - cardano-ledger
@@ -15,20 +15,20 @@ extra-deps:
   - generic-monoid-0.1.0.0
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 7a8755b6988a9dd137f3f61a77c6d51e4eafa781
+    commit: 00487726c4bc21b4744e59d913334ebfeac7d68e
     subdirs:
       - .
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: d733bbc887d800c387b7ef4ed0a23225fca28d02
+    commit: 80deee31f8d9422b8e090e55b17e1a714153180b
     subdirs:
       - binary
       - binary/test
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 203ec5b7ac22f8d44fc2d6a44ea1233962c2c0e6
+    commit: 607e37de698198c7f06c8f9d1c6628f8af4b4c51
     subdirs:
       - byron/semantics/executable-spec
       - byron/ledger/executable-spec
@@ -41,7 +41,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: a71addb2c45a8e116c2a57385b67812d51352a7a
+    commit: dbd932704fa4520bc24e45b2c00407c5f437c12a
     subdirs:
       - contra-tracer
 


### PR DESCRIPTION
A few code changes needed to be compatible with the latest version of `cardano-ledger-specs`.