### PR TITLE
Allow software updates to start from version 0 or 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ important files are:
 
 - `nix/regenerate.sh`, which generates `nix` expressions for all the Haskell
   dependencies in the Stack project
-  
+
 - `nix/update-iohk-nix.sh`, which updates the `iohk-nix-src.json` according to
 the latest version of [`iohk-nix`](https://github.com/input-output-hk/iohk-nix/)
 
@@ -241,6 +241,6 @@ There are a couple of common issues that developers run into while working with
 
 <p align="center">
   <a href="https://github.com/input-output-hk/cardano-wallet/blob/master/LICENSE">
-    <img src="https://img.shields.io/github/license/input-output-hk/cardano-wallet.svg?style=for-the-badge"/>
+    <img src="https://img.shields.io/github/license/input-output-hk/cardano-ledger?style=for-the-badge"/>
   </a>
 </p>

--- a/cabal.project
+++ b/cabal.project
@@ -45,19 +45,19 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 607e37de698198c7f06c8f9d1c6628f8af4b4c51
+  tag: 2aa807f4a4b6fd0ae0a511289586a2c2d18b56fb
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 607e37de698198c7f06c8f9d1c6628f8af4b4c51
+  tag: 2aa807f4a4b6fd0ae0a511289586a2c2d18b56fb
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 607e37de698198c7f06c8f9d1c6628f8af4b4c51
+  tag: 2aa807f4a4b6fd0ae0a511289586a2c2d18b56fb
   subdir: byron/chain/executable-spec
 
 source-repository-package

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Registration.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Registration.hs
@@ -435,10 +435,13 @@ registerSoftwareUpdate appVersions registeredSUPs proposal = do
 
 -- | Check that a new 'SoftwareVersion' is a valid next version
 --
---   The new version is valid for a given application if it is the same or one
+--   The new version is valid for a given application if it is exactly one
 --   more than the current version
 svCanFollow :: ApplicationVersions -> SoftwareVersion -> Bool
-svCanFollow avs softwareVersion = case M.lookup appName avs of
-  Nothing -> appVersion == 1
-  Just (currentAppVersion, _, _) -> appVersion == currentAppVersion + 1
-  where SoftwareVersion appName appVersion = softwareVersion
+svCanFollow avs (SoftwareVersion appName appVersion) =
+  case M.lookup appName avs of
+    -- For new apps, the version must start at 0 or 1.
+    Nothing -> appVersion == 0 || appVersion == 1
+
+    -- For existing apps, it must be exactly one more than the current version
+    Just (currentAppVersion, _, _) -> appVersion == currentAppVersion + 1

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Registration.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Registration.hs
@@ -68,6 +68,7 @@ import Cardano.Chain.Update.SoftwareVersion
   , SoftwareVersion(SoftwareVersion)
   , SoftwareVersionError
   , checkSoftwareVersion
+  , svAppName
   )
 import Cardano.Chain.Update.SystemTag (SystemTagError, checkSystemTag, SystemTag)
 import Cardano.Crypto
@@ -418,7 +419,7 @@ registerSoftwareUpdate appVersions registeredSUPs proposal = do
   mapM_ checkSystemTag (M.keys metadata) `wrapError` SystemTagError
 
   -- Check that this software version isn't already registered
-  null (M.filter ((== softwareVersion) . fst) registeredSUPs)
+  null (M.filter ((== svAppName softwareVersion) . svAppName . fst) registeredSUPs)
     `orThrowError` DuplicateSoftwareVersion softwareVersion
 
   -- Check that the software version is valid

--- a/nix/.stack.nix/cs-blockchain.nix
+++ b/nix/.stack.nix/cs-blockchain.nix
@@ -50,8 +50,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "607e37de698198c7f06c8f9d1c6628f8af4b4c51";
-      sha256 = "04a9kz985ygjahbk22y923wjliaw7xlaw4nmxij686ycyj306cs1";
+      rev = "2aa807f4a4b6fd0ae0a511289586a2c2d18b56fb";
+      sha256 = "0mb6r0sw1526m5cd4xjml8lc8vrjdql8plvfxhf9v6ifcv2218qz";
       });
     postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -69,8 +69,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "607e37de698198c7f06c8f9d1c6628f8af4b4c51";
-      sha256 = "04a9kz985ygjahbk22y923wjliaw7xlaw4nmxij686ycyj306cs1";
+      rev = "2aa807f4a4b6fd0ae0a511289586a2c2d18b56fb";
+      sha256 = "0mb6r0sw1526m5cd4xjml8lc8vrjdql8plvfxhf9v6ifcv2218qz";
       });
     postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -75,8 +75,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "607e37de698198c7f06c8f9d1c6628f8af4b4c51";
-      sha256 = "04a9kz985ygjahbk22y923wjliaw7xlaw4nmxij686ycyj306cs1";
+      rev = "2aa807f4a4b6fd0ae0a511289586a2c2d18b56fb";
+      sha256 = "0mb6r0sw1526m5cd4xjml8lc8vrjdql8plvfxhf9v6ifcv2218qz";
       });
     postUnpack = "sourceRoot+=/byron/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,7 +28,7 @@ extra-deps:
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 607e37de698198c7f06c8f9d1c6628f8af4b4c51
+    commit: 2aa807f4a4b6fd0ae0a511289586a2c2d18b56fb
     subdirs:
       - byron/semantics/executable-spec
       - byron/ledger/executable-spec


### PR DESCRIPTION
It does not really matter if application versions start from 0 or 1, and the old cardano-sl code allows both. An initial version 0 has been used on the public testnet (but not mainnet), and so it is useful to agree with the old cardano-sl and declare that to be valid.

Also update the comments for the function that does the validation of the versions. The existing comments says that we allow keeping the same version, but the existing code and the formal spec always require an increment of exactly 1. So we correct the comment.

TODO:
- [x] bring the formal and executable specs in line on the 0 vs 1 issue.