### PR TITLE
HasCallStack constraints

### DIFF
--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -261,7 +261,8 @@ annotateBlock epochSlots block =
 -- We need to do this because the delegation certificate is included in the
 -- block.
 rcDCert
-  :: Abstract.VKey
+  :: HasCallStack
+  => Abstract.VKey
   -- ^ Key for which the delegation certificate is being constructed.
   -> Abstract.BlockCount
   -- ^ Chain stability parameter


### PR DESCRIPTION
Both `sEpoch` and `rcDCert` itself can throw errors, and it's easier to track those down with a callstack.