### PR TITLE
Add generic `ToJSON` instances 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -22,19 +22,19 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 965b8b143632faea16680a195e6de57091382700
+  tag: 4f24cf8d6686ac764c6ddbc188c88d9296497a50
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 965b8b143632faea16680a195e6de57091382700
+  tag: 4f24cf8d6686ac764c6ddbc188c88d9296497a50
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 965b8b143632faea16680a195e6de57091382700
+  tag: 4f24cf8d6686ac764c6ddbc188c88d9296497a50
   subdir: binary/test
 
 source-repository-package

--- a/cardano-ledger/cardano-ledger.cabal
+++ b/cardano-ledger/cardano-ledger.cabal
@@ -127,6 +127,7 @@ library
                        Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
 
   build-depends:       base >=4.11 && <5
+                     , aeson
                      , base58-bytestring
                      , base64-bytestring-type
                      , bimap >=0.4 && <0.5

--- a/cardano-ledger/src/Cardano/Chain/Block/Block.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Block.hs
@@ -77,7 +77,9 @@ module Cardano.Chain.Block.Block
 where
 
 import Cardano.Prelude
+
 import Control.Monad.Fail (fail)
+import Data.Aeson (ToJSON)
 import qualified Data.ByteString as BS
 import Data.Text.Lazy.Builder (Builder, fromText)
 import Formatting (bprint, build, int, later, shown)
@@ -166,6 +168,8 @@ data ABlock a = ABlock
   , blockAnnotation :: a
   } deriving (Eq, Show, Generic, NFData, Functor)
 
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (ABlock a) where
 
 --------------------------------------------------------------------------------
 -- Block Constructors
@@ -355,7 +359,10 @@ renderBlock es block =
 data ABlockOrBoundary a
   = ABOBBlock (ABlock a)
   | ABOBBoundary (ABoundaryBlock a)
-  deriving (Eq, Show, Functor)
+  deriving (Eq, Generic, Show, Functor)
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (ABlockOrBoundary a) where
 
 -- | Encode a 'Block' accounting for deprecated epoch boundary blocks
 toCBORABOBBlock :: EpochSlots -> ABlock a -> Encoding
@@ -408,11 +415,14 @@ toCBORABlockOrBoundary pm epochSlots abob = case abob of
 -- extra body data.
 data ABoundaryBody a = ABoundaryBody
   { boundaryBodyAnnotation :: !a
-  } deriving (Eq, Show, Functor)
+  } deriving (Eq, Generic, Show, Functor)
 
 instance Decoded (ABoundaryBody ByteString) where
   type BaseType (ABoundaryBody ByteString) = ABoundaryBody ()
   recoverBytes = boundaryBodyAnnotation
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (ABoundaryBody a) where
 
 fromCBORABoundaryBody :: Decoder s (ABoundaryBody ByteSpan)
 fromCBORABoundaryBody = do
@@ -437,11 +447,14 @@ data ABoundaryBlock a = ABoundaryBlock
   , boundaryHeader          :: !(ABoundaryHeader a)
   , boundaryBody            :: !(ABoundaryBody a)
   , boundaryAnnotation      :: !a
-  } deriving (Eq, Show, Functor)
+  } deriving (Eq, Generic, Show, Functor)
 
 instance Decoded (ABoundaryBlock ByteString) where
   type BaseType (ABoundaryBlock ByteString) = ABoundaryBlock ()
   recoverBytes = boundaryAnnotation
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (ABoundaryBlock a) where
 
 -- | Extract the hash of a boundary block from its annotation.
 boundaryHashAnnotated :: ABoundaryBlock ByteString -> HeaderHash

--- a/cardano-ledger/src/Cardano/Chain/Block/Body.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Body.hs
@@ -18,6 +18,8 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
+
 import Cardano.Binary
   (ByteSpan, FromCBOR(..), ToCBOR(..), encodeListLen, enforceSize)
 import qualified Cardano.Chain.Delegation.Payload as Delegation
@@ -45,6 +47,9 @@ data ABody a = ABody
   , bodyUpdatePayload :: !(Update.APayload a)
   -- ^ Additional update information for the update system
   } deriving (Eq, Show, Generic, Functor, NFData)
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (ABody a) where
 
 instance ToCBOR Body where
   toCBOR bc =

--- a/cardano-ledger/src/Cardano/Chain/Block/Header.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Header.hs
@@ -70,6 +70,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import qualified Data.ByteString as BS
 import Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map (singleton)
@@ -157,6 +158,8 @@ data AHeader a = AHeader
   -- ^ An annotation that captures the bytes from the deprecated ExtraHeaderData
   } deriving (Eq, Show, Generic, NFData, Functor, NoUnexpectedThunks)
 
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (AHeader a) where
 
 --------------------------------------------------------------------------------
 -- Header Constructors
@@ -452,6 +455,9 @@ data ABoundaryHeader a = UnsafeABoundaryHeader
   , boundaryHeaderAnnotation :: !a
   } deriving (Eq, Show, Functor, Generic, NoUnexpectedThunks)
 
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (ABoundaryHeader a) where
+
 -- | Smart constructor for 'ABoundaryHeader'
 --
 -- Makes sure that the hash is forced.
@@ -557,6 +563,9 @@ instance B.Buildable BlockSignature where
     . "  Delegation certificate: " . build
     )
     cert
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (ABlockSignature a) where
 
 instance ToCBOR BlockSignature where
   toCBOR (ABlockSignature cert sig) =

--- a/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
@@ -13,6 +13,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Formatting (bprint, build, shown)
 import qualified Formatting.Buildable as B
 
@@ -41,6 +42,9 @@ instance B.Buildable Proof where
     (proofSsc proof)
     (proofDelegation proof)
     (proofUpdate proof)
+
+-- Used for debugging purposes only
+instance ToJSON Proof where
 
 instance ToCBOR Proof where
   toCBOR bc =

--- a/cardano-ledger/src/Cardano/Chain/Common/AddrAttributes.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/AddrAttributes.hs
@@ -13,6 +13,8 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON(..), object, (.=))
+import qualified Data.ByteString.Char8 as Char8
 import Data.Text.Lazy.Builder (Builder)
 import Formatting (bprint, builder)
 import qualified Formatting.Buildable as B
@@ -53,6 +55,9 @@ instance B.Buildable AddrAttributes where
     derivationPathBuilder = case aaVKDerivationPath aa of
       Nothing -> "{}"
       Just _  -> "{path is encrypted}"
+
+-- Used for debugging purposes only
+instance ToJSON AddrAttributes where
 
 {- NOTE: Address attributes serialization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -141,6 +146,9 @@ newtype HDAddressPayload = HDAddressPayload
     deriving newtype (ToCBOR, HeapWords)
     deriving anyclass (NFData, NoUnexpectedThunks)
 
+-- Used for debugging purposes only
+instance ToJSON HDAddressPayload where
+  toJSON (HDAddressPayload bs) = object ["HDAddressPayload" .= Char8.unpack bs]
+
 instance FromCBOR HDAddressPayload where
   fromCBOR = HDAddressPayload <$> decodeBytesCanonical
-

--- a/cardano-ledger/src/Cardano/Chain/Common/AddrSpendingData.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/AddrSpendingData.hs
@@ -14,6 +14,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
@@ -77,6 +78,9 @@ data AddrType
   | ATRedeem
   deriving (Eq, Ord, Generic, Show)
   deriving anyclass (NFData, NoUnexpectedThunks)
+
+-- Used for debugging purposes only
+instance ToJSON AddrType where
 
 -- Tag 1 was previously used for scripts, but never appeared on the chain
 instance ToCBOR AddrType where

--- a/cardano-ledger/src/Cardano/Chain/Common/Address.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Address.hs
@@ -53,6 +53,7 @@ import Cardano.Prelude
 import qualified Data.ByteArray
 
 import Control.Monad.Except (MonadError)
+import qualified Data.Aeson as Aeson
 import Data.ByteString.Base58
   (Alphabet(..), bitcoinAlphabet, decodeBase58, encodeBase58)
 import Data.Text.Internal.Builder (Builder)
@@ -125,6 +126,9 @@ data Address = Address
   -- spending data is hashed.
   } deriving (Eq, Ord, Generic, Show)
     deriving anyclass (NFData, NoUnexpectedThunks)
+
+-- Used for debugging purposes only
+instance Aeson.ToJSON Address where
 
 instance ToCBOR Address where
   toCBOR addr =

--- a/cardano-ledger/src/Cardano/Chain/Common/Attributes.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Attributes.hs
@@ -30,7 +30,9 @@ where
 import Cardano.Prelude
 import qualified Prelude
 
+import Data.Aeson (ToJSON(..))
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy.Char8 as LChar8
 import qualified Data.Map.Strict as M
 import Formatting (bprint, build, int)
 import Formatting.Buildable (Buildable)
@@ -49,7 +51,6 @@ import Cardano.Binary
   , dropWord8
   )
 
-
 -- | Representation of unparsed fields in Attributes. Newtype wrapper is used
 --   for clear backward compatibility between previous representation (which was
 --   just a single ByteString) during transition from Store to CBOR.
@@ -58,6 +59,11 @@ newtype UnparsedFields =
   deriving (Eq, Ord, Show, Generic)
   deriving newtype HeapWords
   deriving anyclass (NFData, NoUnexpectedThunks)
+
+-- Used for debugging purposes only
+instance ToJSON UnparsedFields where
+    toJSON (UnparsedFields map') = toJSON $ M.map LChar8.unpack map'
+
 
 fromUnparsedFields :: UnparsedFields -> Map Word8 LBS.ByteString
 fromUnparsedFields (UnparsedFields m) = m
@@ -102,6 +108,9 @@ instance Buildable (Attributes ()) where
     | otherwise = bprint
       ("Attributes { data: (), remain: <" . int . " bytes> }")
       (unknownAttributesLength attr)
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (Attributes a) where
 
 instance ToCBOR (Attributes ()) where
   toCBOR = toCBORAttributes []

--- a/cardano-ledger/src/Cardano/Chain/Common/ChainDifficulty.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/ChainDifficulty.hs
@@ -11,6 +11,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Formatting.Buildable (Buildable)
 
 import Cardano.Binary
@@ -22,6 +23,9 @@ import Cardano.Binary
 newtype ChainDifficulty = ChainDifficulty
   { unChainDifficulty :: Word64
   } deriving (Show, Eq, Ord, Enum, Generic, Buildable, NFData, NoUnexpectedThunks)
+
+-- Used for debugging purposes only
+instance ToJSON ChainDifficulty where
 
 instance ToCBOR ChainDifficulty where
     toCBOR cd = encodeListLen 1 <> toCBOR (unChainDifficulty cd)

--- a/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Lovelace.hs
@@ -51,6 +51,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Data.Data (Data)
 import Formatting (Format, bprint, build, int, sformat)
 import qualified Formatting.Buildable as B
@@ -80,6 +81,9 @@ instance B.Buildable Lovelace where
 instance Bounded Lovelace where
   minBound = Lovelace 0
   maxBound = Lovelace maxLovelaceVal
+
+-- Used for debugging purposes only
+instance ToJSON Lovelace where
 
 instance ToCBOR Lovelace where
   toCBOR = toCBOR . unsafeGetLovelace

--- a/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -15,6 +15,7 @@ where
 
 import Cardano.Prelude
 
+import qualified Data.Aeson as Aeson
 import Control.Monad (fail)
 import Control.Monad.Except (MonadError(..))
 import Formatting (sformat, build, bprint, float, int)
@@ -52,6 +53,9 @@ instance B.Buildable LovelacePortion where
     x
     lovelacePortionDenominator
     (fromRational (lovelacePortionToRational cp) :: Double)
+
+-- Used for debugging purposes only
+instance Aeson.ToJSON LovelacePortion where
 
 instance ToCBOR LovelacePortion where
   toCBOR = toCBOR . getLovelacePortion
@@ -97,4 +101,3 @@ rationalToLovelacePortion r
 lovelacePortionToRational :: LovelacePortion -> Rational
 lovelacePortionToRational (LovelacePortion n) =
   toInteger n % toInteger lovelacePortionDenominator
-

--- a/cardano-ledger/src/Cardano/Chain/Common/Merkle.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Merkle.hs
@@ -38,6 +38,7 @@ where
 -- what's going on.
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Data.Bits (Bits(..))
 import Data.ByteArray (ByteArrayAccess, convert)
 import Data.ByteString.Builder (Builder, byteString, word8)
@@ -66,6 +67,9 @@ newtype MerkleRoot a = MerkleRoot
 
 instance Buildable (MerkleRoot a) where
   build (MerkleRoot h) = "MerkleRoot|" <> build h
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (MerkleRoot a) where
 
 instance ToCBOR a => ToCBOR (MerkleRoot a) where
   toCBOR = toCBOR . getMerkleRoot

--- a/cardano-ledger/src/Cardano/Chain/Common/NetworkMagic.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/NetworkMagic.hs
@@ -11,6 +11,7 @@ module Cardano.Chain.Common.NetworkMagic
 
 import Cardano.Prelude hiding ((%))
 
+import           Data.Aeson (ToJSON)
 import           Formatting (bprint, build, (%))
 import qualified Formatting.Buildable as B
 
@@ -32,6 +33,9 @@ data NetworkMagic
 instance B.Buildable NetworkMagic where
     build NetworkMainOrStage = "NetworkMainOrStage"
     build (NetworkTestnet n) = bprint ("NetworkTestnet ("%build%")") n
+
+-- Used for debugging purposes only
+instance ToJSON NetworkMagic where
 
 instance HeapWords NetworkMagic where
   heapWords NetworkMainOrStage = 0

--- a/cardano-ledger/src/Cardano/Chain/Common/TxFeePolicy.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/TxFeePolicy.hs
@@ -19,6 +19,7 @@ where
 import Cardano.Prelude
 
 import Control.Monad.Except (MonadError)
+import qualified Data.Aeson as Aeson
 import Formatting (bprint, build, formatToString)
 import qualified Formatting.Buildable as B
 import Text.JSON.Canonical
@@ -61,6 +62,9 @@ data TxFeePolicy
 instance B.Buildable TxFeePolicy where
     build (TxFeePolicyTxSizeLinear tsp) =
         bprint ("policy(tx-size-linear): ".build) tsp
+
+-- Used for debugging purposes only
+instance Aeson.ToJSON TxFeePolicy where
 
 instance ToCBOR TxFeePolicy where
     toCBOR policy = case policy of

--- a/cardano-ledger/src/Cardano/Chain/Common/TxSizeLinear.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/TxSizeLinear.hs
@@ -14,6 +14,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Data.Fixed (Nano)
 import Formatting (bprint, build, sformat)
 import qualified Formatting.Buildable as B
@@ -46,6 +47,9 @@ data TxSizeLinear =
 
 instance B.Buildable TxSizeLinear where
   build (TxSizeLinear a b) = bprint (build . " + " . build . "*s") a b
+
+-- Used for debugging purposes only
+instance ToJSON TxSizeLinear where
 
 instance ToCBOR TxSizeLinear where
   -- We encode as 'Nano' for backwards compatibility

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
@@ -37,6 +37,7 @@ where
 import Cardano.Prelude
 
 import qualified Cardano.Crypto.Wallet as CC
+import qualified Data.Aeson as Aeson
 import Data.Coerce (coerce)
 import Formatting (bprint, build)
 import qualified Formatting.Buildable as B
@@ -99,6 +100,8 @@ data ACertificate a = UnsafeACertificate
   } deriving (Eq, Ord, Show, Generic, Functor)
     deriving anyclass (NFData, NoUnexpectedThunks)
 
+-- Used for debugging purposes only
+instance Aeson.ToJSON a => Aeson.ToJSON (ACertificate a) where
 
 --------------------------------------------------------------------------------
 -- Certificate Constructors

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Payload.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Payload.hs
@@ -17,6 +17,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Formatting (bprint, int)
 import Formatting.Buildable (Buildable(..))
 
@@ -52,6 +53,9 @@ instance Buildable (APayload a) where
     ("proxy signing keys (" . int . " items): " . listJson . "\n")
     (length psks)
     psks
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (APayload a) where
 
 instance ToCBOR Payload where
   toCBOR = toCBOR . getPayload

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Hash.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Hash.hs
@@ -10,6 +10,7 @@ module Cardano.Chain.Genesis.Hash
 where
 
 import Control.DeepSeq (NFData)
+import Data.Aeson (ToJSON)
 
 import Cardano.Prelude
 
@@ -21,3 +22,6 @@ newtype GenesisHash = GenesisHash
   } deriving (Eq, Generic, NFData, FromCBOR, ToCBOR, NoUnexpectedThunks)
 
 deriving instance Show GenesisHash
+
+-- Used for debugging purposes only
+instance ToJSON GenesisHash where

--- a/cardano-ledger/src/Cardano/Chain/Slotting/EpochNumber.hs
+++ b/cardano-ledger/src/Cardano/Chain/Slotting/EpochNumber.hs
@@ -17,6 +17,7 @@ where
 import Cardano.Prelude
 
 import Control.Monad.Except (MonadError)
+import qualified Data.Aeson as Aeson
 import Data.Data (Data)
 import Data.Ix (Ix)
 import Formatting (bprint, int)
@@ -46,6 +47,9 @@ newtype EpochNumber = EpochNumber
 
 instance Buildable EpochNumber where
   build = bprint ("#" . int)
+
+-- Used for debugging purposes only
+instance Aeson.ToJSON EpochNumber where
 
 instance ToCBOR EpochNumber where
   toCBOR (EpochNumber epoch) = toCBOR epoch

--- a/cardano-ledger/src/Cardano/Chain/Slotting/SlotNumber.hs
+++ b/cardano-ledger/src/Cardano/Chain/Slotting/SlotNumber.hs
@@ -16,6 +16,7 @@ where
 
 import Cardano.Prelude
 
+import qualified Data.Aeson as Aeson
 import Formatting (bprint, int)
 import qualified Formatting.Buildable as B
 import Text.JSON.Canonical (FromJSON(..), ToJSON(..))
@@ -33,6 +34,10 @@ newtype SlotNumber = SlotNumber
   } deriving (Eq, Generic, Ord, Show)
     deriving newtype Num
     deriving anyclass (NFData, NoUnexpectedThunks)
+
+
+-- Used for debugging purposes only
+instance Aeson.ToJSON SlotNumber where
 
 instance ToCBOR SlotNumber where
   toCBOR = toCBOR . unSlotNumber

--- a/cardano-ledger/src/Cardano/Chain/Ssc.hs
+++ b/cardano-ledger/src/Cardano/Chain/Ssc.hs
@@ -21,6 +21,8 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
+
 import Cardano.Binary
   ( DecoderError(..)
   , Dropper
@@ -47,6 +49,9 @@ import qualified Data.ByteString as ByteString (pack)
 data SscPayload =
   SscPayload
   deriving (Eq, Show, Generic, NFData)
+
+-- Used for debugging purposes only
+instance ToJSON SscPayload where
 
 instance ToCBOR SscPayload where
   toCBOR _ = encodeListLen 2
@@ -87,6 +92,9 @@ dropSscPayload = do
 data SscProof =
   SscProof
   deriving (Eq, Show, Generic, NFData, NoUnexpectedThunks)
+
+-- Used for debugging purposes only
+instance ToJSON SscProof where
 
 instance ToCBOR SscProof where
   toCBOR _ =

--- a/cardano-ledger/src/Cardano/Chain/UTxO/Tx.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/Tx.hs
@@ -18,6 +18,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Formatting (Format, bprint, build, builder, int)
 import qualified Formatting.Buildable as B
 
@@ -78,6 +79,9 @@ instance B.Buildable Tx where
       | attributesAreKnown attrs = mempty
       | otherwise                = bprint (", attributes: " . build) attrs
 
+-- Used for debugging purposes only
+instance ToJSON Tx where
+
 instance ToCBOR Tx where
   toCBOR tx =
     encodeListLen 3 <> toCBOR (txInputs tx) <> toCBOR (txOutputs tx) <> toCBOR
@@ -131,6 +135,9 @@ instance B.Buildable TxIn where
   build (TxInUtxo txInHash txInIndex) =
     bprint ("TxInUtxo " . shortHashF . " #" . int) txInHash txInIndex
 
+-- Used for debugging purposes only
+instance ToJSON TxIn where
+
 instance ToCBOR TxIn where
   toCBOR (TxInUtxo txInHash txInIndex) =
     encodeListLen 2 <> toCBOR (0 :: Word8) <> encodeKnownCborDataItem
@@ -168,6 +175,9 @@ instance B.Buildable TxOut where
     (txOutValue txOut)
     (txOutAddress txOut)
 
+-- Used for debugging purposes only
+instance ToJSON TxOut where
+
 instance ToCBOR TxOut where
   toCBOR txOut =
     encodeListLen 2 <> toCBOR (txOutAddress txOut) <> toCBOR (txOutValue txOut)
@@ -182,4 +192,3 @@ instance FromCBOR TxOut where
 
 instance HeapWords TxOut where
   heapWords (TxOut address _) = 3 + heapWords address
-

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxAux.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxAux.hs
@@ -22,6 +22,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import qualified Data.ByteString.Lazy as Lazy
 import Formatting (Format, bprint, build, later)
 import qualified Formatting.Buildable as B
@@ -66,6 +67,9 @@ data ATxAux a = ATxAux
 instance Decoded (ATxAux ByteString) where
   type BaseType (ATxAux ByteString) = ATxAux ()
   recoverBytes = aTaAnnotation
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (ATxAux a) where
 
 taTx :: ATxAux a -> Tx
 taTx = unAnnotated . aTaTx

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxPayload.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxPayload.hs
@@ -21,6 +21,8 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
+
 import Cardano.Binary (Annotated(..), ByteSpan, FromCBOR(..), ToCBOR(..))
 import Cardano.Chain.UTxO.Tx (Tx)
 import Cardano.Chain.UTxO.TxAux (ATxAux(..), TxAux, taTx, taWitness)
@@ -40,6 +42,9 @@ newtype ATxPayload a = ATxPayload
 
 unTxPayload :: ATxPayload a -> [TxAux]
 unTxPayload = fmap void . aUnTxPayload
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (ATxPayload a) where
 
 instance ToCBOR TxPayload where
   toCBOR = toCBOR . unTxPayload

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxProof.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxProof.hs
@@ -12,6 +12,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
@@ -37,6 +38,9 @@ data TxProof = TxProof
   , txpWitnessesHash :: !(Hash [TxWitness])
   } deriving (Show, Eq, Generic, NoUnexpectedThunks)
     deriving anyclass NFData
+
+-- Used for debugging purposes only
+instance ToJSON TxProof where
 
 instance B.Buildable TxProof where
   build proof = bprint

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxWitness.hs
@@ -18,6 +18,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Data.Vector (Vector)
 import Formatting (bprint, build)
 import qualified Formatting.Buildable as B
@@ -78,6 +79,9 @@ instance B.Buildable TxInWitness where
   build (RedeemWitness key sig) =
     bprint ("VKWitness: key = " . build . ", sig = " . build) key sig
 
+-- Used for debugging purposes only
+instance ToJSON TxInWitness where
+
 instance ToCBOR TxInWitness where
   toCBOR input = case input of
     VKWitness key sig ->
@@ -123,6 +127,9 @@ recoverSigData atx =
     signedBytes = serialize' txHash --TODO: make the prefix bytes explicit
   in Annotated (TxSigData txHash) signedBytes
 
+-- Used for debugging purposes only
+instance ToJSON TxSigData where
+
 instance ToCBOR TxSigData where
   toCBOR txSigData = toCBOR (txSigTxHash txSigData)
   encodedSizeExpr size pxy = size (txSigTxHash <$> pxy)
@@ -132,4 +139,3 @@ instance FromCBOR TxSigData where
 
 -- | 'Signature' of addrId
 type TxSig = Signature TxSigData
-

--- a/cardano-ledger/src/Cardano/Chain/Update/ApplicationName.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/ApplicationName.hs
@@ -17,6 +17,7 @@ where
 import Cardano.Prelude
 
 import Control.Monad.Except (MonadError(throwError))
+import Data.Aeson (ToJSON)
 import Data.Char (isAscii)
 import Data.Data (Data)
 import qualified Data.Text as T
@@ -49,6 +50,9 @@ data ApplicationNameError
   = ApplicationNameTooLong Text
   | ApplicationNameNotAscii Text
   deriving (Data, Eq, Show)
+
+-- Used for debugging purposes only
+instance ToJSON ApplicationName where
 
 instance ToCBOR ApplicationNameError where
   toCBOR err = case err of

--- a/cardano-ledger/src/Cardano/Chain/Update/InstallerHash.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/InstallerHash.hs
@@ -10,6 +10,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Formatting (bprint, build)
 import qualified Formatting.Buildable as B
 
@@ -32,6 +33,9 @@ newtype InstallerHash = InstallerHash
 
 instance B.Buildable InstallerHash where
   build (InstallerHash h) = bprint ("{ installer hash: " . build . " }") h
+
+-- Used for debugging purposes only
+instance ToJSON InstallerHash where
 
 instance ToCBOR InstallerHash where
   toCBOR (InstallerHash h) =

--- a/cardano-ledger/src/Cardano/Chain/Update/Payload.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Payload.hs
@@ -17,6 +17,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Formatting (bprint)
 import qualified Formatting.Buildable as B
 
@@ -67,6 +68,9 @@ instance B.Buildable Payload where
     = formatMaybeProposal (payloadProposal p) <> bprint
       ("\n    votes: " . listJson)
       (map formatVoteShort (payloadVotes p))
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (APayload a) where
 
 instance ToCBOR Payload where
   toCBOR p =

--- a/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
@@ -37,6 +37,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import qualified Data.Map.Strict as M
 import Data.Text.Lazy.Builder (Builder)
 import Formatting (bprint, build)
@@ -91,6 +92,8 @@ data AProposal a = AProposal
 
 type Proposal = AProposal ()
 
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (AProposal a) where
 
 --------------------------------------------------------------------------------
 -- Proposal Constructors
@@ -216,6 +219,8 @@ data ProposalBody = ProposalBody
   } deriving (Eq, Show, Generic)
     deriving anyclass NFData
 
+-- Used for debugging purposes only
+instance ToJSON ProposalBody where
 
 --------------------------------------------------------------------------------
 -- ProposalBody Binary Serialization

--- a/cardano-ledger/src/Cardano/Chain/Update/ProtocolParametersUpdate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/ProtocolParametersUpdate.hs
@@ -14,6 +14,7 @@ where
 
 import Cardano.Prelude hiding (empty)
 
+import Data.Aeson (ToJSON)
 import Data.Text.Lazy.Builder (Builder)
 import Formatting (Format, bprint, build, bytes, later, shortest)
 import qualified Formatting.Buildable as B
@@ -82,6 +83,9 @@ instance B.Buildable ProtocolParametersUpdate where
 
     bytes' :: Format r (Natural -> r)
     bytes' = bytes (shortest @Double)
+
+-- Used for debugging purposes only
+instance ToJSON ProtocolParametersUpdate where
 
 instance ToCBOR ProtocolParametersUpdate where
   toCBOR ppu =

--- a/cardano-ledger/src/Cardano/Chain/Update/ProtocolVersion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/ProtocolVersion.hs
@@ -11,6 +11,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Formatting (bprint, shown)
 import Formatting.Buildable (Buildable(..))
 import qualified Prelude
@@ -32,6 +33,9 @@ instance Show ProtocolVersion where
 
 instance Buildable ProtocolVersion where
   build = bprint shown
+
+-- Used for debugging purposes only
+instance ToJSON ProtocolVersion where
 
 instance ToCBOR ProtocolVersion where
   toCBOR pv =

--- a/cardano-ledger/src/Cardano/Chain/Update/SoftforkRule.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/SoftforkRule.hs
@@ -15,6 +15,7 @@ where
 
 import Cardano.Prelude
 
+import qualified Data.Aeson as Aeson
 import Control.Monad.Except (MonadError)
 import Formatting (bprint, build)
 import qualified Formatting.Buildable as B
@@ -49,6 +50,9 @@ instance B.Buildable SoftforkRule where
     (srInitThd sr)
     (srMinThd sr)
     (srThdDecrement sr)
+
+-- Used for debugging purposes only
+instance Aeson.ToJSON SoftforkRule where
 
 instance ToCBOR SoftforkRule where
   toCBOR sr =

--- a/cardano-ledger/src/Cardano/Chain/Update/SoftwareVersion.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/SoftwareVersion.hs
@@ -19,6 +19,7 @@ import Cardano.Prelude
 import qualified Prelude
 
 import Control.Monad.Except (MonadError)
+import Data.Aeson (ToJSON)
 import Data.Data (Data)
 import Formatting (bprint, build, formatToString, int, stext)
 import qualified Formatting.Buildable as B (Buildable(..))
@@ -50,6 +51,9 @@ instance B.Buildable SoftwareVersion where
 
 instance Show SoftwareVersion where
   show = formatToString build
+
+-- Used for debugging purposes only
+instance ToJSON SoftwareVersion where
 
 instance ToCBOR SoftwareVersion where
   toCBOR sv = encodeListLen 2 <> toCBOR (svAppName sv) <> toCBOR (svNumber sv)

--- a/cardano-ledger/src/Cardano/Chain/Update/SystemTag.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/SystemTag.hs
@@ -22,6 +22,7 @@ where
 import Cardano.Prelude
 
 import Control.Monad.Except (MonadError(throwError))
+import Data.Aeson (ToJSON, ToJSONKey)
 import Data.Char (isAscii)
 import Data.Data (Data)
 import qualified Data.Text as T
@@ -48,6 +49,12 @@ newtype SystemTag = SystemTag
   } deriving (Eq, Ord, Show, Generic)
     deriving newtype B.Buildable
     deriving anyclass (NFData, NoUnexpectedThunks)
+
+-- Used for debugging purposes only
+instance ToJSON SystemTag where
+
+-- Used for debugging purposes only
+instance ToJSONKey SystemTag where
 
 instance ToCBOR SystemTag where
   toCBOR = toCBOR . getSystemTag

--- a/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
@@ -38,6 +38,7 @@ where
 
 import Cardano.Prelude
 
+import Data.Aeson (ToJSON)
 import Data.Text.Lazy.Builder (Builder)
 import Formatting (Format, bprint, build, later)
 import qualified Formatting.Buildable as B
@@ -96,6 +97,9 @@ data AVote a = UnsafeVote
   , annotation  :: !a
   } deriving (Eq, Show, Generic, Functor)
     deriving anyclass NFData
+
+-- Used for debugging purposes only
+instance ToJSON a => ToJSON (AVote a) where
 
 
 --------------------------------------------------------------------------------

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "965b8b143632faea16680a195e6de57091382700";
-      sha256 = "0x3cy5xa9mqdqnavs45assmmcrzw07qcwsv95capqwa6awz1plhh";
+      rev = "4f24cf8d6686ac764c6ddbc188c88d9296497a50";
+      sha256 = "1ydv47r7b6vhmjxhr71111sbrpbn3mz0fp5266l4ngr8ca1f8i06";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -4,7 +4,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-binary"; version = "1.5.0"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK";
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "965b8b143632faea16680a195e6de57091382700";
-      sha256 = "0x3cy5xa9mqdqnavs45assmmcrzw07qcwsv95capqwa6awz1plhh";
+      rev = "4f24cf8d6686ac764c6ddbc188c88d9296497a50";
+      sha256 = "1ydv47r7b6vhmjxhr71111sbrpbn3mz0fp5266l4ngr8ca1f8i06";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -4,7 +4,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-crypto-class"; version = "2.0.0"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK";
@@ -48,8 +48,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "965b8b143632faea16680a195e6de57091382700";
-      sha256 = "0x3cy5xa9mqdqnavs45assmmcrzw07qcwsv95capqwa6awz1plhh";
+      rev = "4f24cf8d6686ac764c6ddbc188c88d9296497a50";
+      sha256 = "1ydv47r7b6vhmjxhr71111sbrpbn3mz0fp5266l4ngr8ca1f8i06";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -18,6 +18,7 @@
       "library" = {
         depends = [
           (hsPkgs.base)
+          (hsPkgs.aeson)
           (hsPkgs.base58-bytestring)
           (hsPkgs.base64-bytestring-type)
           (hsPkgs.bimap)

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ extra-deps:
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 965b8b143632faea16680a195e6de57091382700
+    commit: 4f24cf8d6686ac764c6ddbc188c88d9296497a50
     subdirs:
       - binary
       - binary/test


### PR DESCRIPTION
Generic `ToJSON` instances have been added to debug blocks, txs, delegation certificates and update proposals. These instances are necessary when decoding `CBOR` files and re-encoding the resulting haskell types as `JSON`.