### PR TITLE
Fix space leak in cvsPreviousHash

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Validation.hs
@@ -300,15 +300,16 @@ updateChainBoundary cvs bvd = do
 
   -- Update the previous hash
   pure $ cvs
-    { cvsPreviousHash =
-      Right
-      . coerce
-      . hashRaw
-      . BSL.fromStrict
-      . wrapBoundaryBytes
-      $ boundaryHeaderAnnotation (boundaryHeader bvd)
+    { cvsPreviousHash = Right $! previousHash
     }
-
+ where
+   previousHash :: HeaderHash
+   previousHash =
+       coerce
+     . hashRaw
+     . BSL.fromStrict
+     . wrapBoundaryBytes
+     $ boundaryHeaderAnnotation (boundaryHeader bvd)
 
 validateHeaderMatchesBody
   :: MonadError ProofValidationError m

--- a/cardano-ledger/src/Cardano/Chain/Byron/API.hs
+++ b/cardano-ledger/src/Cardano/Chain/Byron/API.hs
@@ -265,7 +265,7 @@ validateBlock cfg validationMode block blkHash cvs = do
     bodyState' <- validateBody validationMode block bodyEnv bodyState
     return cvs {
           CC.cvsLastSlot        = CC.blockSlot block
-        , CC.cvsPreviousHash    = Right blkHash
+        , CC.cvsPreviousHash    = Right $! blkHash
         , CC.cvsUtxo            = CC.utxo            bodyState'
         , CC.cvsUpdateState     = CC.updateState     bodyState'
         , CC.cvsDelegationState = CC.delegationState bodyState'


### PR DESCRIPTION
```haskell
data ChainValidationState = ChainValidationState
  { ..
  , cvsPreviousHash    :: !(Either GenesisHash HeaderHash)
    ..
  }
```

The bang on the `Either` does not force the contents of the `Either`. So the
hash was not being forced, which meant that we were holding onto the whole
previous header!

Fix this by using `$!`.