### PR TITLE
Preserve software updates through epoch boundaries.

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
@@ -494,7 +494,7 @@ registerEpoch env st lastSeenEpoch = do
          , adoptedProtocolParameters = nextProtocolParameters'
          , candidateProtocolUpdates = []
          , registeredProtocolUpdateProposals = M.empty
-         , registeredSoftwareUpdateProposals = M.empty
+         , registeredSoftwareUpdateProposals = registeredSoftwareUpdateProposals
          , confirmedProposals = M.empty
          , proposalVotes = M.empty
          , registeredEndorsements = S.empty
@@ -520,4 +520,5 @@ registerEpoch env st lastSeenEpoch = do
       , adoptedProtocolVersion
       , adoptedProtocolParameters
       , candidateProtocolUpdates
+      , registeredSoftwareUpdateProposals
       } = st


### PR DESCRIPTION
Software update proposals do not trigger on the epoch boundary, they get confirmed as soon as we have a minimum number of endorsements based on block issuance. Zeroing out the software updates on an epoch change will inhibit this.

This is also in line with the current spec

Addresses #725 