### PR TITLE
Disallow duplicate votes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -62,29 +62,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 47fd353ab0ea7ef008ab2f16d0a371ae79c8106d
-  --sha256: 0mbmsgi42wyv1a7zcrb13lpz8rklksxcdyf12s650fqqvim12yfm
+  tag: 647cd71e3c4630488e71596f5e9c26fee598b541
+  --sha256: 08vkca171019z7xql2z7lg9piz6bgy5nn7h0ja6ab0s4ngf83gii
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 47fd353ab0ea7ef008ab2f16d0a371ae79c8106d
-  --sha256: 0mbmsgi42wyv1a7zcrb13lpz8rklksxcdyf12s650fqqvim12yfm
+  tag: 647cd71e3c4630488e71596f5e9c26fee598b541
+  --sha256: 08vkca171019z7xql2z7lg9piz6bgy5nn7h0ja6ab0s4ngf83gii
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 47fd353ab0ea7ef008ab2f16d0a371ae79c8106d
-  --sha256: 0mbmsgi42wyv1a7zcrb13lpz8rklksxcdyf12s650fqqvim12yfm
+  tag: 647cd71e3c4630488e71596f5e9c26fee598b541
+  --sha256: 08vkca171019z7xql2z7lg9piz6bgy5nn7h0ja6ab0s4ngf83gii
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 479c1718ab85761ae72d13c559b12227c8837748
-  --sha256: 090r44w11lapsvbll4diak7zmim1rcy16yjf6mc30fy92185mr4r
+  tag: ef164a834ef2b2d9ceb2ec262109a726ee534d66
+  --sha256: 0n6m65yfwsz37fpqv1f6sw5qrdh1hxiipss7yj1pvxdnya3ndnlc
   subdir:   contra-tracer
 
 source-repository-package

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,7 +28,7 @@ extra-deps:
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 47fd353ab0ea7ef008ab2f16d0a371ae79c8106d
+    commit: 647cd71e3c4630488e71596f5e9c26fee598b541
     subdirs:
       - byron/semantics/executable-spec
       - byron/ledger/executable-spec
@@ -41,7 +41,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 479c1718ab85761ae72d13c559b12227c8837748
+    commit: ef164a834ef2b2d9ceb2ec262109a726ee534d66
     subdirs:
       - contra-tracer
 


### PR DESCRIPTION
Addresses #739 

It is now invalid to cast a duplicate vote. We bump the dependency on `cardano-ledger-specs` to include https://github.com/input-output-hk/cardano-ledger-specs/pull/1287, which makes the corresponding change there.

PR will probably need to be updated when that PR is merged.