### PR TITLE
Avoid thunks in candidateProtocolUpdates

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
@@ -412,7 +412,7 @@ registerEndorsement env st endorsement = do
     vsKeep = S.fromList $ fst <$> M.elems registeredProtocolUpdateProposals'
 
   pure $!
-    st { candidateProtocolUpdates = candidateProtocolUpdates'
+    st { candidateProtocolUpdates = forceElemsToWHNF candidateProtocolUpdates'
        , registeredProtocolUpdateProposals = registeredProtocolUpdateProposals'
        , registeredSoftwareUpdateProposals =
            M.restrictKeys registeredSoftwareUpdateProposals pidsKeep


### PR DESCRIPTION
This was popping up as an unexpected thunk in the consensus tests.

This is field is a list, so the bang doesn't have much effect, so we must
force its elements.