### PR TITLE
Fix EBB header's "body proof" hash.

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Block/Header.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Header.hs
@@ -532,7 +532,8 @@ toCBORABoundaryHeader pm hdr =
              Right hh -> toCBOR hh
          )
       -- Body proof
-      <> toCBOR (hash (mempty :: LByteString))
+      -- The body is always an empty slot leader schedule, so we hash that.
+      <> toCBOR (hash ([] :: [()]))
       -- Consensus data
       <> ( encodeListLen 2
           -- Epoch


### PR DESCRIPTION
In OBFT, the EBB body always contains an empty slot leader schedule. The EBB header contains a hash of the body. That hash needs to match. It was previously the hash of the empty CBOR bytestring (0x40) but it needs to be the hash of the empty list, using the indefinite encoding (0x9F FF).