### PR TITLE
Update endorsement count rules.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -62,29 +62,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 647cd71e3c4630488e71596f5e9c26fee598b541
-  --sha256: 08vkca171019z7xql2z7lg9piz6bgy5nn7h0ja6ab0s4ngf83gii
+  tag: c006b101b699b7b54a96d077fdbad07005b8da77
+  --sha256: 1m2xs2z9bq83k65l2hx41zbj1akyl83cdlxhdxssd8nbmb723qar
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 647cd71e3c4630488e71596f5e9c26fee598b541
-  --sha256: 08vkca171019z7xql2z7lg9piz6bgy5nn7h0ja6ab0s4ngf83gii
+  tag: c006b101b699b7b54a96d077fdbad07005b8da77
+  --sha256: 1m2xs2z9bq83k65l2hx41zbj1akyl83cdlxhdxssd8nbmb723qar
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 647cd71e3c4630488e71596f5e9c26fee598b541
-  --sha256: 08vkca171019z7xql2z7lg9piz6bgy5nn7h0ja6ab0s4ngf83gii
+  tag: c006b101b699b7b54a96d077fdbad07005b8da77
+  --sha256: 1m2xs2z9bq83k65l2hx41zbj1akyl83cdlxhdxssd8nbmb723qar
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 3e45d5dd4942c295f0ea4bfed7c407b914b15447
-  --sha256: 0vik0qqw0p5xdrl2r84fz8jhmlzcx0b3cxpvb434ldb8xnlx8q8i
+  tag: ef164a834ef2b2d9ceb2ec262109a726ee534d66
+  --sha256: 0n6m65yfwsz37fpqv1f6sw5qrdh1hxiipss7yj1pvxdnya3ndnlc
   subdir:   contra-tracer
 
 source-repository-package

--- a/cardano-ledger/src/Cardano/Chain/ProtocolConstants.hs
+++ b/cardano-ledger/src/Cardano/Chain/ProtocolConstants.hs
@@ -4,6 +4,7 @@
 
 module Cardano.Chain.ProtocolConstants
   ( kSlotSecurityParam
+  , kUpdateStabilityParam
   , kChainQualityThreshold
   , kEpochSlots
   )
@@ -20,6 +21,12 @@ import Cardano.Chain.Slotting.SlotCount (SlotCount(..))
 --   property. It's basically @blkSecurityParam / chainQualityThreshold@.
 kSlotSecurityParam :: BlockCount -> SlotCount
 kSlotSecurityParam = SlotCount . (*) 2 . unBlockCount
+
+-- | Update stability parameter expressed in number of slots. This is the time
+--   between an protocol version update receiving its final endorsement and
+--   being accepted, and is set to double the security param.
+kUpdateStabilityParam :: BlockCount -> SlotCount
+kUpdateStabilityParam = SlotCount . (*) 4 . unBlockCount
 
 -- | Minimal chain quality (number of blocks divided by number of
 --   slots) necessary for security of the system.

--- a/cardano-ledger/src/Cardano/Chain/ProtocolConstants.hs
+++ b/cardano-ledger/src/Cardano/Chain/ProtocolConstants.hs
@@ -25,6 +25,15 @@ kSlotSecurityParam = SlotCount . (*) 2 . unBlockCount
 -- | Update stability parameter expressed in number of slots. This is the time
 --   between an protocol version update receiving its final endorsement and
 --   being accepted, and is set to double the security param.
+--
+--   This extra safety margin is required because an update in the protocol
+--   version may trigger a hard fork, which can change "era"-level parameters
+--   such as slot length and the number of slots per epoch. As such, the
+--   consensus layer wishes to always have a margin between such an update being
+--   _certain to happen_ and it actually happening.
+--
+--   For full details, you can see
+--   https://github.com/input-output-hk/cardano-ledger-specs/issues/1288
 kUpdateStabilityParam :: BlockCount -> SlotCount
 kUpdateStabilityParam = SlotCount . (*) 4 . unBlockCount
 

--- a/cardano-ledger/src/Cardano/Chain/Slotting/EpochSlots.hs
+++ b/cardano-ledger/src/Cardano/Chain/Slotting/EpochSlots.hs
@@ -6,6 +6,7 @@
 module Cardano.Chain.Slotting.EpochSlots
   ( EpochSlots(..)
   , WithEpochSlots (..)
+  , epochFirstSlot
   )
 where
 
@@ -15,6 +16,8 @@ import Data.Data (Data)
 import Formatting.Buildable (Buildable)
 
 import Cardano.Binary (FromCBOR(..), ToCBOR(..))
+import Cardano.Chain.Slotting.EpochNumber
+import Cardano.Chain.Slotting.SlotNumber
 
 -- | The number of slots per epoch.
 newtype EpochSlots = EpochSlots
@@ -33,3 +36,9 @@ data WithEpochSlots a = WithEpochSlots
   , unWithEpochSlots :: a
   }
   deriving (Show, Eq)
+
+-- | Calculate the first slot in an epoch. Note that this function will fail if
+-- Byron is not the first and only era - a more robust method should use
+-- 'EpochInfo' from cardano-slotting.
+epochFirstSlot :: EpochSlots -> EpochNumber -> SlotNumber
+epochFirstSlot (EpochSlots n) (EpochNumber k) = SlotNumber $ n * k

--- a/cardano-ledger/src/Cardano/Chain/Slotting/EpochSlots.hs
+++ b/cardano-ledger/src/Cardano/Chain/Slotting/EpochSlots.hs
@@ -37,8 +37,10 @@ data WithEpochSlots a = WithEpochSlots
   }
   deriving (Show, Eq)
 
--- | Calculate the first slot in an epoch. Note that this function will fail if
--- Byron is not the first and only era - a more robust method should use
--- 'EpochInfo' from cardano-slotting.
+-- | Calculate the first slot in an epoch.
+--
+-- Note that this function will give an undetermined result if Byron is not the
+-- first and only era - a more robust method should use 'EpochInfo' from
+-- cardano-slotting.
 epochFirstSlot :: EpochSlots -> EpochNumber -> SlotNumber
 epochFirstSlot (EpochSlots n) (EpochNumber k) = SlotNumber $ n * k

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
@@ -54,7 +54,15 @@ import Cardano.Chain.Common.BlockCount (BlockCount)
 import Cardano.Chain.Common.KeyHash (KeyHash)
 import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.Genesis as Genesis
-import Cardano.Chain.Slotting (EpochNumber, SlotNumber, subSlotCount, SlotCount(SlotCount), unSlotNumber)
+import Cardano.Chain.ProtocolConstants (kEpochSlots)
+import Cardano.Chain.Slotting
+  ( EpochNumber
+  , SlotNumber
+  , subSlotCount
+  , SlotCount(SlotCount)
+  , epochFirstSlot
+  , unSlotNumber
+  )
 import Cardano.Chain.Update.Proposal (AProposal, UpId, recoverUpId)
 import Cardano.Chain.Update.ProtocolParameters
   ( ProtocolParameters
@@ -473,10 +481,9 @@ registerEpoch
   -> State
 registerEpoch env st lastSeenEpoch = do
   let PVBump.State
-        currentEpoch'
         adoptedProtocolVersion'
         nextProtocolParameters'
-        = tryBumpVersion subEnv subSt lastSeenEpoch
+        = tryBumpVersion subEnv subSt
   if adoptedProtocolVersion' == adoptedProtocolVersion
     then
       -- Nothing changes in the state, since we are not changing protocol
@@ -489,8 +496,7 @@ registerEpoch env st lastSeenEpoch = do
       -- We have a new protocol version, so we update the current protocol
       -- version and parameters, and we perform a cleanup of the state
       -- variables.
-      st { currentEpoch = currentEpoch'
-         , adoptedProtocolVersion = adoptedProtocolVersion'
+      st { adoptedProtocolVersion = adoptedProtocolVersion'
          , adoptedProtocolParameters = nextProtocolParameters'
          , candidateProtocolUpdates = []
          , registeredProtocolUpdateProposals = M.empty
@@ -501,23 +507,21 @@ registerEpoch env st lastSeenEpoch = do
          , proposalRegistrationSlot = M.empty
          }
   where
-    subEnv = PVBump.Environment k currentSlot candidateProtocolUpdates
+    subEnv = PVBump.Environment k firstSlot candidateProtocolUpdates
 
     subSt =
       PVBump.State
-        currentEpoch
         adoptedProtocolVersion
         adoptedProtocolParameters
 
+    firstSlot = epochFirstSlot (kEpochSlots k) lastSeenEpoch
 
     Environment
       { k
-      , currentSlot
       } = env
 
     State
-      { currentEpoch
-      , adoptedProtocolVersion
+      { adoptedProtocolVersion
       , adoptedProtocolParameters
       , candidateProtocolUpdates
       } = st

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface.hs
@@ -507,14 +507,14 @@ registerEpoch env st lastSeenEpoch = do
          , proposalRegistrationSlot = M.empty
          }
   where
-    subEnv = PVBump.Environment k firstSlot candidateProtocolUpdates
+    subEnv = PVBump.Environment k firstSlotOfLastSeenEpoch candidateProtocolUpdates
 
     subSt =
       PVBump.State
         adoptedProtocolVersion
         adoptedProtocolParameters
 
-    firstSlot = epochFirstSlot (kEpochSlots k) lastSeenEpoch
+    firstSlotOfLastSeenEpoch = epochFirstSlot (kEpochSlots k) lastSeenEpoch
 
     Environment
       { k

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface/ProtocolVersionBump.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface/ProtocolVersionBump.hs
@@ -34,7 +34,10 @@ data State = State
 
 -- | Change the protocol version when an epoch change is detected, and there is
 -- a candidate protocol update that was confirmed at least @4 * k@ slots before
--- the start of the epoch, where @k@ is the chain security parameter.
+-- the start of the new epoch, where @k@ is the chain security parameter.
+--
+-- For a full history of why this is required, see
+-- https://github.com/input-output-hk/cardano-ledger-specs/issues/1288
 --
 -- This corresponds to the @PVBUMP@ rules in the Byron ledger specification.
 tryBumpVersion

--- a/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface/ProtocolVersionBump.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Validation/Interface/ProtocolVersionBump.hs
@@ -9,9 +9,9 @@ where
 
 import Cardano.Prelude hiding (State)
 
-import Cardano.Chain.ProtocolConstants (kSlotSecurityParam)
+import Cardano.Chain.ProtocolConstants (kUpdateStabilityParam)
 import Cardano.Chain.Common.BlockCount (BlockCount)
-import Cardano.Chain.Slotting (EpochNumber, SlotNumber, subSlotCount)
+import Cardano.Chain.Slotting (SlotNumber, subSlotCount)
 import Cardano.Chain.Update.ProtocolParameters (ProtocolParameters)
 import Cardano.Chain.Update.ProtocolVersion (ProtocolVersion)
 import Cardano.Chain.Update.Validation.Endorsement
@@ -23,44 +23,39 @@ import Cardano.Chain.Update.Validation.Endorsement
 
 data Environment = Environment
   { k                         :: !BlockCount
-  , currentSlot               :: !SlotNumber
+  , epochFirstSlot            :: !SlotNumber
   , candidateProtocolVersions :: ![CandidateProtocolUpdate]
   }
 
 data State = State
-  { currentEpoch              :: !EpochNumber
-  , nextProtocolVersion       :: !ProtocolVersion
+  { nextProtocolVersion       :: !ProtocolVersion
   , nextProtocolParameters    :: !ProtocolParameters
   }
 
 -- | Change the protocol version when an epoch change is detected, and there is
--- a candidate protocol update that was confirmed at least @2 * k@ slots ago,
--- where @k@ is the chain security parameter.
+-- a candidate protocol update that was confirmed at least @4 * k@ slots before
+-- the start of the epoch, where @k@ is the chain security parameter.
 --
 -- This corresponds to the @PVBUMP@ rules in the Byron ledger specification.
 tryBumpVersion
   :: Environment
   -> State
-  -> EpochNumber
   -> State
-tryBumpVersion env st lastSeenEpoch =
-  case (currentEpoch < lastSeenEpoch, stableCandidates) of
-    (True, newestStable:_) ->
+tryBumpVersion env st =
+  case stableCandidates of
+    (newestStable:_) ->
       let CandidateProtocolUpdate
             { cpuProtocolVersion
             , cpuProtocolParameters
             } = newestStable
       in
-        st { currentEpoch = lastSeenEpoch
-           , nextProtocolVersion = cpuProtocolVersion
+        st { nextProtocolVersion = cpuProtocolVersion
            , nextProtocolParameters = cpuProtocolParameters
            }
     _ -> st
 
   where
-    Environment { k, currentSlot, candidateProtocolVersions } = env
-
-    State { currentEpoch } = st
+    Environment { k, epochFirstSlot, candidateProtocolVersions } = env
 
     stableCandidates =
-      filter ((<= subSlotCount (kSlotSecurityParam k) currentSlot) . cpuSlot) candidateProtocolVersions
+      filter ((<= subSlotCount (kUpdateStabilityParam k) epochFirstSlot) . cpuSlot) candidateProtocolVersions

--- a/stack.yaml
+++ b/stack.yaml
@@ -31,7 +31,7 @@ extra-deps:
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 647cd71e3c4630488e71596f5e9c26fee598b541
+    commit: c006b101b699b7b54a96d077fdbad07005b8da77
     subdirs:
       - byron/semantics/executable-spec
       - byron/ledger/executable-spec
@@ -44,7 +44,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 3e45d5dd4942c295f0ea4bfed7c407b914b15447
+    commit: ef164a834ef2b2d9ceb2ec262109a726ee534d66
     subdirs:
       - contra-tracer
 


### PR DESCRIPTION
This addresses #743 and #745. Endorsements must now be processed 4k
slots before the start of an epoch, rather than 2k slots before the
first block in the next epoch.

I've also tried to tidy the PVBUMP implementation to bring it closer to
the specs.