### PR TITLE
Use a hash representation with a faster Ord instance

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -35,22 +35,22 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f869bee9b08ba1044b1476737c9d65083e1c6c7f
-  --sha256: 0df3bdf13cwx3hd8n4q53g9hybb0w8mh837y64ydd88xhdfaf6a3
+  tag: 68dcff6e832efa8711b9757d8ddaba61759da973
+  --sha256: 1mqyxi6h2bq4w81v3vn05s0y4i6zp42g6yagy8bzbihh97q2wc0g
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f869bee9b08ba1044b1476737c9d65083e1c6c7f
-  --sha256: 0df3bdf13cwx3hd8n4q53g9hybb0w8mh837y64ydd88xhdfaf6a3
+  tag: 68dcff6e832efa8711b9757d8ddaba61759da973
+  --sha256: 1mqyxi6h2bq4w81v3vn05s0y4i6zp42g6yagy8bzbihh97q2wc0g
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f869bee9b08ba1044b1476737c9d65083e1c6c7f
-  --sha256: 0df3bdf13cwx3hd8n4q53g9hybb0w8mh837y64ydd88xhdfaf6a3
+  tag: 68dcff6e832efa8711b9757d8ddaba61759da973
+  --sha256: 1mqyxi6h2bq4w81v3vn05s0y4i6zp42g6yagy8bzbihh97q2wc0g
   subdir: binary/test
 
 source-repository-package

--- a/cardano-ledger/src/Cardano/Chain/Common/Address.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Address.hs
@@ -35,7 +35,6 @@ module Cardano.Chain.Common.Address
   -- * Utilities
   , addrAttributesUnwrapped
   , addrNetworkMagic
-  , unAddressHash
 
   -- * Pattern-matching helpers
   , isRedeemAddress
@@ -49,8 +48,6 @@ module Cardano.Chain.Common.Address
 where
 
 import Cardano.Prelude
-
-import qualified Data.ByteArray
 
 import Control.Monad.Except (MonadError)
 import qualified Data.Aeson as Aeson
@@ -109,10 +106,6 @@ instance FromCBOR Address' where
     len <- decodeListLenCanonical
     matchSize "Address'" 3 len
     fmap Address' $ (,,) <$> fromCBOR <*> fromCBOR <*> fromCBOR
-
--- | Get the ByteString of the hash.
-unAddressHash :: AddressHash Address' -> ByteString
-unAddressHash = Data.ByteArray.convert
 
 -- | 'Address' is where you can send Lovelace
 data Address = Address

--- a/cardano-ledger/src/Cardano/Chain/Common/AddressHash.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/AddressHash.hs
@@ -11,13 +11,13 @@ import Crypto.Hash (Blake2b_224, Digest, SHA3_256)
 import qualified Crypto.Hash as CryptoHash
 
 import Cardano.Binary (ToCBOR, serialize)
-import Cardano.Crypto.Hashing (AbstractHash(..))
+import Cardano.Crypto.Hashing (AbstractHash, abstractHashFromDigest)
 
 -- | Hash used to identify address.
 type AddressHash = AbstractHash Blake2b_224
 
 unsafeAddressHash :: ToCBOR a => a -> AddressHash b
-unsafeAddressHash = AbstractHash . secondHash . firstHash
+unsafeAddressHash = abstractHashFromDigest . secondHash . firstHash
  where
   firstHash :: ToCBOR a => a -> Digest SHA3_256
   firstHash = CryptoHash.hashlazy . serialize

--- a/cardano-ledger/src/Cardano/Chain/Common/Merkle.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Merkle.hs
@@ -40,7 +40,6 @@ import Cardano.Prelude
 
 import Data.Aeson (ToJSON)
 import Data.Bits (Bits(..))
-import Data.ByteArray (ByteArrayAccess)
 import Data.ByteString.Builder (Builder, byteString, word8)
 import qualified Data.ByteString.Builder.Extra as Builder
 import qualified Data.ByteString.Lazy as LBS
@@ -62,7 +61,6 @@ import Cardano.Crypto (Hash, hashDecoded, hashRaw, hashToBytes)
 newtype MerkleRoot a = MerkleRoot
   { getMerkleRoot :: Hash Raw  -- ^ returns root 'Hash' of Merkle Tree
   } deriving (Show, Eq, Ord, Generic)
-    deriving newtype ByteArrayAccess
     deriving anyclass (NFData, NoUnexpectedThunks)
 
 instance Buildable (MerkleRoot a) where

--- a/cardano-ledger/src/Cardano/Chain/Common/Merkle.hs
+++ b/cardano-ledger/src/Cardano/Chain/Common/Merkle.hs
@@ -40,7 +40,7 @@ import Cardano.Prelude
 
 import Data.Aeson (ToJSON)
 import Data.Bits (Bits(..))
-import Data.ByteArray (ByteArrayAccess, convert)
+import Data.ByteArray (ByteArrayAccess)
 import Data.ByteString.Builder (Builder, byteString, word8)
 import qualified Data.ByteString.Builder.Extra as Builder
 import qualified Data.ByteString.Lazy as LBS
@@ -51,7 +51,7 @@ import qualified Prelude
 
 import Cardano.Binary
   (Annotated(..), FromCBOR(..), Raw, ToCBOR(..), serializeBuilder)
-import Cardano.Crypto (AbstractHash(..), Hash, hashDecoded, hashRaw)
+import Cardano.Crypto (Hash, hashDecoded, hashRaw, hashToBytes)
 
 
 --------------------------------------------------------------------------------
@@ -79,7 +79,7 @@ instance FromCBOR a => FromCBOR (MerkleRoot a) where
   fromCBOR = MerkleRoot <$> fromCBOR
 
 merkleRootToBuilder :: MerkleRoot a -> Builder
-merkleRootToBuilder (MerkleRoot (AbstractHash d)) = byteString (convert d)
+merkleRootToBuilder (MerkleRoot h) = byteString (hashToBytes h)
 
 mkRoot :: MerkleRoot a -> MerkleRoot a -> MerkleRoot a
 mkRoot a b = MerkleRoot . hashRaw . toLazyByteString $ mconcat

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
@@ -55,8 +55,7 @@ import Cardano.Chain.UTxO
   , mkTxPayload
   )
 import Cardano.Crypto
-  ( AbstractHash(..)
-  , Hash
+  ( Hash
   , ProtocolMagicId(..)
   , VerificationKey(..)
   , RedeemSignature

--- a/crypto/src/Cardano/Crypto/Hashing.hs
+++ b/crypto/src/Cardano/Crypto/Hashing.hs
@@ -86,7 +86,7 @@ import Cardano.Binary
 --   Made abstract in order to support different algorithms
 newtype AbstractHash algo a =
   AbstractHash (Digest algo)
-  deriving (Show, Eq, Ord, ByteArray.ByteArrayAccess, Generic, NFData)
+  deriving (Show, Eq, Ord, Generic, NFData)
   deriving NoUnexpectedThunks via UseIsNormalForm (Digest algo)
 
 instance HashAlgorithm algo => Read (AbstractHash algo a) where

--- a/crypto/src/Cardano/Crypto/Hashing.hs
+++ b/crypto/src/Cardano/Crypto/Hashing.hs
@@ -44,9 +44,6 @@ module Cardano.Crypto.Hashing
   , hashHexF
   , mediumHashF
   , shortHashF
-
-    -- * Utility
-  , hashDigestSize'
   )
 where
 
@@ -163,12 +160,6 @@ instance HeapWords (AbstractHash algo a) where
     --         +--------------+
     --
     = 8
-
-hashDigestSize' :: forall algo . HashAlgorithm algo => Int
-hashDigestSize' = hashDigestSize @algo
-  (panic
-    "Cardano.Crypto.Hashing.hashDigestSize': HashAlgorithm value is evaluated!"
-  )
 
 -- | Parses given hash in base16 form.
 decodeAbstractHash

--- a/crypto/src/Cardano/Crypto/Hashing.hs
+++ b/crypto/src/Cardano/Crypto/Hashing.hs
@@ -16,7 +16,7 @@
 
 module Cardano.Crypto.Hashing
   ( -- * 'AbstractHash' type supporting different hash algorithms
-    AbstractHash(..)
+    AbstractHash
   , HashAlgorithm
     -- ** Hashing
   , abstractHash

--- a/crypto/test/Test/Cardano/Crypto/Gen.hs
+++ b/crypto/test/Test/Cardano/Crypto/Gen.hs
@@ -52,7 +52,7 @@ import qualified Hedgehog.Range as Range
 import Cardano.Binary (Annotated(..), Raw(..), ToCBOR)
 import Cardano.Crypto (PassPhrase)
 import Cardano.Crypto.Hashing
-  (AbstractHash(..), Hash, HashAlgorithm, abstractHash, hash)
+  (AbstractHash, Hash, HashAlgorithm, abstractHash, hash)
 import Cardano.Crypto.ProtocolMagic
   ( AProtocolMagic(..)
   , ProtocolMagic

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,7 +24,7 @@ extra-deps:
     commit: 2547ad1e80aeabca2899951601079408becbc92c
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: f869bee9b08ba1044b1476737c9d65083e1c6c7f
+    commit: 68dcff6e832efa8711b9757d8ddaba61759da973
     subdirs:
       - binary
       - binary/test


### PR DESCRIPTION
Change `AbstractHash` from being a `newtype` over `Digest` to a `newtype` over `ShortByteString` and adjust the conversion functions.

The `ShortByteString` type has efficient `Eq` & `Ord` instances whereas the `Digest` type has very inefficient ones.