### PR TITLE
crypto: Deprecate hash function

### DIFF
--- a/cardano-ledger/src/Cardano/Chain/Block/Header.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Header.hs
@@ -129,10 +129,10 @@ import Cardano.Crypto
   , SignTag(..)
   , SigningKey
   , VerificationKey
-  , hash
   , hashDecoded
   , hashHexF
   , hashRaw
+  , serializeCborHash
   , sign
   , unsafeAbstractHash
   )
@@ -533,7 +533,7 @@ toCBORABoundaryHeader pm hdr =
          )
       -- Body proof
       -- The body is always an empty slot leader schedule, so we hash that.
-      <> toCBOR (hash ([] :: [()]))
+      <> toCBOR (serializeCborHash ([] :: [()]))
       -- Consensus data
       <> ( encodeListLen 2
           -- Epoch

--- a/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
+++ b/cardano-ledger/src/Cardano/Chain/Block/Proof.hs
@@ -24,7 +24,7 @@ import qualified Cardano.Chain.Delegation.Payload as Delegation
 import Cardano.Chain.Ssc (SscProof(..))
 import Cardano.Chain.UTxO.TxProof (TxProof, mkTxProof, recoverTxProof)
 import qualified Cardano.Chain.Update.Proof as Update
-import Cardano.Crypto (Hash, hash, hashDecoded)
+import Cardano.Crypto (Hash, hashDecoded, serializeCborHash)
 
 
 -- | Proof of everything contained in the payload
@@ -70,7 +70,7 @@ mkProof :: Body -> Proof
 mkProof body = Proof
   { proofUTxO        = mkTxProof $ bodyTxPayload body
   , proofSsc        = SscProof
-  , proofDelegation = hash $ bodyDlgPayload body
+  , proofDelegation = serializeCborHash $ bodyDlgPayload body
   , proofUpdate     = Update.mkProof $ bodyUpdatePayload body
   }
 

--- a/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Delegation/Certificate.hs
@@ -26,7 +26,6 @@ module Cardano.Chain.Delegation.Certificate
 
   -- * Certificate Accessor
   , epoch
-  , certificateId
   , recoverCertificateId
 
   -- * Certificate Predicate
@@ -64,7 +63,6 @@ import Cardano.Crypto
   , SignTag(SignCertificate)
   , Signature
   , VerificationKey(unVerificationKey)
-  , hash
   , hashDecoded
   , safeSign
   , safeToVerification
@@ -147,12 +145,8 @@ unsafeCertificate e ivk dvk sig = UnsafeACertificate (Annotated e ()) ivk dvk si
 epoch :: ACertificate a -> EpochNumber
 epoch = unAnnotated . aEpoch
 
-certificateId :: ACertificate a -> CertificateId
-certificateId = hash . void
-
 recoverCertificateId :: ACertificate ByteString -> CertificateId
 recoverCertificateId = hashDecoded
-
 
 --------------------------------------------------------------------------------
 -- Certificate Predicate

--- a/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
+++ b/cardano-ledger/src/Cardano/Chain/Genesis/Generate.hs
@@ -74,7 +74,6 @@ import Cardano.Crypto as Crypto
   , runSecureRandom
   , getProtocolMagicId
   , getRequiresNetworkMagic
-  , hash
   , keyGen
   , noPassSafeSigner
   , toVerification
@@ -82,6 +81,7 @@ import Cardano.Crypto as Crypto
   , redeemKeyGen
   , redeemToVerification
   , toCompactRedeemVerificationKey
+  , serializeCborHash
   )
 
 
@@ -389,7 +389,7 @@ generateGenesisConfigWithEntropy startTime genesisSpec = do
   where
     -- Anything will do for the genesis hash. A hash of "patak" was used before,
     -- and so it remains. Here lies the last of the Serokell code. RIP.
-    genesisHash = GenesisHash $ coerce $ hash ("patak" :: Text)
+    genesisHash = GenesisHash $ coerce $ serializeCborHash ("patak" :: Text)
 
 
 ----------------------------------------------------------------------------

--- a/cardano-ledger/src/Cardano/Chain/UTxO/Tx.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/Tx.hs
@@ -39,7 +39,7 @@ import Cardano.Chain.Common
   , lovelaceF
   )
 import Cardano.Chain.Common.Attributes (Attributes, attributesAreKnown)
-import Cardano.Crypto (Hash, hash, shortHashF)
+import Cardano.Crypto (Hash, serializeCborHash, shortHashF)
 
 
 --------------------------------------------------------------------------------
@@ -69,7 +69,7 @@ instance B.Buildable Tx where
     . listJson
     . builder
     )
-    (hash tx)
+    (serializeCborHash tx)
     (txInputs tx)
     (txOutputs tx)
     attrsBuilder

--- a/cardano-ledger/src/Cardano/Chain/UTxO/TxProof.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/TxProof.hs
@@ -29,7 +29,7 @@ import Cardano.Chain.UTxO.TxPayload
   , txpWitnesses
   )
 import Cardano.Chain.UTxO.TxWitness (TxWitness)
-import Cardano.Crypto (Hash, hash, hashDecoded)
+import Cardano.Crypto (Hash, hashDecoded, serializeCborHash)
 
 
 data TxProof = TxProof
@@ -74,7 +74,7 @@ mkTxProof :: TxPayload -> TxProof
 mkTxProof payload = TxProof
   { txpNumber        = fromIntegral (length $ txpTxs payload)
   , txpRoot          = mtRoot (mkMerkleTree $ txpTxs payload)
-  , txpWitnessesHash = hash $ txpWitnesses payload
+  , txpWitnessesHash = serializeCborHash $ txpWitnesses payload
   }
 
 recoverTxProof :: ATxPayload ByteString -> TxProof

--- a/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
+++ b/cardano-ledger/src/Cardano/Chain/UTxO/UTxO.hs
@@ -56,7 +56,7 @@ import Cardano.Chain.UTxO.Compact
   , toCompactTxIn
   , toCompactTxOut
   )
-import Cardano.Crypto (hash)
+import Cardano.Crypto (serializeCborHash)
 
 
 newtype UTxO = UTxO
@@ -106,7 +106,7 @@ fromBalances =
 -- references an address constructed by hashing the TxOut address. This means
 -- it is not guaranteed (or likely) to be a real address.
 fromTxOut :: TxOut -> UTxO
-fromTxOut out = fromList [(TxInUtxo (coerce . hash $ txOutAddress out) 0, out)]
+fromTxOut out = fromList [(TxInUtxo (coerce . serializeCborHash $ txOutAddress out) 0, out)]
 
 toList :: UTxO -> [(TxIn, TxOut)]
 toList = fmap (bimap fromCompactTxIn fromCompactTxOut) . M.toList . unUTxO
@@ -160,7 +160,7 @@ txOutputUTxO tx = UTxO $ M.fromList
   indexedOutputs = zip [0 ..] (NE.toList $ txOutputs tx)
 
   txId :: Tx -> TxId
-  txId = hash
+  txId = serializeCborHash
 
 isRedeemUTxO :: UTxO -> Bool
 isRedeemUTxO =

--- a/cardano-ledger/src/Cardano/Chain/Update/Proof.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Proof.hs
@@ -6,7 +6,7 @@ module Cardano.Chain.Update.Proof
 where
 
 import Cardano.Chain.Update.Payload (APayload(..), Payload)
-import Cardano.Crypto (Hash, hash, hashDecoded)
+import Cardano.Crypto (Hash, hashDecoded, serializeCborHash)
 import Cardano.Prelude
 
 
@@ -14,7 +14,7 @@ import Cardano.Prelude
 type Proof = Hash Payload
 
 mkProof :: Payload -> Proof
-mkProof = hash
+mkProof = serializeCborHash
 
 recoverProof :: APayload ByteString -> Proof
 recoverProof = hashDecoded

--- a/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Proposal.hs
@@ -66,10 +66,10 @@ import Cardano.Crypto
   , SafeSigner
   , SignTag(SignUSProposal)
   , Signature
-  , hash
   , hashDecoded
   , safeSign
   , safeToVerification
+  , serializeCborHash
   )
 
 
@@ -196,7 +196,7 @@ instance B.Buildable (AProposal ()) where
     )
     (softwareVersion body')
     (protocolVersion body')
-    (hash proposal)
+    (serializeCborHash proposal)
     (protocolParametersUpdate body')
     (M.keys $ metadata body')
    where

--- a/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
+++ b/cardano-ledger/src/Cardano/Chain/Update/Vote.hs
@@ -24,7 +24,6 @@ module Cardano.Chain.Update.Vote
 
   -- * Vote Accessors
   , proposalId
-  , voteId
   , recoverVoteId
 
   -- * Vote Binary Serialization
@@ -65,7 +64,6 @@ import Cardano.Crypto
   , SigningKey
   , SignTag(SignUSVote)
   , Signature
-  , hash
   , hashDecoded
   , safeSign
   , safeToVerification
@@ -171,12 +169,8 @@ unsafeVote vk upId voteSignature =
 proposalId :: AVote a -> UpId
 proposalId = unAnnotated . aProposalId
 
-voteId :: AVote a -> VoteId
-voteId = hash . void
-
 recoverVoteId :: AVote ByteString -> VoteId
 recoverVoteId = hashDecoded
-
 
 --------------------------------------------------------------------------------
 -- Vote Binary Serialization

--- a/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Block/CBOR.hs
@@ -62,8 +62,8 @@ import Cardano.Crypto
   ( ProtocolMagicId(..)
   , SignTag(..)
   , abstractHash
-  , hash
   , noPassSafeSigner
+  , serializeCborHash
   , sign
   , toVerification
   )
@@ -310,7 +310,7 @@ exampleProof = Proof
   where dp = Delegation.unsafePayload (take 4 exampleCertificates)
 
 exampleHeaderHash :: HeaderHash
-exampleHeaderHash = coerce (hash ("HeaderHash" :: Text))
+exampleHeaderHash = coerce $ serializeCborHash ("HeaderHash" :: Text)
 
 exampleBody :: Body
 exampleBody = Body exampleTxPayload SscPayload dp Update.examplePayload

--- a/cardano-ledger/test/Test/Cardano/Chain/Byron/API.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Byron/API.hs
@@ -186,7 +186,7 @@ ts_mempoolValidation = withTestsTS 100 . property $ do
         Nothing -> []
         Just up ->
           let up' = elaborateUpdateProposal pm up
-              upIdMap' = Map.insert (Spec._upId up) (H.hash up') upIdMap
+              upIdMap' = Map.insert (Spec._upId up) (H.serializeCborHash up') upIdMap
               vote' = elaborateVote pm upIdMap' <$> vote
           in  addAnnotation <$>
                 [MempoolUpdateProposal up'] <>
@@ -213,7 +213,7 @@ ts_mempoolValidation = withTestsTS 100 . property $ do
       apply1 :: ChainValidationState -> AMempoolPayload ByteString
              -> Either ApplyMempoolPayloadErr ChainValidationState
       apply1 c mp = applyMempoolPayload validationMode config (SlotNumber genSlot) mp c
-      headerHash = coerce (H.hash (0 :: Int)) :: HeaderHash
+      headerHash = coerce (H.serializeCborHash (0 :: Int)) :: HeaderHash
       applyMempoolPayloadResult = foldM apply1 cvs mempoolPayloads
       validateBlockResult =
         validateBlock config validationMode concreteBlock headerHash cvs

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -175,7 +175,7 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
       addUpdateProposalId (abstractProposal, concreteProposal) =
         Map.insert
           (Abstract.Update._upId abstractProposal)
-          (H.hash concreteProposal)
+          (H.serializeCborHash concreteProposal)
           proposalsIdMap
 
 
@@ -219,7 +219,7 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
             else coerce dummyHash
 
       dummyHash :: H.Hash Int
-      dummyHash = H.hash 0
+      dummyHash = H.serializeCborHash 0
 
 elaborateBS
   :: AbstractToConcreteIdMaps
@@ -313,7 +313,7 @@ abEnvToCfg (_currentSlot, _genesisUtxo, allowedDelegators, protocolParams, stabl
   -- We shouldn't need to use 'coerce' after
   -- https://github.com/input-output-hk/cardano-ledger/issues/332 gets
   -- implemented.
-  genesisHash = Genesis.GenesisHash $ coerce $ H.hash ("" :: ByteString)
+  genesisHash = Genesis.GenesisHash $ coerce $ H.serializeCborHash ("" :: ByteString)
 
   gPps = elaboratePParams protocolParams
 

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/UTxO.hs
@@ -108,7 +108,7 @@ elaborateWitness concreteTx (Abstract.Wit key _) = Concrete.VKWitness
  where
   (concreteVK, concreteSK) = elaborateKeyPair $ vKeyPair key
   signature = sign Dummy.protocolMagicId SignTx concreteSK sigData
-  sigData   = Concrete.TxSigData $ hash concreteTx
+  sigData   = Concrete.TxSigData $ serializeCborHash concreteTx
 
 elaborateTxIns
   :: (Abstract.TxId -> Concrete.TxId)

--- a/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Elaboration/Update.hs
@@ -165,7 +165,7 @@ elaborateUpSD ( protocolVersion
     -- elaborators should be able to generate random data, or the abstract
     -- update payload should include (an abstract version of) these hashes.
     concreteSystemHashes =
-      repeat $ Concrete.InstallerHash $ coerce $ H.hash ("" :: ByteString)
+      repeat $ Concrete.InstallerHash $ coerce $ H.serializeCborHash ("" :: ByteString)
 
 
 -- | Convert a 'ProtocolParameters' value to a 'ProtocolParametersUpdate'
@@ -245,6 +245,6 @@ elaborateProposalId proposalsIdMap abstractProposalId  =
         -- NOTE: if the elaborators returned a `Gen a` value, then we could
         -- return random hashes here.
         abstractIdHash :: Concrete.UpId -- Keeps GHC happy ...
-        abstractIdHash = coerce $ H.hash id
+        abstractIdHash = coerce $ H.serializeCborHash id
           where
             Abstract.UpId id = abstractProposalId

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Example.hs
@@ -60,9 +60,9 @@ import Cardano.Crypto
   , VerificationKey(..)
   , RedeemSignature
   , SignTag(..)
-  , hash
   , redeemDeterministicKeyGen
   , redeemSign
+  , serializeCborHash
   , sign
   )
 import qualified Cardano.Crypto.Wallet as CC
@@ -120,7 +120,7 @@ exampleTxProof = TxProof 32 mroot hashWit
  where
   mroot = mtRoot $ mkMerkleTree
     [(UnsafeTx exampleTxInList exampleTxOutList (mkAttributes ()))]
-  hashWit = hash $ [(V.fromList [(VKWitness exampleVerificationKey exampleTxSig)])]
+  hashWit = serializeCborHash $ [(V.fromList [(VKWitness exampleVerificationKey exampleTxSig)])]
 
 exampleTxSig :: TxSig
 exampleTxSig =
@@ -141,4 +141,4 @@ exampleRedeemSignature = redeemSign
   where rsk = fromJust (snd <$> redeemDeterministicKeyGen (getBytes 0 32))
 
 exampleHashTx :: Hash Tx
-exampleHashTx = coerce (hash "golden" :: Hash Text)
+exampleHashTx = coerce (serializeCborHash "golden" :: Hash Text)

--- a/cardano-ledger/test/Test/Cardano/Chain/UTxO/Model.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/UTxO/Model.hs
@@ -30,7 +30,7 @@ import Cardano.Chain.UTxO
 import qualified Cardano.Chain.UTxO as Concrete
 import qualified Cardano.Chain.UTxO.UTxO as Concrete.UTxO
 import Cardano.Chain.ValidationMode (ValidationMode (..))
-import Cardano.Crypto (hash, hashDecoded)
+import Cardano.Crypto (hashDecoded, serializeCborHash)
 
 import qualified Cardano.Ledger.Spec.STS.UTXO as Abstract
 import Cardano.Ledger.Spec.STS.UTXOW (UTXOW)
@@ -153,4 +153,4 @@ elaborateTxId :: Map Abstract.TxId Concrete.TxId
 elaborateTxId txIdMap txId =
   case M.lookup txId txIdMap of
     Just concreteTxId -> concreteTxId
-    Nothing -> coerce (hash (show txId :: Text))
+    Nothing -> coerce $ serializeCborHash (show txId :: Text)

--- a/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
+++ b/cardano-ledger/test/Test/Cardano/Chain/Update/Example.hs
@@ -50,7 +50,7 @@ import Cardano.Chain.Update
   , payload
   , signProposal
   )
-import Cardano.Crypto (ProtocolMagicId(..), hash)
+import Cardano.Crypto (ProtocolMagicId(..), serializeCborHash)
 
 import Test.Cardano.Crypto.CBOR (getBytes)
 import Test.Cardano.Crypto.Example (exampleSafeSigner)
@@ -129,10 +129,10 @@ exampleInstallerHashes offset count = map
   (toInstallerHash . (* offset))
   [0 .. count - 1]
  where
-  toInstallerHash start = InstallerHash . hash . Raw $ getBytes start 128
+  toInstallerHash start = InstallerHash . serializeCborHash . Raw $ getBytes start 128
 
 exampleUpId :: UpId
-exampleUpId = hash exampleProposal
+exampleUpId = serializeCborHash exampleProposal
 
 examplePayload :: Payload
 examplePayload = payload up uv

--- a/crypto/src/Cardano/Crypto/Hashing.hs
+++ b/crypto/src/Cardano/Crypto/Hashing.hs
@@ -35,6 +35,7 @@ module Cardano.Crypto.Hashing
   , hash
   , hashDecoded
   , hashRaw
+  , serializeCborHash
     -- ** Conversion
   , hashFromBytes
   , unsafeHashFromBytes
@@ -181,6 +182,7 @@ decodeAbstractHash prettyHash = do
     Just h -> return h
 
 -- | Hash the 'ToCBOR'-serialised version of a value
+-- Once this is no longer used outside this module it should be made private.
 abstractHash :: (HashAlgorithm algo, ToCBOR a) => a -> AbstractHash algo a
 abstractHash = unsafeAbstractHash . serialize
 
@@ -225,9 +227,14 @@ abstractHashToBytes (AbstractHash h) = SBS.fromShort h
 -- | The type of our commonly used hash, Blake2b 256
 type Hash = AbstractHash Blake2b_256
 
+{-# DEPRECATED hash "Use serializeCborHash or hash the annotation instead." #-}
 -- | The hash of a value, serialised via 'ToCBOR'.
 hash :: ToCBOR a => a -> Hash a
 hash = abstractHash
+
+-- | The hash of a value, serialised via 'ToCBOR'.
+serializeCborHash :: ToCBOR a => a -> Hash a
+serializeCborHash = abstractHash
 
 -- | The hash of a value's annotation
 hashDecoded :: (Decoded t) => t -> Hash (BaseType t)

--- a/crypto/test/Test/Cardano/Crypto/CBOR.hs
+++ b/crypto/test/Test/Cardano/Crypto/CBOR.hs
@@ -34,9 +34,9 @@ import Cardano.Crypto
   , SigningKey(..)
   , SignTag(SignForTestingOnly)
   , Signature
-  , hash
   , redeemDeterministicKeyGen
   , redeemSign
+  , serializeCborHash
   , sign
   )
 
@@ -218,7 +218,7 @@ goldenDeprecatedSecretProof = deprecatedGoldenDecode
 --------------------------------------------------------------------------------
 
 goldenAbstractHash :: Property
-goldenAbstractHash = goldenTestCBOR (hash ()) "test/golden/AbstractHash"
+goldenAbstractHash = goldenTestCBOR (serializeCborHash ()) "test/golden/AbstractHash"
 
 genUnitAbstractHash :: Gen (AbstractHash Blake2b_256 ())
 genUnitAbstractHash = genAbstractHash $ pure ()

--- a/crypto/test/Test/Cardano/Crypto/Gen.hs
+++ b/crypto/test/Test/Cardano/Crypto/Gen.hs
@@ -52,7 +52,7 @@ import qualified Hedgehog.Range as Range
 import Cardano.Binary (Annotated(..), Raw(..), ToCBOR)
 import Cardano.Crypto (PassPhrase)
 import Cardano.Crypto.Hashing
-  (AbstractHash, Hash, HashAlgorithm, abstractHash, hash)
+  (AbstractHash, Hash, HashAlgorithm, abstractHash, serializeCborHash)
 import Cardano.Crypto.ProtocolMagic
   ( AProtocolMagic(..)
   , ProtocolMagic
@@ -209,7 +209,7 @@ genHashRaw :: Gen (Hash Raw)
 genHashRaw = genAbstractHash $ Raw <$> gen32Bytes
 
 genTextHash :: Gen (Hash Text)
-genTextHash = hash <$> Gen.text (Range.linear 0 10) Gen.alphaNum
+genTextHash = serializeCborHash <$> Gen.text (Range.linear 0 10) Gen.alphaNum
 
 feedPM :: (ProtocolMagicId -> Gen a) -> Gen a
 feedPM genA = genA =<< genProtocolMagicId

--- a/crypto/test/Test/Cardano/Crypto/Hashing.hs
+++ b/crypto/test/Test/Cardano/Crypto/Hashing.hs
@@ -25,7 +25,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import Cardano.Binary (ToCBOR)
-import Cardano.Crypto (decodeAbstractHash, hash, hashHexF)
+import Cardano.Crypto (decodeAbstractHash, hashHexF, serializeCborHash)
 
 
 --------------------------------------------------------------------------------
@@ -58,14 +58,14 @@ prop_goldenHash :: Property
 prop_goldenHash =
   withTests 1
     .   property
-    $   sformat hashHexF (hash (1 :: Word64))
+    $   sformat hashHexF (serializeCborHash (1 :: Word64))
     === "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25"
 
 
 -- | Check that 'decodeAbstractHash' correctly decodes hash values
 prop_decodeAbstractHash :: Property
 prop_decodeAbstractHash = property $ do
-  a <- hash <$> forAll (Gen.int Range.constantBounded)
+  a <- serializeCborHash <$> forAll (Gen.int Range.constantBounded)
   decodeAbstractHash (sformat hashHexF a) === Right a
 
 
@@ -78,4 +78,4 @@ hashInequality :: (Eq a, Show a, ToCBOR a) => Gen a -> Property
 hashInequality genA = property $ do
   a <- forAll genA
   b <- forAll $ Gen.filter (/= a) genA
-  hash a /== hash b
+  serializeCborHash a /== serializeCborHash b

--- a/crypto/test/Test/Cardano/Crypto/Orphans.hs
+++ b/crypto/test/Test/Cardano/Crypto/Orphans.hs
@@ -12,7 +12,7 @@ import qualified Crypto.PubKey.Ed25519 as Ed25519
 import           Cardano.Crypto
                    ( SigningKey(..)
                    )
-import           Cardano.Crypto.Hashing (hash)
+import           Cardano.Crypto.Hashing (serializeCborHash)
 
 
 -- Note that we /only/ provide these Eq and Ord instances for test suites.
@@ -21,7 +21,7 @@ import           Cardano.Crypto.Hashing (hash)
 
 
 instance Eq SigningKey where
-  a == b = hash a == hash b
+  a == b = serializeCborHash a == serializeCborHash b
 
 instance Ord Ed25519.PublicKey where
   compare x1 x2 = compare (toByteString x1) (toByteString x2)


### PR DESCRIPTION
The function 'hash :: ToCBOR a => a -> Hash a' serializes 'a' to CBOR
and then hashes it. Since a lot of data types are actually annotated,
performing the CBOR encoding is completely un-necessary, since the
existing annotation can be passed directly to 'hashRaw'.

We do however provide 'serializeCborHash :: ToCBOR a => a -> Hash a'
which is fine for tests and for the case where there is no annotation.